### PR TITLE
Refactor Live Activity handling and improve assignment sorting

### DIFF
--- a/backend/server/config.py
+++ b/backend/server/config.py
@@ -52,6 +52,15 @@ class Settings(BaseSettings):
     # fire_at within [now, now + window_seconds] becomes eligible each tick
     scheduler_window_seconds: int = 60
 
+    # --- Live Activity token retention ---
+    # Prune update-token rows that reached a terminal state (ended / failed /
+    # cancelled) and have not been touched since `live_activity_token_retention_days`.
+    # Active rows are never pruned; a device that stops syncing keeps its
+    # pending rows until the device itself is unregistered and the cascade
+    # delete fires.
+    live_activity_token_retention_days: int = 30
+    live_activity_token_retention_interval_hours: int = 24
+
     # --- Bulletins ---
     bulletin_list_url: str = (
         "https://bulletin.ntust.edu.tw/p/403-1045-1391-1.php"

--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -22,6 +22,7 @@ from server.push.apns_client import build_sender
 from server.routes import bulletins as bulletins_routes
 from server.routes import debug as debug_routes
 from server.routes import devices as devices_routes
+from server.routes import live_activities as live_activities_routes
 from server.routes import schedule as schedule_routes
 from server.scheduler.runtime import build_scheduler
 
@@ -133,6 +134,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         return {"pong": "tigerduck"}
 
     app.include_router(devices_routes.router, prefix=settings.api_base_path)
+    app.include_router(live_activities_routes.router, prefix=settings.api_base_path)
     app.include_router(schedule_routes.router, prefix=settings.api_base_path)
     app.include_router(debug_routes.router, prefix=settings.api_base_path)
     app.include_router(bulletins_routes.router, prefix=settings.api_base_path)

--- a/backend/server/migrations/versions/b6f4c9a2d1e0_add_live_activity_update_tokens.py
+++ b/backend/server/migrations/versions/b6f4c9a2d1e0_add_live_activity_update_tokens.py
@@ -1,0 +1,51 @@
+"""add live activity update tokens
+
+Revision ID: b6f4c9a2d1e0
+Revises: 9a4c7e1f2d8b
+Create Date: 2026-04-24 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'b6f4c9a2d1e0'
+down_revision: Union[str, Sequence[str], None] = '9a4c7e1f2d8b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'live_activity_update_tokens',
+        sa.Column('activity_id', sa.String(length=256), nullable=False),
+        sa.Column('device_id', sa.String(length=128), nullable=False),
+        sa.Column('source_id', sa.String(length=128), nullable=False),
+        sa.Column('scenario', sa.String(length=32), nullable=False),
+        sa.Column('update_token_hex', sa.String(length=512), nullable=False),
+        sa.Column('countdown_target', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('snapshot_json', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('status', sa.String(length=16), nullable=False),
+        sa.Column('attempts', sa.BigInteger(), nullable=False),
+        sa.Column('last_error', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('ended_at', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['device_id'], ['device_registrations.device_id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('activity_id'),
+    )
+    op.create_index(op.f('ix_live_activity_update_tokens_countdown_target'), 'live_activity_update_tokens', ['countdown_target'], unique=False)
+    op.create_index(op.f('ix_live_activity_update_tokens_device_id'), 'live_activity_update_tokens', ['device_id'], unique=False)
+    op.create_index('ix_live_activity_tokens_due', 'live_activity_update_tokens', ['status', 'countdown_target'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_live_activity_tokens_due', table_name='live_activity_update_tokens')
+    op.drop_index(op.f('ix_live_activity_update_tokens_device_id'), table_name='live_activity_update_tokens')
+    op.drop_index(op.f('ix_live_activity_update_tokens_countdown_target'), table_name='live_activity_update_tokens')
+    op.drop_table('live_activity_update_tokens')

--- a/backend/server/models.py
+++ b/backend/server/models.py
@@ -39,6 +39,13 @@ class PushStatus(StrEnum):
     cancelled = "cancelled"
 
 
+class LiveActivityTokenStatus(StrEnum):
+    active = "active"
+    ended = "ended"
+    failed = "failed"
+    cancelled = "cancelled"
+
+
 class DevicePlatform(StrEnum):
     """Push delivery platform. Picks which sender the dispatcher uses —
     APNs for apple, FCM for android. Stored as a plain string (not a PG
@@ -72,6 +79,9 @@ class DeviceRegistration(Base):
     )
 
     pushes: Mapped[list["ScheduledPush"]] = relationship(
+        back_populates="device", cascade="all, delete-orphan"
+    )
+    live_activity_tokens: Mapped[list["LiveActivityUpdateToken"]] = relationship(
         back_populates="device", cascade="all, delete-orphan"
     )
 
@@ -108,6 +118,50 @@ class ScheduledPush(Base):
 
     __table_args__ = (
         Index("ix_pushes_due", "status", "fire_at"),
+    )
+
+
+class LiveActivityUpdateToken(Base):
+    __tablename__ = "live_activity_update_tokens"
+
+    activity_id: Mapped[str] = mapped_column(String(256), primary_key=True)
+    device_id: Mapped[str] = mapped_column(
+        String(128),
+        ForeignKey("device_registrations.device_id", ondelete="CASCADE"),
+        index=True,
+    )
+    source_id: Mapped[str] = mapped_column(String(128))
+    scenario: Mapped[str] = mapped_column(String(32))
+    update_token_hex: Mapped[str] = mapped_column(String(512))
+    countdown_target: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        index=True,
+    )
+    snapshot_json: Mapped[dict] = mapped_column(JSONB)
+
+    status: Mapped[str] = mapped_column(
+        String(16), default=LiveActivityTokenStatus.active.value
+    )
+    attempts: Mapped[int] = mapped_column(BigInteger, default=0)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    device: Mapped[DeviceRegistration] = relationship(
+        back_populates="live_activity_tokens"
+    )
+
+    __table_args__ = (
+        Index("ix_live_activity_tokens_due", "status", "countdown_target"),
     )
 
 

