### PR TITLE
Fix UI inconsistencies and reduce settings icon size

### DIFF
--- a/swift/TigerDuck/Features/More/MoreView.swift
+++ b/swift/TigerDuck/Features/More/MoreView.swift
@@ -20,9 +20,9 @@ struct MoreView: View {
                                 SettingsView()
                             } label: {
                                 Image(systemName: "gearshape.fill")
-                                    .font(.title3)
+                                    .font(.body)
                                     .foregroundStyle(.primary)
-                                    .frame(width: 50, height: 50)
+                                    .frame(width: 34, height: 34)
                                     .glassEffect(.regular.interactive(), in: .circle)
                             }
                             .buttonStyle(.plain)
@@ -31,9 +31,9 @@ struct MoreView: View {
                                 SettingsView()
                             } label: {
                                 Image(systemName: "gearshape.fill")
-                                    .font(.title3)
+                                    .font(.body)
                                     .foregroundStyle(Color.textPrimary)
-                                    .frame(width: 44, height: 44)
+                                    .frame(width: 34, height: 34)
                                     .background(.ultraThinMaterial, in: Circle())
                             }
                             .buttonStyle(.plain)


### PR DESCRIPTION
This pull request makes minor UI adjustments to the settings button in the `MoreView` component, focusing on making the button and its icon smaller for a more compact appearance.

- UI adjustments to settings button in `MoreView` (`MoreView.swift`):
  * Reduced the icon font size from `.title3` to `.body` and decreased the button's frame size for both the glass effect and background variants. [[1]](diffhunk://#diff-3608781ad0eeb7967c9bc4605f0c046142516c536a93f7fe0e113a2c2217cc56L23-R25) [[2]](diffhunk://#diff-3608781ad0eeb7967c9bc4605f0c046142516c536a93f7fe0e113a2c2217cc56L34-R36)