--- a/backend/server/push/payload.py
+++ b/backend/server/push/payload.py
@@ -166,6 +166,7 @@ def build_pts_payload(
     aps: dict[str, Any] = {
         "timestamp": timestamp,
         "event": "start",
+        "input-push-token": 1,
         "attributes-type": attrs_type,
         "attributes": {"activityId": composed_activity_id(scenario, source_id)},
         "content-state": {"snapshot": normalized_snapshot},
@@ -179,6 +180,26 @@ def build_pts_payload(
     if dismissal_unix is not None:
         aps["dismissal-date"] = dismissal_unix
     return {"aps": aps}
+
+
+def build_end_payload(
+    snapshot: dict[str, Any],
+    now: datetime | None = None,
+    dismissal_date: datetime | None = None,
+) -> dict[str, Any]:
+    """Construct the `aps` payload that explicitly ends a Live Activity."""
+    ts = now or datetime.now(timezone.utc)
+    timestamp = int(ts.timestamp())
+    normalized_snapshot = _normalize_snapshot_for_apns(snapshot)
+    dismissal_unix = int((dismissal_date or ts).timestamp())
+    return {
+        "aps": {
+            "timestamp": timestamp,
+            "event": "end",
+            "content-state": {"snapshot": normalized_snapshot},
+            "dismissal-date": dismissal_unix,
+        }
+    }
 
 
 def build_alert_request(
@@ -268,4 +289,24 @@ def build_apns_request(
         expiration=expiration,
         priority=10,
         message=message,
+    )
+
+
+def build_live_activity_end_request(
+    *,
+    update_token: str,
+    bundle_id: str,
+    snapshot: dict[str, Any],
+    ttl_seconds: int = 4 * 3600,
+    now: datetime | None = None,
+) -> ApnsRequest:
+    """Build an APNs request that ends one existing Live Activity."""
+    ts = now or datetime.now(timezone.utc)
+    topic = f"{bundle_id}.push-type.liveactivity"
+    return ApnsRequest(
+        device_token=update_token,
+        topic=topic,
+        expiration=int(ts.timestamp()) + ttl_seconds,
+        priority=10,
+        message=build_end_payload(snapshot=snapshot, now=ts, dismissal_date=ts),
     )

--- a/backend/server/routes/debug.py
+++ b/backend/server/routes/debug.py
@@ -14,7 +14,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import select
 
 from server.db import SessionDep
-from server.models import DeviceRegistration, PushStatus, ScheduledPush
+from server.models import (
+    DeviceRegistration,
+    LiveActivityUpdateToken,
+    PushStatus,
+    ScheduledPush,
+)
 from server.push.payload import build_apns_request
 from server.scheduler.dispatcher import dispatch_due_pushes
 from server.security import require_shared_secret
@@ -41,10 +46,19 @@ async def stats(request: Request, session: SessionDep) -> dict:
         select(ScheduledPush.status, func.count()).group_by(ScheduledPush.status)
     )
     by_status = dict(rows.all())
-    device_count = (await session.execute(select(func.count()).select_from(DeviceRegistration))).scalar_one()
+    activity_rows = await session.execute(
+        select(LiveActivityUpdateToken.status, func.count()).group_by(
+            LiveActivityUpdateToken.status
+        )
+    )
+    activities_by_status = dict(activity_rows.all())
+    device_count = (
+        await session.execute(select(func.count()).select_from(DeviceRegistration))
+    ).scalar_one()
     return {
         "devices": device_count,
         "pushes_by_status": by_status,
+        "live_activities_by_status": activities_by_status,
         "sender_type": type(request.app.state.sender).__name__,
     }
 

--- a/backend/server/routes/live_activities.py
+++ b/backend/server/routes/live_activities.py
@@ -1,0 +1,87 @@
+"""Live Activity update-token registration endpoints."""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from server.db import SessionDep
+from server.models import (
+    DeviceRegistration,
+    LiveActivityTokenStatus,
+    LiveActivityUpdateToken,
+)
+from server.schemas import (
+    LiveActivityTokenRegisterRequest,
+    LiveActivityTokenRegisterResponse,
+)
+from server.security import require_shared_secret
+
+router = APIRouter(
+    prefix="/live-activities",
+    tags=["live-activities"],
+    dependencies=[Depends(require_shared_secret)],
+)
+logger = structlog.get_logger(__name__)
+
+
+@router.post("/register", response_model=LiveActivityTokenRegisterResponse)
+async def register_live_activity_token(
+    payload: LiveActivityTokenRegisterRequest,
+    session: SessionDep,
+) -> LiveActivityTokenRegisterResponse:
+    """Upsert the per-activity update token used for server-side end pushes."""
+    device = await session.get(DeviceRegistration, payload.device_id)
+    if device is None:
+        raise HTTPException(status_code=404, detail="device not registered")
+
+    stmt = (
+        pg_insert(LiveActivityUpdateToken)
+        .values(
+            activity_id=payload.activity_id,
+            device_id=payload.device_id,
+            source_id=payload.source_id,
+            scenario=payload.scenario.value,
+            update_token_hex=payload.update_token_hex,
+            countdown_target=payload.countdown_target,
+            snapshot_json=payload.snapshot,
+            status=LiveActivityTokenStatus.active.value,
+            attempts=0,
+            last_error=None,
+            ended_at=None,
+        )
+        .on_conflict_do_update(
+            index_elements=[LiveActivityUpdateToken.activity_id],
+            set_={
+                "device_id": payload.device_id,
+                "source_id": payload.source_id,
+                "scenario": payload.scenario.value,
+                "update_token_hex": payload.update_token_hex,
+                "countdown_target": payload.countdown_target,
+                "snapshot_json": payload.snapshot,
+                "status": LiveActivityTokenStatus.active.value,
+                "attempts": 0,
+                "last_error": None,
+                "ended_at": None,
+                "updated_at": func.now(),
+            },
+        )
+        .returning(LiveActivityUpdateToken)
+    )
+    result = await session.execute(stmt)
+    row = result.scalar_one()
+
+    logger.info(
+        "live_activity_token.registered",
+        device_id=row.device_id,
+        activity_id=row.activity_id,
+        scenario=row.scenario,
+        countdown_target=row.countdown_target,
+    )
+    return LiveActivityTokenRegisterResponse(
+        device_id=row.device_id,
+        activity_id=row.activity_id,
+        registered_at=row.updated_at,
+    )

--- a/backend/server/routes/schedule.py
+++ b/backend/server/routes/schedule.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Path, status
-from sqlalchemy import and_, delete, func, select
+from sqlalchemy import and_, delete, func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from server.db import SessionDep
-from server.models import DeviceRegistration, PushStatus, ScheduledPush, build_push_id
+from server.models import (
+    DeviceRegistration,
+    LiveActivityTokenStatus,
+    LiveActivityUpdateToken,
+    PushStatus,
+    ScheduledPush,
+    build_push_id,
+)
 from server.schemas import (
     ScheduleDeleteResponse,
     ScheduleSyncRequest,
@@ -145,7 +152,8 @@ async def cancel_by_source(
     """Cancel every pending push for this device+source_id (all scenarios).
 
     Called when user completes an assignment or skips a course — removes all
-    three potential pushes (classPreparing / inClass / assignmentUrgent).
+    three potential pushes and queues any active Live Activity token for an
+    immediate server-side end push.
     """
     stmt = delete(ScheduledPush).where(
         and_(
@@ -156,6 +164,17 @@ async def cancel_by_source(
     )
     result = await session.execute(stmt)
     deleted = result.rowcount or 0
+    await session.execute(
+        update(LiveActivityUpdateToken)
+        .where(
+            and_(
+                LiveActivityUpdateToken.device_id == device_id,
+                LiveActivityUpdateToken.source_id == source_id,
+                LiveActivityUpdateToken.status == LiveActivityTokenStatus.active.value,
+            )
+        )
+        .values(countdown_target=func.now(), updated_at=func.now())
+    )
     logger.info(
         "schedule.cancelled",
         device_id=device_id,

--- a/backend/server/scheduler/dispatcher.py
+++ b/backend/server/scheduler/dispatcher.py
@@ -141,6 +141,12 @@ async def dispatch_due_pushes(
                 if push.attempts + 1 >= MAX_ATTEMPTS:
                     failed += 1
 
+        # Look-ahead by `scheduler_window_seconds` so a countdown that lands
+        # 0–N seconds after this tick is still fired now rather than waiting
+        # one more full tick. Mirrors the push path above; without it, the
+        # `cancel_by_source` flow (which sets countdown_target=now()) would
+        # race the tick and leave the activity running for up to one tick
+        # interval past its intended end.
         activity_stmt = (
             select(LiveActivityUpdateToken, DeviceRegistration)
             .join(
@@ -151,7 +157,7 @@ async def dispatch_due_pushes(
                 LiveActivityUpdateToken.status
                 == LiveActivityTokenStatus.active.value,
                 LiveActivityUpdateToken.countdown_target.is_not(None),
-                LiveActivityUpdateToken.countdown_target <= ts,
+                LiveActivityUpdateToken.countdown_target <= window_end,
             )
             .with_for_update(skip_locked=True)
             .limit(64)

--- a/backend/server/scheduler/dispatcher.py
+++ b/backend/server/scheduler/dispatcher.py
@@ -24,9 +24,20 @@ from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from server.config import Settings
-from server.models import DeviceRegistration, PushStatus, ScheduledPush
+from server.models import (
+    DeviceRegistration,
+    LiveActivityTokenStatus,
+    LiveActivityUpdateToken,
+    PushStatus,
+    ScheduledPush,
+)
 from server.push.apns_client import PushSender, SendResult
-from server.push.payload import ApnsRequest, _countdown_target_unix, build_apns_request
+from server.push.payload import (
+    ApnsRequest,
+    _countdown_target_unix,
+    build_apns_request,
+    build_live_activity_end_request,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -128,6 +139,63 @@ async def dispatch_due_pushes(
                 # transient — retry next tick unless exhausted
                 await _bump_or_fail(session, push, result)
                 if push.attempts + 1 >= MAX_ATTEMPTS:
+                    failed += 1
+
+        activity_stmt = (
+            select(LiveActivityUpdateToken, DeviceRegistration)
+            .join(
+                DeviceRegistration,
+                DeviceRegistration.device_id == LiveActivityUpdateToken.device_id,
+            )
+            .where(
+                LiveActivityUpdateToken.status
+                == LiveActivityTokenStatus.active.value,
+                LiveActivityUpdateToken.countdown_target.is_not(None),
+                LiveActivityUpdateToken.countdown_target <= ts,
+            )
+            .with_for_update(skip_locked=True)
+            .limit(64)
+        )
+        activity_rows = (await session.execute(activity_stmt)).all()
+
+        for token, device in activity_rows:
+            dispatched += 1
+            try:
+                request = build_live_activity_end_request(
+                    update_token=token.update_token_hex,
+                    bundle_id=device.bundle_id,
+                    snapshot=token.snapshot_json,
+                    now=ts,
+                )
+            except Exception as build_error:  # pragma: no cover — defensive
+                await _mark_activity_failed(
+                    session,
+                    token,
+                    reason=f"build_error: {build_error}",
+                )
+                failed += 1
+                logger.exception(
+                    "dispatcher.activity_end_build_error",
+                    activity_id=token.activity_id,
+                )
+                continue
+
+            result = await _send_safely(sender, request)
+            classification = _classify(result)
+
+            if classification == "sent":
+                await _mark_activity_ended(session, token, ts)
+                sent += 1
+            elif classification == "bad_token":
+                await _mark_activity_cancelled(
+                    session,
+                    token,
+                    reason=result.description or "bad_token",
+                )
+                cancelled += 1
+            else:
+                await _bump_or_fail_activity(session, token, result)
+                if token.attempts + 1 >= MAX_ATTEMPTS:
                     failed += 1
 
         await session.commit()
@@ -234,6 +302,82 @@ async def _bump_or_fail(
         await session.execute(
             update(ScheduledPush)
             .where(ScheduledPush.push_id == push.push_id)
+            .values(
+                attempts=next_attempts,
+                last_error=f"status={result.status} desc={result.description}",
+                updated_at=func.now(),
+            )
+        )
+
+
+async def _mark_activity_ended(
+    session: AsyncSession,
+    token: LiveActivityUpdateToken,
+    ts: datetime,
+) -> None:
+    await session.execute(
+        update(LiveActivityUpdateToken)
+        .where(LiveActivityUpdateToken.activity_id == token.activity_id)
+        .values(
+            status=LiveActivityTokenStatus.ended.value,
+            ended_at=ts,
+            attempts=token.attempts + 1,
+            last_error=None,
+            updated_at=func.now(),
+        )
+    )
+
+
+async def _mark_activity_cancelled(
+    session: AsyncSession,
+    token: LiveActivityUpdateToken,
+    reason: str,
+) -> None:
+    await session.execute(
+        update(LiveActivityUpdateToken)
+        .where(LiveActivityUpdateToken.activity_id == token.activity_id)
+        .values(
+            status=LiveActivityTokenStatus.cancelled.value,
+            attempts=token.attempts + 1,
+            last_error=reason,
+            updated_at=func.now(),
+        )
+    )
+
+
+async def _mark_activity_failed(
+    session: AsyncSession,
+    token: LiveActivityUpdateToken,
+    reason: str,
+) -> None:
+    await session.execute(
+        update(LiveActivityUpdateToken)
+        .where(LiveActivityUpdateToken.activity_id == token.activity_id)
+        .values(
+            status=LiveActivityTokenStatus.failed.value,
+            attempts=token.attempts + 1,
+            last_error=reason,
+            updated_at=func.now(),
+        )
+    )
+
+
+async def _bump_or_fail_activity(
+    session: AsyncSession,
+    token: LiveActivityUpdateToken,
+    result: SendResult,
+) -> None:
+    next_attempts = token.attempts + 1
+    if next_attempts >= MAX_ATTEMPTS:
+        await _mark_activity_failed(
+            session,
+            token,
+            reason=f"status={result.status} desc={result.description}",
+        )
+    else:
+        await session.execute(
+            update(LiveActivityUpdateToken)
+            .where(LiveActivityUpdateToken.activity_id == token.activity_id)
             .values(
                 attempts=next_attempts,
                 last_error=f"status={result.status} desc={result.description}",

--- a/backend/server/scheduler/retention.py
+++ b/backend/server/scheduler/retention.py
@@ -1,0 +1,59 @@
+"""Periodic cleanup for Live Activity update-token rows.
+
+The dispatcher only moves rows between states — it never deletes them. Over
+time, ended / failed / cancelled rows accumulate for every Live Activity a
+device has ever run. This job prunes terminal rows whose `updated_at` sits
+outside the retention window so the table stays bounded.
+
+Rows with `status=active` are intentionally left alone: they still reference
+a running Live Activity, and a stale active row will either be replaced by
+the client's next registration (ON CONFLICT DO UPDATE) or cascade-deleted
+when the owning device is unregistered.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import structlog
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from server.config import Settings
+from server.models import LiveActivityTokenStatus, LiveActivityUpdateToken
+
+logger = structlog.get_logger(__name__)
+
+
+_TERMINAL_STATES = (
+    LiveActivityTokenStatus.ended.value,
+    LiveActivityTokenStatus.failed.value,
+    LiveActivityTokenStatus.cancelled.value,
+)
+
+
+async def prune_terminal_activity_tokens(
+    session_factory: async_sessionmaker[AsyncSession],
+    settings: Settings,
+) -> int:
+    """Delete terminal-state update-token rows older than the retention
+    window. Returns the number of rows deleted for observability."""
+    cutoff = datetime.now(timezone.utc) - timedelta(
+        days=settings.live_activity_token_retention_days
+    )
+    async with session_factory() as session:
+        result = await session.execute(
+            delete(LiveActivityUpdateToken).where(
+                LiveActivityUpdateToken.status.in_(_TERMINAL_STATES),
+                LiveActivityUpdateToken.updated_at < cutoff,
+            )
+        )
+        await session.commit()
+    deleted = result.rowcount or 0
+    logger.info(
+        "live_activity_tokens.retention.done",
+        deleted=deleted,
+        cutoff=cutoff.isoformat(),
+        retention_days=settings.live_activity_token_retention_days,
+    )
+    return deleted

--- a/backend/server/scheduler/runtime.py
+++ b/backend/server/scheduler/runtime.py
@@ -17,6 +17,7 @@ from server.bulletins.llm.openai_compat import OpenAICompatibleProvider
 from server.config import Settings
 from server.push.apns_client import PushSender
 from server.scheduler.dispatcher import dispatch_due_pushes
+from server.scheduler.retention import prune_terminal_activity_tokens
 
 
 def build_llm_provider(settings: Settings) -> LLMProvider:
@@ -44,6 +45,7 @@ def build_scheduler(
     * `bulletin_process` — drain pending bulletins through the LLM every 60s.
     * `bulletin_dispatch` — fan out alert pushes every 60s.
     * `bulletin_retention` — prune aged-out soft-deleted bulletins daily.
+    * `live_activity_token_retention` — prune terminal update-token rows daily.
 
     Passing `llm=None` (the default) builds the real OpenAI-compatible
     provider; tests inject `RecordingProvider` to stay offline.
@@ -65,6 +67,9 @@ def build_scheduler(
 
     async def bulletin_retention() -> None:
         await bulletin_jobs.retention_job(session_factory, settings)
+
+    async def live_activity_token_retention() -> None:
+        await prune_terminal_activity_tokens(session_factory, settings)
 
     scheduler.add_job(
         pts_tick,
@@ -102,6 +107,16 @@ def build_scheduler(
         bulletin_retention,
         trigger=IntervalTrigger(hours=settings.bulletin_retention_interval_hours),
         id="bulletin_retention",
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=3600,
+    )
+    scheduler.add_job(
+        live_activity_token_retention,
+        trigger=IntervalTrigger(
+            hours=settings.live_activity_token_retention_interval_hours
+        ),
+        id="live_activity_token_retention",
         max_instances=1,
         coalesce=True,
         misfire_grace_time=3600,

--- a/backend/server/schemas.py
+++ b/backend/server/schemas.py
@@ -67,3 +67,19 @@ class ScheduleDeleteResponse(BaseModel):
     device_id: str
     source_id: str
     deleted: int
+
+
+class LiveActivityTokenRegisterRequest(BaseModel):
+    device_id: str = Field(min_length=1, max_length=128)
+    activity_id: str = Field(min_length=1, max_length=256)
+    source_id: str = Field(min_length=1, max_length=128, pattern=r"^[^:]+$")
+    scenario: ScenarioKind
+    update_token_hex: str = Field(min_length=1, max_length=512)
+    countdown_target: datetime | None = None
+    snapshot: dict[str, Any]
+
+
+class LiveActivityTokenRegisterResponse(BaseModel):
+    device_id: str
+    activity_id: str
+    registered_at: datetime

--- a/backend/server/schemas.py
+++ b/backend/server/schemas.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ScenarioKind(StrEnum):
@@ -77,6 +77,21 @@ class LiveActivityTokenRegisterRequest(BaseModel):
     update_token_hex: str = Field(min_length=1, max_length=512)
     countdown_target: datetime | None = None
     snapshot: dict[str, Any]
+
+    @model_validator(mode="after")
+    def _snapshot_source_id_must_match(self) -> "LiveActivityTokenRegisterRequest":
+        # Snapshot carries its own sourceId (mirrors Swift's
+        # LiveActivitySnapshot.sourceId). If it disagrees with the top-level
+        # source_id, the server-side cancel_by_source lookup and the
+        # Live Activity payload would reference different ids — a silent
+        # divergence that is almost always a client bug.
+        snapshot_source_id = self.snapshot.get("sourceId")
+        if snapshot_source_id is not None and snapshot_source_id != self.source_id:
+            raise ValueError(
+                f"snapshot.sourceId ({snapshot_source_id!r}) must match "
+                f"source_id ({self.source_id!r})"
+            )
+        return self
 
 
 class LiveActivityTokenRegisterResponse(BaseModel):

--- a/backend/server/tests/conftest.py
+++ b/backend/server/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from collections.abc import AsyncIterator
 
@@ -67,9 +68,17 @@ def test_settings() -> Settings:
     # `scheduler_tick_seconds=99999` neuters the background APScheduler job
     # that ASGITransport starts via the lifespan handler — otherwise the
     # dispatcher could mark test rows `sent` and make assertions flaky.
+    #
+    # Honor TIGERDUCK_TEST_DATABASE_URL so the same tests can run in a
+    # CI/container setup where Postgres lives on a different host (e.g. the
+    # compose `postgres` service) without editing this file.
+    database_url = os.environ.get(
+        "TIGERDUCK_TEST_DATABASE_URL",
+        "postgresql+asyncpg://tigerduck:tigerduck@localhost:5432/tigerduck_test",
+    )
     return Settings(
         env="development",
-        database_url="postgresql+asyncpg://tigerduck:tigerduck@localhost:5432/tigerduck_test",
+        database_url=database_url,
         apns_env="development",
         scheduler_tick_seconds=99999,
         api_shared_secret="",

--- a/backend/server/tests/test_dispatcher.py
+++ b/backend/server/tests/test_dispatcher.py
@@ -11,7 +11,14 @@ from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 
 from server.config import Settings
 from server.db import build_session_factory
-from server.models import DeviceRegistration, PushStatus, ScheduledPush, build_push_id
+from server.models import (
+    DeviceRegistration,
+    LiveActivityTokenStatus,
+    LiveActivityUpdateToken,
+    PushStatus,
+    ScheduledPush,
+    build_push_id,
+)
 from server.push.apns_client import RecordingSender, SendResult
 from server.scheduler.dispatcher import dispatch_due_pushes
 
@@ -75,6 +82,54 @@ async def _seed_push(
 async def _status_of(factory: async_sessionmaker, push_id: str) -> tuple[str, int, str | None]:
     async with factory() as s:
         row = await s.get(ScheduledPush, push_id)
+        assert row is not None
+        return row.status, row.attempts, row.last_error
+
+
+async def _seed_live_activity_token(
+    factory: async_sessionmaker,
+    *,
+    activity_id: str,
+    source_id: str,
+    scenario: str,
+    countdown_target: datetime,
+    status: str = LiveActivityTokenStatus.active.value,
+    attempts: int = 0,
+) -> str:
+    async with factory() as s:
+        token = LiveActivityUpdateToken(
+            activity_id=activity_id,
+            device_id=DEVICE_ID,
+            source_id=source_id,
+            scenario=scenario,
+            update_token_hex="cc" * 80,
+            countdown_target=countdown_target,
+            snapshot_json={
+                "scenario": scenario,
+                "title": "Algorithms",
+                "subtitle": "10:10-12:00",
+                "locationText": "T2-401",
+                "instructor": "王小明",
+                "countdownTarget": countdown_target.isoformat(),
+                "progressStart": None,
+                "accentHex": 0x4A90E2,
+                "deepLink": None,
+                "sourceId": source_id,
+            },
+            status=status,
+            attempts=attempts,
+        )
+        s.add(token)
+        await s.commit()
+    return activity_id
+
+
+async def _activity_status_of(
+    factory: async_sessionmaker,
+    activity_id: str,
+) -> tuple[str, int, str | None]:
+    async with factory() as s:
+        row = await s.get(LiveActivityUpdateToken, activity_id)
         assert row is not None
         return row.status, row.attempts, row.last_error
 
@@ -251,3 +306,61 @@ async def test_bad_token_prunes_device_and_cancels(
         assert dev is None
         push = await s.get(ScheduledPush, push_id)
         assert push is None
+
+
+async def test_due_live_activity_end_is_sent(
+    client: AsyncClient,
+    prepared_engine: AsyncEngine,
+    test_settings: Settings,
+):
+    await _register_device(client)
+    factory = build_session_factory(prepared_engine)
+    now = datetime.now(timezone.utc)
+    activity_id = await _seed_live_activity_token(
+        factory,
+        activity_id="inClass::slot-end",
+        source_id="slot-end",
+        scenario="inClass",
+        countdown_target=now,
+    )
+
+    sender = RecordingSender()
+    outcome = await dispatch_due_pushes(factory, sender, test_settings, now=now)
+
+    assert outcome.dispatched == 1
+    assert outcome.sent == 1
+    assert len(sender.requests) == 1
+    req = sender.requests[0]
+    assert req.device_token == "cc" * 80
+    assert req.message["aps"]["event"] == "end"
+    assert req.message["aps"]["dismissal-date"] == int(now.timestamp())
+
+    status, attempts, err = await _activity_status_of(factory, activity_id)
+    assert status == LiveActivityTokenStatus.ended.value
+    assert attempts == 1
+    assert err is None
+
+
+async def test_future_live_activity_end_is_skipped(
+    client: AsyncClient,
+    prepared_engine: AsyncEngine,
+    test_settings: Settings,
+):
+    await _register_device(client)
+    factory = build_session_factory(prepared_engine)
+    now = datetime.now(timezone.utc)
+    activity_id = await _seed_live_activity_token(
+        factory,
+        activity_id="inClass::slot-future-end",
+        source_id="slot-future-end",
+        scenario="inClass",
+        countdown_target=now + timedelta(minutes=10),
+    )
+
+    sender = RecordingSender()
+    outcome = await dispatch_due_pushes(factory, sender, test_settings, now=now)
+
+    assert outcome.dispatched == 0
+    assert sender.requests == []
+    status, _, _ = await _activity_status_of(factory, activity_id)
+    assert status == LiveActivityTokenStatus.active.value

--- a/backend/server/tests/test_dispatcher.py
+++ b/backend/server/tests/test_dispatcher.py
@@ -341,6 +341,33 @@ async def test_due_live_activity_end_is_sent(
     assert err is None
 
 
+async def test_live_activity_end_within_window_is_sent(
+    client: AsyncClient,
+    prepared_engine: AsyncEngine,
+    test_settings: Settings,
+):
+    """Near-future Live Activity ends fire the same tick, matching the push
+    path. `scheduler_window_seconds` (default 60) is the symmetric look-ahead."""
+    await _register_device(client)
+    factory = build_session_factory(prepared_engine)
+    now = datetime.now(timezone.utc)
+    activity_id = await _seed_live_activity_token(
+        factory,
+        activity_id="inClass::slot-near-end",
+        source_id="slot-near-end",
+        scenario="inClass",
+        countdown_target=now + timedelta(seconds=30),
+    )
+
+    sender = RecordingSender()
+    outcome = await dispatch_due_pushes(factory, sender, test_settings, now=now)
+
+    assert outcome.dispatched == 1
+    assert outcome.sent == 1
+    status, _, _ = await _activity_status_of(factory, activity_id)
+    assert status == LiveActivityTokenStatus.ended.value
+
+
 async def test_future_live_activity_end_is_skipped(
     client: AsyncClient,
     prepared_engine: AsyncEngine,

--- a/backend/server/tests/test_live_activities.py
+++ b/backend/server/tests/test_live_activities.py
@@ -67,6 +67,32 @@ async def test_register_live_activity_token_requires_device(client: AsyncClient)
     assert response.status_code == 404
 
 
+async def test_register_live_activity_token_rejects_mismatched_source_id(
+    client: AsyncClient,
+):
+    """`snapshot.sourceId` must equal the top-level `source_id`. A bug on the
+    client that sends mismatched values would otherwise silently store a row
+    whose snapshot points at the wrong assignment/slot, so the later
+    cancel_by_source / end-push flow would reference divergent ids."""
+    await _register_device(client)
+    target = datetime.now(timezone.utc) + timedelta(minutes=15)
+    snapshot = _snapshot(target)
+    snapshot["sourceId"] = "slot-other"  # deliberately mismatched
+    response = await client.post(
+        "/v1/live-activities/register",
+        json={
+            "device_id": DEVICE_ID,
+            "activity_id": "classPreparing::slot-live",
+            "source_id": "slot-live",
+            "scenario": "classPreparing",
+            "update_token_hex": "b" * 128,
+            "countdown_target": _iso(target),
+            "snapshot": snapshot,
+        },
+    )
+    assert response.status_code == 422, response.text
+
+
 async def test_register_live_activity_token_upserts(
     client: AsyncClient,
     prepared_engine: AsyncEngine,
@@ -115,3 +141,6 @@ async def test_register_live_activity_token_upserts(
     assert len(rows) == 1
     assert rows[0].update_token_hex == "c" * 128
     assert rows[0].status == LiveActivityTokenStatus.active.value
+    # Re-registering a previously-ended activity (ended_at would be set by the
+    # dispatcher) must reset the terminal markers so the row is eligible again.
+    assert rows[0].ended_at is None

--- a/backend/server/tests/test_live_activities.py
+++ b/backend/server/tests/test_live_activities.py
@@ -1,0 +1,117 @@
+"""Live Activity update-token endpoint tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from server.db import build_session_factory
+from server.models import LiveActivityTokenStatus, LiveActivityUpdateToken
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+DEVICE_ID = "device-live-activity"
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _snapshot(countdown_target: datetime) -> dict:
+    return {
+        "scenario": "classPreparing",
+        "title": "Algorithms",
+        "subtitle": "10:10-12:00",
+        "locationText": "T2-401",
+        "instructor": "王小明",
+        "countdownTarget": _iso(countdown_target),
+        "progressStart": None,
+        "accentHex": 0x4A90E2,
+        "deepLink": None,
+        "sourceId": "slot-live",
+    }
+
+
+async def _register_device(client: AsyncClient) -> None:
+    response = await client.post(
+        "/v1/devices/register",
+        json={
+            "user_id": "user-live",
+            "device_id": DEVICE_ID,
+            "pts_token_hex": "a" * 128,
+            "apns_env": "development",
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+async def test_register_live_activity_token_requires_device(client: AsyncClient):
+    target = datetime.now(timezone.utc) + timedelta(minutes=15)
+    response = await client.post(
+        "/v1/live-activities/register",
+        json={
+            "device_id": "missing-device",
+            "activity_id": "classPreparing::slot-live",
+            "source_id": "slot-live",
+            "scenario": "classPreparing",
+            "update_token_hex": "b" * 128,
+            "countdown_target": _iso(target),
+            "snapshot": _snapshot(target),
+        },
+    )
+    assert response.status_code == 404
+
+
+async def test_register_live_activity_token_upserts(
+    client: AsyncClient,
+    prepared_engine: AsyncEngine,
+):
+    await _register_device(client)
+    target = datetime.now(timezone.utc) + timedelta(minutes=15)
+
+    first = await client.post(
+        "/v1/live-activities/register",
+        json={
+            "device_id": DEVICE_ID,
+            "activity_id": "classPreparing::slot-live",
+            "source_id": "slot-live",
+            "scenario": "classPreparing",
+            "update_token_hex": "b" * 128,
+            "countdown_target": _iso(target),
+            "snapshot": _snapshot(target),
+        },
+    )
+    assert first.status_code == 200, first.text
+
+    second_target = target + timedelta(minutes=5)
+    second = await client.post(
+        "/v1/live-activities/register",
+        json={
+            "device_id": DEVICE_ID,
+            "activity_id": "classPreparing::slot-live",
+            "source_id": "slot-live",
+            "scenario": "classPreparing",
+            "update_token_hex": "c" * 128,
+            "countdown_target": _iso(second_target),
+            "snapshot": _snapshot(second_target),
+        },
+    )
+    assert second.status_code == 200, second.text
+
+    factory = build_session_factory(prepared_engine)
+    async with factory() as s:
+        rows = (
+            await s.execute(
+                select(LiveActivityUpdateToken).where(
+                    LiveActivityUpdateToken.device_id == DEVICE_ID
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].update_token_hex == "c" * 128
+    assert rows[0].status == LiveActivityTokenStatus.active.value

--- a/backend/server/tests/test_payload.py
+++ b/backend/server/tests/test_payload.py
@@ -11,6 +11,7 @@ from server.push.payload import (
     SCENARIO_CLASS_PREPARING,
     SCENARIO_IN_CLASS,
     build_apns_request,
+    build_live_activity_end_request,
     build_pts_payload,
 )
 
@@ -45,6 +46,7 @@ def test_build_pts_payload_minimum_shape():
     )
     aps = payload["aps"]
     assert aps["event"] == "start"
+    assert aps["input-push-token"] == 1
     assert aps["attributes-type"] == "TigerDuckActivityAttributes"
     # Composite id = `{scenario}::{source_id}` — scoped by scenario so
     # classPreparing and inClass never collide in ActivityKit.
@@ -231,3 +233,26 @@ def test_custom_attrs_type_reflected():
         now=FIXED_NOW,
     )
     assert request.message["aps"]["attributes-type"] == "SomeOtherAttributes"
+
+
+def test_build_live_activity_end_request():
+    snapshot = _sample_snapshot(
+        countdownTarget="2026-04-22T02:10:00+00:00",
+        progressStart=None,
+    )
+    request = build_live_activity_end_request(
+        update_token="b" * 128,
+        bundle_id="org.ntust.app.TigerDuck",
+        snapshot=snapshot,
+        now=FIXED_NOW,
+    )
+
+    assert request.device_token == "b" * 128
+    assert request.topic == "org.ntust.app.TigerDuck.push-type.liveactivity"
+    assert request.priority == 10
+    assert request.expiration == int(FIXED_NOW.timestamp()) + 4 * 3600
+    aps = request.message["aps"]
+    assert aps["event"] == "end"
+    assert aps["timestamp"] == int(FIXED_NOW.timestamp())
+    assert aps["dismissal-date"] == int(FIXED_NOW.timestamp())
+    assert isinstance(aps["content-state"]["snapshot"]["countdownTarget"], float)

--- a/backend/server/tests/test_retention.py
+++ b/backend/server/tests/test_retention.py
@@ -1,0 +1,122 @@
+"""Retention job tests — ended/failed/cancelled Live Activity tokens are
+pruned past their retention window, active rows are untouched."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from server.config import Settings
+from server.db import build_session_factory
+from server.models import LiveActivityTokenStatus, LiveActivityUpdateToken
+from server.scheduler.retention import prune_terminal_activity_tokens
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+DEVICE_ID = "device-retention"
+
+
+async def _register_device(client: AsyncClient) -> None:
+    response = await client.post(
+        "/v1/devices/register",
+        json={
+            "user_id": "user-retention",
+            "device_id": DEVICE_ID,
+            "pts_token_hex": "a" * 128,
+            "apns_env": "development",
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+async def _seed_token(
+    factory,
+    *,
+    activity_id: str,
+    status: str,
+    updated_delta: timedelta,
+) -> None:
+    now = datetime.now(timezone.utc)
+    async with factory() as s:
+        s.add(
+            LiveActivityUpdateToken(
+                activity_id=activity_id,
+                device_id=DEVICE_ID,
+                source_id=activity_id.split("::")[-1],
+                scenario="inClass",
+                update_token_hex="c" * 80,
+                countdown_target=None,
+                snapshot_json={"sourceId": activity_id.split("::")[-1]},
+                status=status,
+                attempts=1,
+            )
+        )
+        await s.commit()
+        # Tests can't rely on created_at/updated_at since SQLAlchemy stamps
+        # them with NOW() at insert. Backdate explicitly so the cutoff logic
+        # has something to match against.
+        await s.execute(
+            update(LiveActivityUpdateToken)
+            .where(LiveActivityUpdateToken.activity_id == activity_id)
+            .values(updated_at=now - updated_delta)
+        )
+        await s.commit()
+
+
+async def test_retention_prunes_terminal_rows_past_cutoff(
+    client: AsyncClient,
+    prepared_engine: AsyncEngine,
+    test_settings: Settings,
+):
+    await _register_device(client)
+    factory = build_session_factory(prepared_engine)
+
+    retention = timedelta(days=test_settings.live_activity_token_retention_days)
+    await _seed_token(
+        factory,
+        activity_id="inClass::old-ended",
+        status=LiveActivityTokenStatus.ended.value,
+        updated_delta=retention + timedelta(days=1),
+    )
+    await _seed_token(
+        factory,
+        activity_id="inClass::old-cancelled",
+        status=LiveActivityTokenStatus.cancelled.value,
+        updated_delta=retention + timedelta(days=1),
+    )
+    await _seed_token(
+        factory,
+        activity_id="inClass::old-failed",
+        status=LiveActivityTokenStatus.failed.value,
+        updated_delta=retention + timedelta(days=1),
+    )
+    await _seed_token(
+        factory,
+        activity_id="inClass::recent-ended",
+        status=LiveActivityTokenStatus.ended.value,
+        updated_delta=timedelta(days=1),
+    )
+    await _seed_token(
+        factory,
+        activity_id="inClass::old-but-active",
+        status=LiveActivityTokenStatus.active.value,
+        updated_delta=retention + timedelta(days=1),
+    )
+
+    deleted = await prune_terminal_activity_tokens(factory, test_settings)
+    assert deleted == 3
+
+    async with factory() as s:
+        rows = (
+            await s.execute(
+                select(LiveActivityUpdateToken.activity_id).order_by(
+                    LiveActivityUpdateToken.activity_id
+                )
+            )
+        ).scalars().all()
+    assert rows == ["inClass::old-but-active", "inClass::recent-ended"]

--- a/swift/TigerDuck.xcodeproj/project.pbxproj
+++ b/swift/TigerDuck.xcodeproj/project.pbxproj
@@ -590,7 +590,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -642,7 +642,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -786,7 +786,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.TigerDuckLiveActivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -820,7 +820,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.TigerDuckLiveActivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -58,6 +58,10 @@ final class AppState {
 
         runPendingMigrations()
 
+        liveActivityCoordinator.setUpdateTokenRegistrationHandler { [weak self] registration in
+            await self?.pushCoordinator.registerLiveActivityUpdateToken(registration)
+        }
+
         // Auto-enable the push stack when the user has already opted in
         // (e.g. across app launches). The coordinator no-ops when the
         // toggle is off, so this is safe to call unconditionally.

--- a/swift/TigerDuck/Extensions/Array+Assignments.swift
+++ b/swift/TigerDuck/Extensions/Array+Assignments.swift
@@ -33,9 +33,9 @@ extension Array where Element == SDAssignment {
     /// due date descending (most recently due first). Ignored-but-unsubmitted
     /// items are excluded because they live in the dedicated 已忽略 filter.
     func allSorted() -> [SDAssignment] {
-        let incomplete = filter { !$0.isCompleted && !$0.isArchived }
+        let incomplete = filter { !($0.isCompleted || $0.isLocallyCompleted) && !$0.isArchived }
             .sorted { $0.dueDate < $1.dueDate }
-        let completed = filter { $0.isCompleted }.sorted { $0.dueDate > $1.dueDate }
+        let completed = filter { ($0.isCompleted || $0.isLocallyCompleted) }.sorted { $0.dueDate > $1.dueDate }
         return incomplete + completed
     }
 }

--- a/swift/TigerDuck/LiveActivity/Runtime/LiveActivityCoordinator.swift
+++ b/swift/TigerDuck/LiveActivity/Runtime/LiveActivityCoordinator.swift
@@ -3,7 +3,7 @@ import Foundation
 import os
 
 /// Reflects a resolved `LiveActivitySnapshot` as at most one running
-/// `TigerDuckActivityAttributes` activity per `(scenario, sourceId)` pair.
+/// `TigerDuckActivityAttributes` activity.
 ///
 /// Scenario-scoped `activityId` (`snapshot.composedActivityId`) is the
 /// single source of truth for identity. It keeps the on-device path and
@@ -12,25 +12,35 @@ import os
 /// the server can start the inClass one without colliding with the
 /// classPreparing one that iOS already has running.
 ///
-/// `apply` touches only the activity matching the current snapshot's
-/// composed id. Activities for other slots / scenarios — typically
-/// prelaunched by the server for upcoming events — are left alone and
-/// auto-dismiss at their own `dismissal-date`. Explicitly ending them
-/// here would kill legitimate future Live Activities (e.g. next
-/// class's classPreparing) the moment the app opens.
+/// The coordinator owns the client-side single-activity invariant. ActivityKit
+/// does not treat `staleDate` as an end signal, and server-started activities
+/// are not guaranteed to disappear unless an explicit end path runs. Every
+/// foreground refresh therefore prunes expired activities and ends any
+/// non-current activity before starting or updating the resolved target.
 @MainActor
 final class LiveActivityCoordinator {
     private let store: SharedSnapshotStore
     private let logger = Logger(subsystem: "org.ntust.app.TigerDuck", category: "LiveActivity")
+    private var automaticEndTasks: [String: Task<Void, Never>] = [:]
+    private var activityObserverTask: Task<Void, Never>?
 
     init(store: SharedSnapshotStore = SharedSnapshotStore()) {
         self.store = store
+        startActivityObserver()
+    }
+
+    deinit {
+        activityObserverTask?.cancel()
+        cancelAutomaticEndTasks()
     }
 
     /// Apply the resolved snapshot. Starts or updates the single activity
-    /// matching the target id; never ends unrelated activities.
+    /// matching the target id and ends stale or unrelated activities.
     func apply(snapshot: LiveActivitySnapshot?) async {
         store.writeSnapshot(snapshot)
+
+        let now = Date()
+        await pruneRunningActivities(keeping: snapshot?.composedActivityId, now: now)
 
         guard ActivityAuthorizationInfo().areActivitiesEnabled else {
             logger.info("Live Activities are disabled by the system")
@@ -38,8 +48,7 @@ final class LiveActivityCoordinator {
         }
 
         guard let snapshot else {
-            // Snapshot cleared — nothing to do for the on-device target.
-            // Server-pushed activities continue their own lifecycle.
+            cancelAutomaticEndTasks()
             return
         }
 
@@ -53,13 +62,15 @@ final class LiveActivityCoordinator {
             if matching.content.state.snapshot != snapshot {
                 await matching.update(content)
             }
+            scheduleAutomaticEnd(for: targetId, snapshot: snapshot, now: now)
         } else {
             do {
-                _ = try Activity.request(
+                _ = try Activity<TigerDuckActivityAttributes>.request(
                     attributes: TigerDuckActivityAttributes(activityId: targetId),
                     content: content,
                     pushType: nil
                 )
+                scheduleAutomaticEnd(for: targetId, snapshot: snapshot, now: now)
             } catch {
                 logger.error("Failed to start Live Activity: \(error.localizedDescription, privacy: .public)")
                 AppLogger.captureError(error, context: [
@@ -75,8 +86,106 @@ final class LiveActivityCoordinator {
     /// screen, server-pushed or otherwise.
     func endAll() async {
         for activity in Activity<TigerDuckActivityAttributes>.activities {
-            await activity.end(nil, dismissalPolicy: .immediate)
+            await end(activity, reason: "endAll")
         }
+        cancelAutomaticEndTasks()
         store.writeSnapshot(nil)
+    }
+
+    private func startActivityObserver() {
+        activityObserverTask = Task { @MainActor [weak self] in
+            for await activity in Activity<TigerDuckActivityAttributes>.activityUpdates {
+                guard let self else { return }
+                let now = Date()
+                await pruneRunningActivities(keeping: nil, now: now, expiredOnly: true)
+                let snapshot = activity.content.state.snapshot
+                if snapshot.countdownTarget.map({ $0 <= now }) == true {
+                    await end(activity, reason: "observed expired activity")
+                } else {
+                    scheduleAutomaticEnd(
+                        for: activity.attributes.activityId,
+                        snapshot: snapshot,
+                        now: now
+                    )
+                }
+            }
+        }
+    }
+
+    private func pruneRunningActivities(
+        keeping targetId: String?,
+        now: Date,
+        expiredOnly: Bool = false
+    ) async {
+        var retainedTaskIds: Set<String> = []
+        for activity in Activity<TigerDuckActivityAttributes>.activities {
+            let activityId = activity.attributes.activityId
+            let isExpired = activity.content.state.snapshot.countdownTarget.map { $0 <= now } ?? false
+            let isCurrentTarget = targetId.map { $0 == activityId } ?? false
+
+            if isExpired {
+                await end(activity, reason: "countdown expired")
+            } else if !expiredOnly, !isCurrentTarget {
+                await end(activity, reason: "non-current activity")
+            } else {
+                retainedTaskIds.insert(activityId)
+                scheduleAutomaticEnd(
+                    for: activityId,
+                    snapshot: activity.content.state.snapshot,
+                    now: now
+                )
+            }
+        }
+        cancelAutomaticEndTasks(except: retainedTaskIds)
+    }
+
+    private func scheduleAutomaticEnd(
+        for activityId: String,
+        snapshot: LiveActivitySnapshot,
+        now: Date
+    ) {
+        automaticEndTasks[activityId]?.cancel()
+
+        guard let target = snapshot.countdownTarget else {
+            automaticEndTasks[activityId] = nil
+            return
+        }
+
+        let delay = max(0, target.timeIntervalSince(now)) + 1
+        automaticEndTasks[activityId] = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled else { return }
+            await self?.endIfStillExpired(activityId: activityId, target: target)
+        }
+    }
+
+    private func endIfStillExpired(activityId: String, target: Date) async {
+        automaticEndTasks[activityId] = nil
+        guard Date() >= target,
+              let activity = Activity<TigerDuckActivityAttributes>.activities
+              .first(where: { $0.attributes.activityId == activityId }) else {
+            return
+        }
+        await end(activity, reason: "automatic countdown end")
+    }
+
+    private func end(
+        _ activity: Activity<TigerDuckActivityAttributes>,
+        reason: String
+    ) async {
+        let activityId = activity.attributes.activityId
+        logger.info(
+            "Ending Live Activity id=\(activityId, privacy: .public) reason=\(reason, privacy: .public)"
+        )
+        await activity.end(nil, dismissalPolicy: .immediate)
+        automaticEndTasks[activityId]?.cancel()
+        automaticEndTasks[activityId] = nil
+    }
+
+    private func cancelAutomaticEndTasks(except retainedIds: Set<String> = []) {
+        for activityId in Array(automaticEndTasks.keys) where !retainedIds.contains(activityId) {
+            automaticEndTasks[activityId]?.cancel()
+            automaticEndTasks[activityId] = nil
+        }
     }
 }

--- a/swift/TigerDuck/LiveActivity/Runtime/LiveActivityCoordinator.swift
+++ b/swift/TigerDuck/LiveActivity/Runtime/LiveActivityCoordinator.swift
@@ -2,6 +2,12 @@ import ActivityKit
 import Foundation
 import os
 
+nonisolated struct LiveActivityUpdateTokenRegistration: Sendable {
+    let activityId: String
+    let updateTokenHex: String
+    let snapshot: LiveActivitySnapshot
+}
+
 /// Reflects a resolved `LiveActivitySnapshot` as at most one running
 /// `TigerDuckActivityAttributes` activity.
 ///
@@ -23,6 +29,8 @@ final class LiveActivityCoordinator {
     private let logger = Logger(subsystem: "org.ntust.app.TigerDuck", category: "LiveActivity")
     private var automaticEndTasks: [String: Task<Void, Never>] = [:]
     private var activityObserverTask: Task<Void, Never>?
+    private var activityUpdateTokenTasks: [String: Task<Void, Never>] = [:]
+    private var updateTokenRegistrationHandler: (@Sendable (LiveActivityUpdateTokenRegistration) async -> Void)?
 
     init(store: SharedSnapshotStore = SharedSnapshotStore()) {
         self.store = store
@@ -31,7 +39,18 @@ final class LiveActivityCoordinator {
 
     deinit {
         activityObserverTask?.cancel()
-        cancelAutomaticEndTasks()
+        for task in automaticEndTasks.values {
+            task.cancel()
+        }
+        for task in activityUpdateTokenTasks.values {
+            task.cancel()
+        }
+    }
+
+    func setUpdateTokenRegistrationHandler(
+        _ handler: @escaping @Sendable (LiveActivityUpdateTokenRegistration) async -> Void
+    ) {
+        updateTokenRegistrationHandler = handler
     }
 
     /// Apply the resolved snapshot. Starts or updates the single activity
@@ -62,14 +81,16 @@ final class LiveActivityCoordinator {
             if matching.content.state.snapshot != snapshot {
                 await matching.update(content)
             }
+            observeUpdateToken(for: matching)
             scheduleAutomaticEnd(for: targetId, snapshot: snapshot, now: now)
         } else {
             do {
-                _ = try Activity<TigerDuckActivityAttributes>.request(
+                let activity = try Activity<TigerDuckActivityAttributes>.request(
                     attributes: TigerDuckActivityAttributes(activityId: targetId),
                     content: content,
-                    pushType: nil
+                    pushType: .token
                 )
+                observeUpdateToken(for: activity)
                 scheduleAutomaticEnd(for: targetId, snapshot: snapshot, now: now)
             } catch {
                 logger.error("Failed to start Live Activity: \(error.localizedDescription, privacy: .public)")
@@ -89,6 +110,7 @@ final class LiveActivityCoordinator {
             await end(activity, reason: "endAll")
         }
         cancelAutomaticEndTasks()
+        cancelUpdateTokenTasks()
         store.writeSnapshot(nil)
     }
 
@@ -102,6 +124,7 @@ final class LiveActivityCoordinator {
                 if snapshot.countdownTarget.map({ $0 <= now }) == true {
                     await end(activity, reason: "observed expired activity")
                 } else {
+                    observeUpdateToken(for: activity)
                     scheduleAutomaticEnd(
                         for: activity.attributes.activityId,
                         snapshot: snapshot,
@@ -129,6 +152,7 @@ final class LiveActivityCoordinator {
                 await end(activity, reason: "non-current activity")
             } else {
                 retainedTaskIds.insert(activityId)
+                observeUpdateToken(for: activity)
                 scheduleAutomaticEnd(
                     for: activityId,
                     snapshot: activity.content.state.snapshot,
@@ -137,6 +161,7 @@ final class LiveActivityCoordinator {
             }
         }
         cancelAutomaticEndTasks(except: retainedTaskIds)
+        cancelUpdateTokenTasks(except: retainedTaskIds)
     }
 
     private func scheduleAutomaticEnd(
@@ -180,12 +205,68 @@ final class LiveActivityCoordinator {
         await activity.end(nil, dismissalPolicy: .immediate)
         automaticEndTasks[activityId]?.cancel()
         automaticEndTasks[activityId] = nil
+        activityUpdateTokenTasks[activityId]?.cancel()
+        activityUpdateTokenTasks[activityId] = nil
     }
 
     private func cancelAutomaticEndTasks(except retainedIds: Set<String> = []) {
         for activityId in Array(automaticEndTasks.keys) where !retainedIds.contains(activityId) {
             automaticEndTasks[activityId]?.cancel()
             automaticEndTasks[activityId] = nil
+        }
+    }
+
+    private func observeUpdateToken(for activity: Activity<TigerDuckActivityAttributes>) {
+        let activityId = activity.attributes.activityId
+        Task { @MainActor [weak self] in
+            await self?.registerCurrentUpdateToken(for: activity)
+        }
+
+        guard activityUpdateTokenTasks[activityId] == nil else { return }
+        activityUpdateTokenTasks[activityId] = Task { @MainActor [weak self] in
+            await self?.registerCurrentUpdateToken(for: activity)
+            for await tokenData in activity.pushTokenUpdates {
+                guard !Task.isCancelled else { return }
+                await self?.registerUpdateToken(
+                    activityId: activityId,
+                    tokenData: tokenData,
+                    snapshot: activity.content.state.snapshot
+                )
+            }
+        }
+    }
+
+    private func registerCurrentUpdateToken(
+        for activity: Activity<TigerDuckActivityAttributes>
+    ) async {
+        guard let tokenData = activity.pushToken else { return }
+        await registerUpdateToken(
+            activityId: activity.attributes.activityId,
+            tokenData: tokenData,
+            snapshot: activity.content.state.snapshot
+        )
+    }
+
+    private func registerUpdateToken(
+        activityId: String,
+        tokenData: Data,
+        snapshot: LiveActivitySnapshot
+    ) async {
+        guard let updateTokenRegistrationHandler else { return }
+        let tokenHex = tokenData.map { String(format: "%02x", $0) }.joined()
+        await updateTokenRegistrationHandler(
+            LiveActivityUpdateTokenRegistration(
+                activityId: activityId,
+                updateTokenHex: tokenHex,
+                snapshot: snapshot
+            )
+        )
+    }
+
+    private func cancelUpdateTokenTasks(except retainedIds: Set<String> = []) {
+        for activityId in Array(activityUpdateTokenTasks.keys) where !retainedIds.contains(activityId) {
+            activityUpdateTokenTasks[activityId]?.cancel()
+            activityUpdateTokenTasks[activityId] = nil
         }
     }
 }

--- a/swift/TigerDuck/Services/API/Moodle/MoodleSiteInfoService.swift
+++ b/swift/TigerDuck/Services/API/Moodle/MoodleSiteInfoService.swift
@@ -37,7 +37,12 @@ actor MoodleSiteInfoService {
         let tokenService = MoodleTokenService.shared
 
         func requestSiteInfo(using token: String) async throws -> [String: Any] {
-            var components = await URLComponents(url: MoodleWebserviceClient.siteBaseURL, resolvingAgainstBaseURL: false)!
+            guard var components = URLComponents(
+                url: MoodleWebserviceClient.siteBaseURL,
+                resolvingAgainstBaseURL: false
+            ) else {
+                throw MoodleWebserviceError.malformedResponse(detail: "invalid site_info URL base")
+            }
             components.path = "/webservice/rest/server.php"
             components.queryItems = [
                 URLQueryItem(name: "moodlewsrestformat", value: "json"),

--- a/swift/TigerDuck/Services/API/Moodle/MoodleSiteInfoService.swift
+++ b/swift/TigerDuck/Services/API/Moodle/MoodleSiteInfoService.swift
@@ -37,7 +37,7 @@ actor MoodleSiteInfoService {
         let tokenService = MoodleTokenService.shared
 
         func requestSiteInfo(using token: String) async throws -> [String: Any] {
-            var components = URLComponents(url: MoodleWebserviceClient.siteBaseURL, resolvingAgainstBaseURL: false)!
+            var components = await URLComponents(url: MoodleWebserviceClient.siteBaseURL, resolvingAgainstBaseURL: false)!
             components.path = "/webservice/rest/server.php"
             components.queryItems = [
                 URLQueryItem(name: "moodlewsrestformat", value: "json"),

--- a/swift/TigerDuck/Services/Push/PushAPIClient.swift
+++ b/swift/TigerDuck/Services/Push/PushAPIClient.swift
@@ -40,6 +40,16 @@ final class PushAPIClient: Sendable {
         try await post(path: "/schedule/sync", body: request, returning: PushAPI.ScheduleSyncResponse.self)
     }
 
+    func registerLiveActivityToken(
+        _ request: PushAPI.LiveActivityTokenRegisterRequest
+    ) async throws -> PushAPI.LiveActivityTokenRegisterResponse {
+        try await post(
+            path: "/live-activities/register",
+            body: request,
+            returning: PushAPI.LiveActivityTokenRegisterResponse.self
+        )
+    }
+
     func cancelSchedule(deviceId: String, sourceId: String) async throws {
         let safeDevice = Self.percentEncoded(deviceId)
         let safeSource = Self.percentEncoded(sourceId)

--- a/swift/TigerDuck/Services/Push/PushAPIDTO.swift
+++ b/swift/TigerDuck/Services/Push/PushAPIDTO.swift
@@ -88,4 +88,36 @@ enum PushAPI {
             case totalPending = "total_pending"
         }
     }
+
+    struct LiveActivityTokenRegisterRequest: Codable, Sendable {
+        let deviceId: String
+        let activityId: String
+        let sourceId: String
+        let scenario: LiveActivityScenarioKind
+        let updateTokenHex: String
+        let countdownTarget: Date?
+        let snapshot: LiveActivitySnapshot
+
+        enum CodingKeys: String, CodingKey {
+            case deviceId = "device_id"
+            case activityId = "activity_id"
+            case sourceId = "source_id"
+            case scenario
+            case updateTokenHex = "update_token_hex"
+            case countdownTarget = "countdown_target"
+            case snapshot
+        }
+    }
+
+    struct LiveActivityTokenRegisterResponse: Codable, Sendable {
+        let deviceId: String
+        let activityId: String
+        let registeredAt: Date
+
+        enum CodingKeys: String, CodingKey {
+            case deviceId = "device_id"
+            case activityId = "activity_id"
+            case registeredAt = "registered_at"
+        }
+    }
 }

--- a/swift/TigerDuck/Services/Push/PushCoordinator.swift
+++ b/swift/TigerDuck/Services/Push/PushCoordinator.swift
@@ -125,6 +125,13 @@ final class PushCoordinator {
         await registration.unregister()
     }
 
+    func registerLiveActivityUpdateToken(
+        _ registrationPayload: LiveActivityUpdateTokenRegistration
+    ) async {
+        guard Defaults[.pushServerEnabled] else { return }
+        await registration.registerLiveActivityUpdateToken(registrationPayload)
+    }
+
     // MARK: - Sync driver
 
     /// Schedules a debounced sync. Multiple rapid callers coalesce into one

--- a/swift/TigerDuck/Services/Push/PushRegistrationService.swift
+++ b/swift/TigerDuck/Services/Push/PushRegistrationService.swift
@@ -42,6 +42,7 @@ actor PushRegistrationService {
     private var lastAttempt: Task<Void, Never>?
     private var lastError: String?
     private var lastRegisteredAt: Date?
+    private var pendingActivityRegistrations: [String: LiveActivityUpdateTokenRegistration] = [:]
 
     init(
         identity: PushIdentity,
@@ -74,6 +75,17 @@ actor PushRegistrationService {
         await registerIfReady()
     }
 
+    func registerLiveActivityUpdateToken(
+        _ registration: LiveActivityUpdateTokenRegistration
+    ) async {
+        pendingActivityRegistrations[registration.activityId] = registration
+        guard ptsTokenHex != nil else {
+            await registerIfReady()
+            return
+        }
+        await performActivityRegistration(registration, logger: logger)
+    }
+
     func registrationFailed(_ error: Error) {
         lastError = "APNs register failed: \(error.localizedDescription)"
         logger.error("APNs registration failed: \(error.localizedDescription, privacy: .public)")
@@ -101,6 +113,7 @@ actor PushRegistrationService {
         }
         deviceTokenHex = nil
         ptsTokenHex = nil
+        pendingActivityRegistrations.removeAll()
     }
 
     // MARK: - Internals
@@ -149,6 +162,7 @@ actor PushRegistrationService {
             let response = try await apiClient.registerDevice(request)
             logger.info("registered device=\(response.deviceId, privacy: .public) user=\(response.userId, privacy: .public)")
             noteSuccessfulRegistration()
+            await flushPendingActivityRegistrations(logger: logger)
         } catch is CancellationError {
             // Expected side-effect of debounce preempting an in-flight
             // request. Swallow silently so the logs stay clean.
@@ -170,5 +184,43 @@ actor PushRegistrationService {
 
     private func noteRegistrationError(_ error: Error) {
         lastError = "register: \(error.localizedDescription)"
+    }
+
+    private func flushPendingActivityRegistrations(logger: Logger) async {
+        for registration in Array(pendingActivityRegistrations.values) {
+            await performActivityRegistration(registration, logger: logger)
+        }
+    }
+
+    private func performActivityRegistration(
+        _ registration: LiveActivityUpdateTokenRegistration,
+        logger: Logger
+    ) async {
+        let snapshot = registration.snapshot
+        let request = PushAPI.LiveActivityTokenRegisterRequest(
+            deviceId: identity.deviceId,
+            activityId: registration.activityId,
+            sourceId: snapshot.sourceId,
+            scenario: snapshot.scenario,
+            updateTokenHex: registration.updateTokenHex,
+            countdownTarget: snapshot.countdownTarget,
+            snapshot: snapshot
+        )
+        do {
+            let response = try await apiClient.registerLiveActivityToken(request)
+            logger.info(
+                "registered live activity token id=\(response.activityId, privacy: .public)"
+            )
+            if pendingActivityRegistrations[registration.activityId]?.updateTokenHex == registration.updateTokenHex {
+                pendingActivityRegistrations[registration.activityId] = nil
+            }
+        } catch let error as PushAPIError {
+            if case .httpStatus(404, _) = error {
+                await registerIfReady()
+            }
+            logger.error("live activity token register failed: \(error.localizedDescription, privacy: .public)")
+        } catch {
+            logger.error("live activity token register failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 }

--- a/swift/TigerDuck/Services/Push/PushRegistrationService.swift
+++ b/swift/TigerDuck/Services/Push/PushRegistrationService.swift
@@ -43,6 +43,18 @@ actor PushRegistrationService {
     private var lastError: String?
     private var lastRegisteredAt: Date?
     private var pendingActivityRegistrations: [String: LiveActivityUpdateTokenRegistration] = [:]
+    // Retry scheduling for activity-token registration. A transient network
+    // or 5xx failure against `/live-activities/register` would otherwise drop
+    // the update-token on the floor — the server would never learn it, and
+    // the end-push path would be permanently broken for that Live Activity.
+    private var activityRegistrationRetryTasks: [String: Task<Void, Never>] = [:]
+    private var activityRegistrationAttempts: [String: Int] = [:]
+    // Exponential backoff: 30s, 90s, 270s. Caps the total wait at ~7 minutes,
+    // long enough to ride out a server deploy or brief offline period without
+    // holding memory for a dead registration indefinitely.
+    private let maxActivityRegistrationAttempts = 4
+    private let activityRegistrationBaseDelaySeconds: Double = 30
+    private let activityRegistrationMaxDelaySeconds: Double = 600
 
     init(
         identity: PushIdentity,
@@ -114,6 +126,11 @@ actor PushRegistrationService {
         deviceTokenHex = nil
         ptsTokenHex = nil
         pendingActivityRegistrations.removeAll()
+        for task in activityRegistrationRetryTasks.values {
+            task.cancel()
+        }
+        activityRegistrationRetryTasks.removeAll()
+        activityRegistrationAttempts.removeAll()
     }
 
     // MARK: - Internals
@@ -214,13 +231,71 @@ actor PushRegistrationService {
             if pendingActivityRegistrations[registration.activityId]?.updateTokenHex == registration.updateTokenHex {
                 pendingActivityRegistrations[registration.activityId] = nil
             }
+            activityRegistrationRetryTasks[registration.activityId]?.cancel()
+            activityRegistrationRetryTasks[registration.activityId] = nil
+            activityRegistrationAttempts[registration.activityId] = nil
         } catch let error as PushAPIError {
             if case .httpStatus(404, _) = error {
+                // Device row is missing server-side — re-register it; the
+                // success path will flush `pendingActivityRegistrations`
+                // immediately, no standalone retry needed.
                 await registerIfReady()
+                logger.error("live activity token register failed (device missing): \(error.localizedDescription, privacy: .public)")
+                return
             }
             logger.error("live activity token register failed: \(error.localizedDescription, privacy: .public)")
+            scheduleActivityRegistrationRetry(registration, logger: logger)
         } catch {
             logger.error("live activity token register failed: \(error.localizedDescription, privacy: .public)")
+            scheduleActivityRegistrationRetry(registration, logger: logger)
         }
+    }
+
+    /// Queue an exponential-backoff retry. Attempts counter and any in-flight
+    /// retry task are keyed by activityId so a newer `registerLiveActivityUpdateToken`
+    /// call (e.g. Apple rotated the update-token) can supersede the retry.
+    private func scheduleActivityRegistrationRetry(
+        _ registration: LiveActivityUpdateTokenRegistration,
+        logger: Logger
+    ) {
+        let activityId = registration.activityId
+        let attempt = (activityRegistrationAttempts[activityId] ?? 0) + 1
+        activityRegistrationAttempts[activityId] = attempt
+        guard attempt < maxActivityRegistrationAttempts else {
+            logger.error(
+                "giving up on live activity token register attempts=\(attempt, privacy: .public) id=\(activityId, privacy: .public)"
+            )
+            pendingActivityRegistrations[activityId] = nil
+            activityRegistrationRetryTasks[activityId]?.cancel()
+            activityRegistrationRetryTasks[activityId] = nil
+            activityRegistrationAttempts[activityId] = nil
+            return
+        }
+        let delay = min(
+            activityRegistrationBaseDelaySeconds * pow(3.0, Double(attempt - 1)),
+            activityRegistrationMaxDelaySeconds
+        )
+        activityRegistrationRetryTasks[activityId]?.cancel()
+        activityRegistrationRetryTasks[activityId] = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            if Task.isCancelled { return }
+            await self?.retryActivityRegistration(registration)
+        }
+    }
+
+    private func retryActivityRegistration(
+        _ registration: LiveActivityUpdateTokenRegistration
+    ) async {
+        // If a newer registration replaced this activity's pending entry
+        // (Apple rotates update-tokens, or the client pushed a fresh
+        // snapshot) the newer call's own success/retry cycle owns the
+        // lifecycle from here — drop this retry.
+        guard
+            pendingActivityRegistrations[registration.activityId]?.updateTokenHex
+                == registration.updateTokenHex
+        else {
+            return
+        }
+        await performActivityRegistration(registration, logger: logger)
     }
 }


### PR DESCRIPTION
This pull request introduces server-side support for managing and ending iOS Live Activities, including database schema changes, new API endpoints, and integration with the scheduling and dispatch system. The changes enable the server to register, track, and explicitly end Live Activities via APNs, and provide new statistics and cancellation flows.

**Live Activity Token Management:**

- Added a new `LiveActivityUpdateToken` model and corresponding database table to track per-activity update tokens, their status, and metadata. Includes migration and ORM relationships. [[1]](diffhunk://#diff-22a5dad912d2ae0de55b965578e22675b9917616bc1e132d47c2d2782615e9eeR1-R51) [[2]](diffhunk://#diff-85fb1b7ec49b242f2992a771c89b53f457fc971d3b29c3c97f1dffb08abae266R124-R167) [[3]](diffhunk://#diff-85fb1b7ec49b242f2992a771c89b53f457fc971d3b29c3c97f1dffb08abae266R84-R86)
- Introduced `LiveActivityTokenStatus` enum to represent the lifecycle states of Live Activities (active, ended, failed, cancelled).

**API and Routing Enhancements:**

- Implemented `/live-activities/register` endpoint for upserting (registering/updating) Live Activity tokens, with input validation and logging.
- Registered the new router in the FastAPI application. [[1]](diffhunk://#diff-d24f0fbde933a2c5b00caeefeab225d556897d8c0a69f8cca88e8565c8f66514R25) [[2]](diffhunk://#diff-d24f0fbde933a2c5b00caeefeab225d556897d8c0a69f8cca88e8565c8f66514R137)

**Scheduler and Dispatch Integration:**

- Updated the scheduler dispatcher to detect due Live Activities (based on `countdown_target`), build and send explicit "end" APNs payloads, and update their status accordingly. Handles error and retry logic. [[1]](diffhunk://#diff-22525b98cc73a2a1556b295e2d396f75ebf8bb3498cfe9d56d78b801825515f5L27-R40) [[2]](diffhunk://#diff-22525b98cc73a2a1556b295e2d396f75ebf8bb3498cfe9d56d78b801825515f5R144-R206)
- Modified the schedule cancellation flow to immediately queue any active Live Activity token for ending when a source is cancelled. [[1]](diffhunk://#diff-cb2b2b08368f472f0ad6be8aaa4b5766c5e6d2e481c26084c8aaaf54d3179ed2L7-R18) [[2]](diffhunk://#diff-cb2b2b08368f472f0ad6be8aaa4b5766c5e6d2e481c26084c8aaaf54d3179ed2L148-R156) [[3]](diffhunk://#diff-cb2b2b08368f472f0ad6be8aaa4b5766c5e6d2e481c26084c8aaaf54d3179ed2R167-R177)

**Payload Construction:**

- Added `build_end_payload` and `build_live_activity_end_request` helpers to construct the correct APNs payload and request for ending a Live Activity. [[1]](diffhunk://#diff-abde413618b0bb5673c427d59151b3e08d73e96aa30a372987af641c0550474bR185-R204) [[2]](diffhunk://#diff-abde413618b0bb5673c427d59151b3e08d73e96aa30a372987af641c0550474bR293-R312)

**Debug and Configuration:**

- Updated debug statistics endpoint to include Live Activity counts by status. [[1]](diffhunk://#diff-db438ea3ec25230e06a7aa3fcd908a2236b2e34c92df16658cdc1c02077d0632L17-R22) [[2]](diffhunk://#diff-db438ea3ec25230e06a7aa3fcd908a2236b2e34c92df16658cdc1c02077d0632L44-R61)
- Introduced configuration options for Live Activity token retention and pruning.