### PR TITLE
Implement FCM delivery for Android and update API base path

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,6 +52,11 @@ TIGERDUCK_APNS_KEY_PATH=server/secrets/AuthKey_CHANGE_ME.p8
 # RecordingFcmSender and Android pushes are silently no-ops.
 TIGERDUCK_FCM_PROJECT_ID=CHANGE_ME_FIREBASE_PROJECT_ID
 TIGERDUCK_FCM_CREDENTIALS_PATH=server/secrets/fcm_service_account.json
+# Per-batch send timeout. firebase-admin's `send_each_for_multicast` opens
+# parallel TLS handshakes per token and the first cold batch also pays for
+# OAuth-token mint, so the default 15s can blow up on the first dispatch
+# tick after server start. 30s leaves headroom; warm batches finish in <1s.
+TIGERDUCK_FCM_SEND_TIMEOUT_SECONDS=30
 
 # --- Bulletin pipeline ----------------------------------------------------
 # Optional PEM bundle containing NTUST's root + intermediates. When present

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -46,6 +46,13 @@ TIGERDUCK_APNS_ENV=development
 # Path is relative to the process CWD (the container WORKDIR = /app).
 TIGERDUCK_APNS_KEY_PATH=server/secrets/AuthKey_CHANGE_ME.p8
 
+# --- FCM (Android push) --------------------------------------------------
+# Drop the Firebase service-account JSON at the path below. When project_id
+# or credentials_path is missing, fcm_client.build_sender() returns
+# RecordingFcmSender and Android pushes are silently no-ops.
+TIGERDUCK_FCM_PROJECT_ID=CHANGE_ME_FIREBASE_PROJECT_ID
+TIGERDUCK_FCM_CREDENTIALS_PATH=server/secrets/fcm_service_account.json
+
 # --- Bulletin pipeline ----------------------------------------------------
 # Optional PEM bundle containing NTUST's root + intermediates. When present
 # and readable, the scraper/backfill client validates TLS against it; when
@@ -58,7 +65,13 @@ TIGERDUCK_APNS_KEY_PATH=server/secrets/AuthKey_CHANGE_ME.p8
 
 # --- API auth ------------------------------------------------------------
 # Shared secret checked on every write endpoint via the X-Push-Token header.
-# Empty = auth disabled (NEVER in production). iOS reads the same value
-# from Info.plist key TigerDuckAPIToken (see swift/TigerDuck/Secrets.xcconfig).
+# Both iOS and Android clients send this same value — the backend has one
+# secret, not per-platform. Empty = auth disabled (NEVER in production).
+#   iOS:     Info.plist key TigerDuckAPIToken (swift/TigerDuck/Secrets.xcconfig).
+#   Android: local.properties (mirror this exact value).
 # Generate: python -c "import secrets; print(secrets.token_urlsafe(32))"
 TIGERDUCK_API_SHARED_SECRET=CHANGE_ME_GENERATE_WITH_SECRETS_TOKEN_URLSAFE_32
+
+# --- Bulletin dispatch ---------------------------------------------------
+# Default 60s is set in server/config.py. Lower it for live testing.
+# TIGERDUCK_BULLETIN_DISPATCH_INTERVAL_SECONDS=60

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,12 @@
 #   publish the postgres port in docker-compose.yml.
 # =============================================================================
 
+# --- Compose-only (interpolated at `docker compose up` time) -----------------
+# Referenced by docker-compose.yml as ${POSTGRES_PASSWORD}. Must match the
+# password portion of TIGERDUCK_DATABASE_URL below.
+# Generate: python -c "import secrets; print(secrets.token_urlsafe(32))"
+POSTGRES_PASSWORD=CHANGE_ME_GENERATE_WITH_SECRETS_TOKEN_URLSAFE_32
+
 # --- Environment ----------------------------------------------------------
 TIGERDUCK_ENV=production
 TIGERDUCK_LOG_LEVEL=INFO

--- a/backend/MIGRATE.md
+++ b/backend/MIGRATE.md
@@ -1,0 +1,221 @@
+# MIGRATE.md
+
+How to upgrade the backend to a new version without losing data.
+
+Schema changes are managed by Alembic (`server/migrations/versions/`). Every
+migration is forward-only and idempotent against `alembic_version` — running
+`alembic upgrade head` against a database that is already current is a no-op.
+
+`start.sh` runs `alembic upgrade head` before launching uvicorn, so the
+common case is just: pull, rebuild, restart.
+
+---
+
+## TL;DR
+
+```bash
+# Same host, same DB volume — the normal upgrade.
+cd backend
+git pull
+docker compose pull postgres            # only if Postgres image was bumped
+docker compose up -d --build backend    # start.sh runs `alembic upgrade head`
+docker compose logs -f backend          # confirm migrations applied cleanly
+```
+
+The named volume `tigerduck_pgdata` survives `up -d --build` and even
+`down` (without `-v`), so data is preserved.
+
+---
+
+## Before any upgrade: take a backup
+
+Even though migrations are reversible in principle, it is cheap insurance
+and the only thing that protects you from operator error.
+
+```bash
+# From the backend/ directory, while the postgres container is running:
+docker compose exec -T postgres \
+  pg_dump -U tigerduck -d tigerduck --format=custom --no-owner \
+  > "backup-$(date +%Y%m%d-%H%M%S).dump"
+```
+
+`--format=custom` is restorable with `pg_restore` and supports parallel
+restore. `--no-owner` makes the dump portable across roles.
+
+To restore that dump into an empty database:
+
+```bash
+docker compose exec -T postgres \
+  pg_restore -U tigerduck -d tigerduck --clean --if-exists --no-owner \
+  < backup-YYYYMMDD-HHMMSS.dump
+```
+
+---
+
+## Scenario A: in-place upgrade (same host, same DB)
+
+This is what `start.sh` automates. The volume `tigerduck_pgdata` keeps the
+data; Alembic walks the version chain from whatever `alembic_version` says
+up to `head`.
+
+```bash
+cd backend
+git pull
+docker compose up -d --build backend
+```
+
+If you want to apply migrations manually (e.g. to inspect SQL first):
+
+```bash
+# Dry-run: print the SQL that would run between current and head.
+docker compose exec backend alembic upgrade head --sql
+
+# Actually apply:
+docker compose exec backend alembic upgrade head
+
+# Inspect state:
+docker compose exec backend alembic current
+docker compose exec backend alembic history --verbose
+```
+
+---
+
+## Scenario B: move to a new host / new Postgres instance
+
+You have an old DB with real data and want the same data inside a freshly
+provisioned Postgres on another machine (or a new volume). **Do not**
+`cp -r` the Postgres data directory between different Postgres versions —
+use `pg_dump` / `pg_restore`.
+
+1. **Dump from the old host** (while it is still running):
+
+   ```bash
+   docker compose exec -T postgres \
+     pg_dump -U tigerduck -d tigerduck --format=custom --no-owner \
+     > tigerduck.dump
+   ```
+
+   The dump includes the `alembic_version` table, so the new database
+   will know exactly which migration it is on after restore.
+
+2. **Bring up the new stack with an empty DB**:
+
+   ```bash
+   # On the new host
+   git clone <repo> && cd <repo>/backend
+   cp .env.example .env   # fill in secrets, POSTGRES_PASSWORD, etc.
+   docker compose up -d postgres
+   docker compose exec postgres pg_isready -U tigerduck -d tigerduck
+   ```
+
+3. **Restore the dump** into the new (empty) `tigerduck` database:
+
+   ```bash
+   docker compose exec -T postgres \
+     pg_restore -U tigerduck -d tigerduck --no-owner \
+     < tigerduck.dump
+   ```
+
+4. **Start the backend**. `start.sh` runs `alembic upgrade head`. Because
+   the dump carried `alembic_version` forward, this either does nothing
+   (you were already at head) or applies any migrations newer than the
+   dump:
+
+   ```bash
+   docker compose up -d --build backend
+   docker compose logs -f backend
+   ```
+
+5. **Verify**:
+
+   ```bash
+   docker compose exec backend alembic current
+   docker compose exec postgres psql -U tigerduck -d tigerduck -c \
+     "select count(*) from device_registrations;"
+   ```
+
+---
+
+## Scenario C: imported a dump that has no `alembic_version`
+
+This happens if the dump came from a pre-Alembic snapshot or someone
+exported only the data tables. Tell Alembic where the schema currently
+stands without re-running migrations:
+
+```bash
+# Stamp to a specific revision that matches the schema you imported:
+docker compose exec backend alembic stamp <revision_id>
+
+# Or, if the imported schema is fully up to date:
+docker compose exec backend alembic stamp head
+```
+
+`stamp` only writes to `alembic_version` — it does not run any DDL.
+After stamping, `alembic upgrade head` will apply only the migrations
+newer than the stamped revision.
+
+---
+
+## Scenario D: rolling back a bad migration
+
+```bash
+# Roll back one revision:
+docker compose exec backend alembic downgrade -1
+
+# Roll back to a specific revision:
+docker compose exec backend alembic downgrade <revision_id>
+```
+
+Downgrade only works if the migration's `downgrade()` is implemented
+(check the file under `server/migrations/versions/`). For destructive
+migrations (column drops, type changes), restore from the `pg_dump` you
+took in the "Before any upgrade" step instead.
+
+---
+
+## API version compatibility (clients across an upgrade)
+
+The HTTP API mounts `/v1` as a deprecated alias of `/v2` (see
+`server/main.py`). Old iOS builds that still call `/v1/...` and omit the
+`platform` field continue to work — the schema defaults `platform` to
+`"apple"`. Responses on `/v1/*` carry `Deprecation: true` and a
+`Link: </v2/...>; rel="successor-version"` header so clients can detect
+the deprecation.
+
+To advertise a removal date set `TIGERDUCK_API_LEGACY_SUNSET` to an
+RFC 8594 HTTP-date string, e.g.:
+
+```
+TIGERDUCK_API_LEGACY_SUNSET="Wed, 01 Nov 2026 00:00:00 GMT"
+```
+
+To drop `/v1` entirely, set `TIGERDUCK_API_LEGACY_BASE_PATHS=[]` (or
+remove the entry) and restart.
+
+---
+
+## Things that do **not** require a migration
+
+- Bumping `api_base_path` (URL change only).
+- Adding a new env var in `config.py` with a default value.
+- Code-only changes to dispatcher / scheduler / push routers.
+
+If `alembic upgrade head` reports "no new upgrade operations", you are
+already current — no action needed.
+
+---
+
+## Useful commands
+
+```bash
+# Show current revision in the live DB:
+docker compose exec backend alembic current
+
+# Show full migration history:
+docker compose exec backend alembic history --verbose
+
+# Generate a new migration after editing models.py:
+docker compose exec backend alembic revision --autogenerate -m "describe change"
+# Then review the generated file under server/migrations/versions/ before
+# committing — autogenerate is a starting point, not the final answer.
+```

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "alembic>=1.14.0",
     "pydantic-settings>=2.6.0",
     "aioapns>=3.4",
+    "firebase-admin>=6.5.0",
     "apscheduler>=3.10.4",
     "pyjwt[crypto]>=2.10.0",
     "structlog>=24.4.0",

--- a/backend/scripts/seed_test_bulletins.py
+++ b/backend/scripts/seed_test_bulletins.py
@@ -1,0 +1,177 @@
+"""Seed fake, already-classified bulletins for Android push smoke testing.
+
+Inserts one bulletin per CanonicalOrg (16 rows), cycling ContentTags (so every
+tag appears at least once across the batch) and Importance levels (low /
+normal / high each appear). Rows go in with processing_state='processed' and
+notified_at IS NULL, so the next dispatcher tick will fan them out to every
+matching device. No LLM call is made.
+
+Usage:
+    cd backend
+    uv run python scripts/seed_test_bulletins.py
+    uv run python scripts/seed_test_bulletins.py --multi-tag   # also adds a row with several tags
+    uv run python scripts/seed_test_bulletins.py --clear       # delete prior seeded rows first
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import delete
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+from server.bulletins.models import (  # noqa: E402
+    Bulletin,
+    BulletinProcessingState,
+)
+from server.bulletins.taxonomy import (  # noqa: E402
+    CanonicalOrg,
+    ContentTag,
+    Importance,
+    ORG_LABELS,
+    TAG_LABELS,
+)
+from server.config import Settings  # noqa: E402
+from server.db import build_engine, build_session_factory  # noqa: E402
+
+SOURCE = "test_seed"
+EXTERNAL_ID_PREFIX = "seed-"
+
+
+def _build_rows(now: datetime, multi_tag: bool) -> list[dict]:
+    orgs = list(CanonicalOrg)
+    tags = list(ContentTag)
+    importances = [Importance.low, Importance.normal, Importance.high]
+
+    rows: list[dict] = []
+    for i, org in enumerate(orgs):
+        tag = tags[i % len(tags)]
+        importance = importances[i % len(importances)]
+        org_label = ORG_LABELS[org]
+        tag_label = TAG_LABELS[tag]
+        title = f"[測試] {org_label}・{tag_label}・{importance.value}"
+        summary = (
+            f"測試公告：org={org.value} tag={tag.value} "
+            f"importance={importance.value}（自動產生，僅供推播煙霧測試）"
+        )
+        rows.append(
+            {
+                "source": SOURCE,
+                "external_id": f"{EXTERNAL_ID_PREFIX}{i:02d}-{org.value}",
+                "source_url": f"https://example.invalid/seed/{i:02d}",
+                "raw_publisher": org_label,
+                "canonical_org": org.value,
+                "content_tags": [tag.value],
+                "summary": summary,
+                "body_clean": summary,
+                "body_md": summary,
+                "importance": importance.value,
+                "title": title,
+                "title_clean": title,
+                "posted_at": now,
+                "first_seen_at": now,
+                "last_seen_at": now,
+                "processing_state": BulletinProcessingState.processed.value,
+                "processing_attempts": 0,
+                "is_deleted": False,
+                "notified_at": None,
+            }
+        )
+
+    # Confirm every tag appeared. With 16 orgs vs 13 tags this is guaranteed,
+    # but assert so a future taxonomy edit can't silently drop coverage.
+    seen_tags = {row["content_tags"][0] for row in rows}
+    missing = {t.value for t in ContentTag} - seen_tags
+    assert not missing, f"tags missing from seed: {missing}"
+
+    if multi_tag:
+        all_tags = [t.value for t in ContentTag]
+        rows.append(
+            {
+                "source": SOURCE,
+                "external_id": f"{EXTERNAL_ID_PREFIX}99-multitag",
+                "source_url": "https://example.invalid/seed/99",
+                "raw_publisher": ORG_LABELS[CanonicalOrg.other],
+                "canonical_org": CanonicalOrg.other.value,
+                "content_tags": all_tags,
+                "summary": "測試公告：所有 tag 同時掛上，驗證多標籤渲染。",
+                "body_clean": "測試公告：所有 tag 同時掛上。",
+                "body_md": "測試公告：所有 tag 同時掛上。",
+                "importance": Importance.high.value,
+                "title": "[測試] 多標籤公告",
+                "title_clean": "[測試] 多標籤公告",
+                "posted_at": now,
+                "first_seen_at": now,
+                "last_seen_at": now,
+                "processing_state": BulletinProcessingState.processed.value,
+                "processing_attempts": 0,
+                "is_deleted": False,
+                "notified_at": None,
+            }
+        )
+    return rows
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    settings = Settings()
+    engine = build_engine(settings)
+    session_factory = build_session_factory(engine)
+    now = datetime.now(timezone.utc)
+
+    try:
+        if args.clear:
+            async with session_factory() as session:
+                result = await session.execute(
+                    delete(Bulletin).where(Bulletin.source == SOURCE)
+                )
+                await session.commit()
+            print(f"[clear] deleted {result.rowcount or 0} prior seeded rows")
+
+        rows = _build_rows(now, multi_tag=args.multi_tag)
+        async with session_factory() as session:
+            session.add_all(Bulletin(**r) for r in rows)
+            await session.commit()
+        print(f"[seed] inserted {len(rows)} bulletins (source={SOURCE!r})")
+        print(
+            "[seed] dispatcher will fan these out on its next tick "
+            f"({settings.bulletin_dispatch_interval_seconds}s). "
+            "Make sure a device is registered with matching subscriptions "
+            "(empty orgs+tags = wildcard)."
+        )
+    finally:
+        await engine.dispose()
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--clear",
+        action="store_true",
+        help=f"delete prior rows where source='{SOURCE}' before inserting",
+    )
+    p.add_argument(
+        "--multi-tag",
+        action="store_true",
+        help="also insert one extra bulletin carrying every tag at once",
+    )
+    return p
+
+
+def main() -> int:
+    args = build_arg_parser().parse_args()
+    try:
+        return asyncio.run(main_async(args))
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/server/__init__.py
+++ b/backend/server/__init__.py
@@ -1,7 +1,7 @@
 """TigerDuck push notification server.
 
 Runs on the Mac mini behind nginx-proxy-manager + Cloudflare, serves the iOS app
-at https://api.tigerduck.app/v1/. Separate from backend/api/ which is POC-only.
+at https://api.tigerduck.app/v2/. Separate from backend/api/ which is POC-only.
 """
 
 from server import config

--- a/backend/server/bulletins/dispatcher.py
+++ b/backend/server/bulletins/dispatcher.py
@@ -26,9 +26,15 @@ from server.bulletins.models import (
     BulletinProcessingState,
 )
 from server.config import Settings
-from server.models import DeviceRegistration
-from server.push.apns_client import PushSender, SendResult
-from server.push.payload import build_alert_request
+from server.models import DevicePlatform, DeviceRegistration
+from server.push.apns_client import SendResult
+from server.push.payload import (
+    ApnsRequest,
+    FcmRequest,
+    build_alert_request,
+    build_fcm_alert_request,
+)
+from server.push.router import PushRouter
 
 logger = structlog.get_logger(__name__)
 
@@ -46,7 +52,7 @@ class DispatchOutcome:
 
 async def dispatch_pending_bulletins(
     session_factory: async_sessionmaker[AsyncSession],
-    sender: PushSender,
+    router: PushRouter,
     settings: Settings,
     *,
     now: datetime | None = None,
@@ -77,7 +83,7 @@ async def dispatch_pending_bulletins(
 
     for bulletin in bulletins:
         sent, failed, cancelled, matched = await _dispatch_one(
-            session_factory, sender, settings, bulletin.id, ts
+            session_factory, router, settings, bulletin.id, ts
         )
         totals[0] += sent
         totals[1] += failed
@@ -99,7 +105,7 @@ async def dispatch_pending_bulletins(
 
 async def _dispatch_one(
     session_factory: async_sessionmaker[AsyncSession],
-    sender: PushSender,
+    router: PushRouter,
     settings: Settings,
     bulletin_id: int,
     ts: datetime,
@@ -158,34 +164,52 @@ async def _dispatch_one(
         ).all()
 
         for dispatch, device, bulletin in pending_rows:
-            if not device.device_token_hex:
-                await session.execute(
-                    update(BulletinDispatch)
-                    .where(BulletinDispatch.id == dispatch.id)
-                    .values(
-                        status=BulletinDispatchStatus.cancelled.value,
-                        last_error="device has no standard APNs token",
-                    )
-                )
-                cancelled_count += 1
-                continue
-
             # Bulletins arrive here in `processed` state, so `title_clean`
             # has already been normalized by the LLM (prefix stripped,
             # de-shouted). Fall back to the raw title when classification
             # left it NULL — mirrors iOS `BulletinAPIDTO.displayTitle`.
-            request = build_alert_request(
-                device_token=device.device_token_hex,
-                bundle_id=device.bundle_id,
-                title=bulletin.title_clean or bulletin.title,
-                body=bulletin.summary or bulletin.title_clean or bulletin.title,
-                bulletin_id=bulletin.id,
-                source_url=bulletin.source_url,
-                canonical_org=bulletin.canonical_org or "",
-                now=ts,
-            )
-            result = await _send_safely(sender, request)
-            classification = _classify(result)
+            title = bulletin.title_clean or bulletin.title
+            body = bulletin.summary or bulletin.title_clean or bulletin.title
+
+            if device.platform == DevicePlatform.android.value:
+                # Android stores the FCM registration token in
+                # `pts_token_hex` (the column is platform-overloaded so we
+                # don't need a schema change for the second channel).
+                if not device.pts_token_hex:
+                    await _cancel_dispatch(
+                        session, dispatch.id, "android device has no FCM token"
+                    )
+                    cancelled_count += 1
+                    continue
+                fcm_req = build_fcm_alert_request(
+                    fcm_token=device.pts_token_hex,
+                    title=title,
+                    body=body,
+                    bulletin_id=bulletin.id,
+                    source_url=bulletin.source_url,
+                    canonical_org=bulletin.canonical_org or "",
+                )
+                result = await _send_android_safely(router, fcm_req)
+            else:
+                if not device.device_token_hex:
+                    await _cancel_dispatch(
+                        session, dispatch.id, "device has no standard APNs token"
+                    )
+                    cancelled_count += 1
+                    continue
+                apns_req = build_alert_request(
+                    device_token=device.device_token_hex,
+                    bundle_id=device.bundle_id,
+                    title=title,
+                    body=body,
+                    bulletin_id=bulletin.id,
+                    source_url=bulletin.source_url,
+                    canonical_org=bulletin.canonical_org or "",
+                    now=ts,
+                )
+                result = await _send_apple_safely(router, apns_req)
+
+            classification = _classify(result, platform=device.platform)
 
             if classification == "sent":
                 await session.execute(
@@ -259,20 +283,49 @@ async def _dispatch_one(
     return (sent_count, failed_count, cancelled_count, len(pending_rows))
 
 
-async def _send_safely(sender: PushSender, request) -> SendResult:
+async def _cancel_dispatch(
+    session: AsyncSession, dispatch_id: int, reason: str
+) -> None:
+    await session.execute(
+        update(BulletinDispatch)
+        .where(BulletinDispatch.id == dispatch_id)
+        .values(
+            status=BulletinDispatchStatus.cancelled.value,
+            last_error=reason,
+        )
+    )
+
+
+async def _send_apple_safely(router: PushRouter, request: ApnsRequest) -> SendResult:
     try:
-        return await sender.send(request)
+        return await router.send_apple(request)
     except Exception as exc:  # aioapns raises on network errors
         return SendResult(success=False, status="exception", description=str(exc))
 
 
-def _classify(result: SendResult) -> str:
+async def _send_android_safely(router: PushRouter, request: FcmRequest) -> SendResult:
+    try:
+        return await router.send_android(request)
+    except Exception as exc:  # firebase-admin raises on network errors
+        return SendResult(success=False, status="exception", description=str(exc))
+
+
+def _classify(result: SendResult, *, platform: str) -> str:
     """Shared classifier with scheduler/dispatcher but local copy so changes
     to one push path don't accidentally mutate the other."""
     if result.success:
         return "sent"
     status = str(result.status).lower()
     desc = (result.description or "").lower()
+
+    if platform == DevicePlatform.android.value:
+        # firebase-admin maps these to dedicated exception types we surface
+        # via SendResult.status in `FcmSender.send`.
+        android_bad_token = ("unregistered", "sender_id_mismatch", "invalid_argument")
+        if any(m in status or m in desc for m in android_bad_token):
+            return "bad_token"
+        return "transient"
+
     bad_token_markers = (
         "410",
         "baddevicetoken",

--- a/backend/server/bulletins/dispatcher.py
+++ b/backend/server/bulletins/dispatcher.py
@@ -322,7 +322,7 @@ def _classify(result: SendResult, *, platform: str) -> str:
         # firebase-admin maps these to dedicated exception types we surface
         # via SendResult.status in `FcmSender.send`.
         android_bad_token = ("unregistered", "sender_id_mismatch", "invalid_argument")
-        if any(m in status or m in desc for m in android_bad_token):
+        if any(m in status for m in android_bad_token):
             return "bad_token"
         return "transient"
 

--- a/backend/server/bulletins/dispatcher.py
+++ b/backend/server/bulletins/dispatcher.py
@@ -163,6 +163,44 @@ async def _dispatch_one(
             )
         ).all()
 
+        # Pre-pass: collapse all Android sends for this bulletin into one
+        # batched FCM call. Apple stays on its original per-row code path
+        # (no equivalent multicast helper on APNs and per-row payloads
+        # diverge by `attrs_type` etc.). Android sends share
+        # title/body/data within a bulletin and only differ by token, so
+        # we can collapse N TLS handshakes into ceil(N/500).
+        android_requests: list[FcmRequest] = []
+        android_dispatch_ids: list[int] = []
+        for dispatch, device, bulletin in pending_rows:
+            if device.platform != DevicePlatform.android.value:
+                continue
+            if not device.pts_token_hex:
+                continue  # handled in the main loop below
+            title = bulletin.title_clean or bulletin.title
+            body = bulletin.summary or bulletin.title_clean or bulletin.title
+            android_requests.append(
+                build_fcm_alert_request(
+                    fcm_token=device.pts_token_hex,
+                    title=title,
+                    body=body,
+                    bulletin_id=bulletin.id,
+                    source_url=bulletin.source_url,
+                    canonical_org=bulletin.canonical_org or "",
+                )
+            )
+            android_dispatch_ids.append(dispatch.id)
+
+        try:
+            android_results = await router.send_android_multi(android_requests)
+        except Exception as exc:  # firebase-admin can still raise on init/auth
+            android_results = [
+                SendResult(success=False, status="exception", description=str(exc))
+                for _ in android_requests
+            ]
+        android_results_by_dispatch: dict[int, SendResult] = dict(
+            zip(android_dispatch_ids, android_results)
+        )
+
         for dispatch, device, bulletin in pending_rows:
             # Bulletins arrive here in `processed` state, so `title_clean`
             # has already been normalized by the LLM (prefix stripped,
@@ -181,15 +219,8 @@ async def _dispatch_one(
                     )
                     cancelled_count += 1
                     continue
-                fcm_req = build_fcm_alert_request(
-                    fcm_token=device.pts_token_hex,
-                    title=title,
-                    body=body,
-                    bulletin_id=bulletin.id,
-                    source_url=bulletin.source_url,
-                    canonical_org=bulletin.canonical_org or "",
-                )
-                result = await _send_android_safely(router, fcm_req)
+                # Result was filled by the batched send above.
+                result = android_results_by_dispatch[dispatch.id]
             else:
                 if not device.device_token_hex:
                     await _cancel_dispatch(
@@ -300,13 +331,6 @@ async def _send_apple_safely(router: PushRouter, request: ApnsRequest) -> SendRe
     try:
         return await router.send_apple(request)
     except Exception as exc:  # aioapns raises on network errors
-        return SendResult(success=False, status="exception", description=str(exc))
-
-
-async def _send_android_safely(router: PushRouter, request: FcmRequest) -> SendResult:
-    try:
-        return await router.send_android(request)
-    except Exception as exc:  # firebase-admin raises on network errors
         return SendResult(success=False, status="exception", description=str(exc))
 
 

--- a/backend/server/bulletins/jobs.py
+++ b/backend/server/bulletins/jobs.py
@@ -31,7 +31,7 @@ from server.bulletins.llm.base import LLMError, LLMProvider
 from server.bulletins.models import Bulletin, BulletinProcessingState
 from server.bulletins.scraper import fetch_list
 from server.config import Settings
-from server.push.apns_client import PushSender
+from server.push.router import PushRouter
 
 logger = structlog.get_logger(__name__)
 
@@ -337,10 +337,10 @@ async def _mark_failed(
 
 async def dispatch_job(
     session_factory: async_sessionmaker[AsyncSession],
-    sender: PushSender,
+    router: PushRouter,
     settings: Settings,
 ) -> None:
-    await dispatch_pending_bulletins(session_factory, sender, settings)
+    await dispatch_pending_bulletins(session_factory, router, settings)
 
 
 async def retention_job(

--- a/backend/server/bulletins/matcher.py
+++ b/backend/server/bulletins/matcher.py
@@ -20,12 +20,12 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.bulletins.models import BulletinSubscription
 from server.bulletins.taxonomy import SubscriptionMode
-from server.models import DeviceRegistration
+from server.models import DeviceRegistration, DevicePlatform
 
 logger = structlog.get_logger(__name__)
 
@@ -96,7 +96,21 @@ async def match_device_ids(
         )
         .where(
             BulletinSubscription.enabled.is_(True),
-            DeviceRegistration.device_token_hex.isnot(None),
+            # Apple devices need an APNs standard token (`device_token_hex`);
+            # Android devices need an FCM registration token, which lives in
+            # `pts_token_hex`. Originally only the apple branch was checked,
+            # which silently excluded every Android device from matching.
+            or_(
+                and_(
+                    DeviceRegistration.platform == DevicePlatform.apple.value,
+                    DeviceRegistration.device_token_hex.isnot(None),
+                ),
+                and_(
+                    DeviceRegistration.platform == DevicePlatform.android.value,
+                    DeviceRegistration.pts_token_hex.isnot(None),
+                    DeviceRegistration.pts_token_hex != "",
+                ),
+            ),
         )
     )
     rows = (await session.execute(stmt)).all()

--- a/backend/server/bulletins/taxonomy.py
+++ b/backend/server/bulletins/taxonomy.py
@@ -9,7 +9,7 @@ Two orthogonal dimensions:
 A subscription rule is `(orgs: set[CanonicalOrg], tags: set[ContentTag], mode)`
 where empty set means wildcard on that dimension. See `matcher.rule_hits`.
 
-Enum-definition order is significant: `GET /v1/bulletins/taxonomy` iterates
+Enum-definition order is significant: `GET /v2/bulletins/taxonomy` iterates
 the enum, so the iOS subscription editor renders the picker in this exact
 sequence.
 """
@@ -61,7 +61,7 @@ class Importance(StrEnum):
 
 
 # Human-readable labels exposed to the iOS subscription UI via
-# `GET /v1/bulletins/taxonomy`. Labels intentionally contain no slashes
+# `GET /v2/bulletins/taxonomy`. Labels intentionally contain no slashes
 # or other separators — the user-facing picker renders single-token names.
 ORG_LABELS: dict[CanonicalOrg, str] = {
     CanonicalOrg.department: "系院所",

--- a/backend/server/config.py
+++ b/backend/server/config.py
@@ -25,6 +25,14 @@ class Settings(BaseSettings):
     env: Literal["development", "production"] = "development"
     log_level: str = "INFO"
     api_base_path: str = "/v2"
+    # Older API prefixes still mounted as aliases for clients that haven't
+    # migrated. Each legacy path serves the same routes as `api_base_path`
+    # but responses carry RFC 8594 deprecation headers (see main.py).
+    api_legacy_base_paths: list[str] = Field(default_factory=lambda: ["/v1"])
+    # Optional RFC 8594 Sunset header value (HTTP-date string) advertised on
+    # legacy responses. Empty string means "no Sunset header" — Deprecation
+    # and successor-version Link still go out.
+    api_legacy_sunset: str = ""
     # Shared-secret that clients must send as X-Push-Token on write endpoints.
     # Empty string disables auth (dev/test convenience). Production must set
     # a non-empty value via TIGERDUCK_API_SHARED_SECRET.

--- a/backend/server/config.py
+++ b/backend/server/config.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     # --- App ---
     env: Literal["development", "production"] = "development"
     log_level: str = "INFO"
-    api_base_path: str = "/v1"
+    api_base_path: str = "/v2"
     # Shared-secret that clients must send as X-Push-Token on write endpoints.
     # Empty string disables auth (dev/test convenience). Production must set
     # a non-empty value via TIGERDUCK_API_SHARED_SECRET.

--- a/backend/server/config.py
+++ b/backend/server/config.py
@@ -61,6 +61,11 @@ class Settings(BaseSettings):
     # Path to the service-account JSON downloaded from the Firebase console.
     # When the file is missing the router falls back to RecordingFcmSender.
     fcm_credentials_path: Path = SERVER_DIR / "secrets" / "fcm_service_account.json"
+    # Hard cap on a single FCM send. firebase-admin's sync `messaging.send`
+    # has no per-call timeout, so without this a stuck token-mint or
+    # unreachable googleapis lookup blocks the bulletin_dispatch tick
+    # indefinitely and APScheduler skips every following tick.
+    fcm_send_timeout_seconds: float = 15.0
 
     # --- Scheduler ---
     # how often dispatcher polls DB for due pushes

--- a/backend/server/config.py
+++ b/backend/server/config.py
@@ -46,6 +46,14 @@ class Settings(BaseSettings):
     # "production" talks to api.push.apple.com (TestFlight / App Store)
     apns_env: Literal["development", "production"] = "development"
 
+    # --- FCM (Android) ---
+    # Firebase project id — only required when delivering real pushes.
+    # Empty string means "use the recording stub", same convention as APNs.
+    fcm_project_id: str = ""
+    # Path to the service-account JSON downloaded from the Firebase console.
+    # When the file is missing the router falls back to RecordingFcmSender.
+    fcm_credentials_path: Path = SERVER_DIR / "secrets" / "fcm_service_account.json"
+
     # --- Scheduler ---
     # how often dispatcher polls DB for due pushes
     scheduler_tick_seconds: int = 30

--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -137,14 +137,60 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     async def ping() -> dict[str, str]:
         return {"pong": "tigerduck"}
 
-    app.include_router(devices_routes.router, prefix=settings.api_base_path)
-    app.include_router(live_activities_routes.router, prefix=settings.api_base_path)
-    app.include_router(schedule_routes.router, prefix=settings.api_base_path)
-    app.include_router(debug_routes.router, prefix=settings.api_base_path)
-    app.include_router(bulletins_routes.router, prefix=settings.api_base_path)
-    app.include_router(bulletins_routes.device_router, prefix=settings.api_base_path)
+    _mount_api(app, settings.api_base_path)
+    for legacy in settings.api_legacy_base_paths:
+        _mount_api(app, legacy)
+
+    if settings.api_legacy_base_paths:
+        _install_deprecation_middleware(
+            app,
+            current=settings.api_base_path,
+            legacy_paths=tuple(settings.api_legacy_base_paths),
+            sunset=settings.api_legacy_sunset,
+        )
 
     return app
+
+
+def _mount_api(app: FastAPI, prefix: str) -> None:
+    # ping is registered per-prefix so the deprecation middleware stamps
+    # /v1/ping responses just like the routed endpoints.
+    async def ping() -> dict[str, str]:
+        return {"pong": "tigerduck"}
+
+    app.add_api_route(f"{prefix}/ping", ping, methods=["GET"], tags=["meta"])
+    app.include_router(devices_routes.router, prefix=prefix)
+    app.include_router(live_activities_routes.router, prefix=prefix)
+    app.include_router(schedule_routes.router, prefix=prefix)
+    app.include_router(debug_routes.router, prefix=prefix)
+    app.include_router(bulletins_routes.router, prefix=prefix)
+    app.include_router(bulletins_routes.device_router, prefix=prefix)
+
+
+def _install_deprecation_middleware(
+    app: FastAPI,
+    *,
+    current: str,
+    legacy_paths: tuple[str, ...],
+    sunset: str,
+) -> None:
+    """Stamp RFC 8594 Deprecation + successor-version Link on legacy responses."""
+
+    @app.middleware("http")
+    async def _deprecation_headers(request, call_next):
+        response = await call_next(request)
+        path = request.url.path
+        for legacy in legacy_paths:
+            if path == legacy or path.startswith(f"{legacy}/"):
+                response.headers["Deprecation"] = "true"
+                successor = current + path[len(legacy):]
+                response.headers["Link"] = (
+                    f'<{successor}>; rel="successor-version"'
+                )
+                if sunset:
+                    response.headers["Sunset"] = sunset
+                break
+        return response
 
 
 app = create_app()

--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -18,7 +18,7 @@ from fastapi import FastAPI  # noqa: E402
 from server.config import Settings, get_settings
 from server.db import build_engine, build_session_factory
 from server.logging_setup import configure as configure_logging
-from server.push.apns_client import build_sender
+from server.push.router import build_router
 from server.routes import bulletins as bulletins_routes
 from server.routes import debug as debug_routes
 from server.routes import devices as devices_routes
@@ -93,12 +93,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     engine = build_engine(settings)
     session_factory = build_session_factory(engine)
-    sender = build_sender(settings)
-    scheduler = build_scheduler(session_factory, sender, settings)
+    router = build_router(settings)
+    scheduler = build_scheduler(session_factory, router, settings)
 
     app.state.engine = engine
     app.state.session_factory = session_factory
-    app.state.sender = sender
+    app.state.router = router
+    # Keep the legacy `sender` attribute pointing at the APNs sender so any
+    # tooling that read `app.state.sender` for Live-Activity / iOS paths
+    # keeps working without a downstream change.
+    app.state.sender = router.apple
     app.state.scheduler = scheduler
     app.state.settings = settings
 
@@ -109,7 +113,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         yield
     finally:
         scheduler.shutdown(wait=False)
-        await sender.close()
+        await router.close()
         await engine.dispose()
         logger.info("server.shutdown")
 

--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -43,7 +43,7 @@ async def _wait_for_llm(settings: Settings) -> bool:
     Intentionally NON-blocking: on failure we log a warning and let the
     server finish booting. Rationale:
 
-    * Read endpoints (`GET /v1/bulletins/...`) don't need the LLM at all.
+    * Read endpoints (`GET /v2/bulletins/...`) don't need the LLM at all.
     * The scheduler's `bulletin_process` job has its own retry/backoff,
       so transient LLM downtime self-heals without server restart.
     * launchd / Docker supervisor would otherwise pin-pong the API

--- a/backend/server/push/fcm_client.py
+++ b/backend/server/push/fcm_client.py
@@ -38,6 +38,7 @@ class FcmSender:
         )
 
     async def send(self, request: FcmRequest) -> SendResult:
+        import firebase_admin
         from firebase_admin import messaging
 
         msg = messaging.Message(
@@ -64,6 +65,10 @@ class FcmSender:
         except messaging.SenderIdMismatchError as e:
             return SendResult(
                 success=False, status="SENDER_ID_MISMATCH", description=str(e)
+            )
+        except firebase_admin.exceptions.InvalidArgumentError as e:
+            return SendResult(
+                success=False, status="INVALID_ARGUMENT", description=str(e)
             )
         except (messaging.QuotaExceededError, messaging.ThirdPartyAuthError) as e:
             return SendResult(

--- a/backend/server/push/fcm_client.py
+++ b/backend/server/push/fcm_client.py
@@ -9,6 +9,7 @@ asyncio loop.
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 from pathlib import Path
 
 import structlog
@@ -49,7 +50,7 @@ class FcmSender:
             data=request.data,
             android=messaging.AndroidConfig(
                 priority="high",
-                ttl=request.ttl_seconds,
+                ttl=timedelta(seconds=request.ttl_seconds),
                 notification=messaging.AndroidNotification(channel_id="bulletins"),
             ),
         )

--- a/backend/server/push/fcm_client.py
+++ b/backend/server/push/fcm_client.py
@@ -23,7 +23,12 @@ logger = structlog.get_logger(__name__)
 class FcmSender:
     """Real FCM sender — requires a Firebase service-account JSON file."""
 
-    def __init__(self, credentials_path: Path, project_id: str) -> None:
+    def __init__(
+        self,
+        credentials_path: Path,
+        project_id: str,
+        send_timeout_seconds: float = 15.0,
+    ) -> None:
         # Import lazily so test envs without firebase-admin installed can
         # still import this module to grab `RecordingFcmSender`.
         import firebase_admin
@@ -37,6 +42,7 @@ class FcmSender:
             name="tigerduck-fcm",
             options={"projectId": project_id},
         )
+        self._send_timeout = send_timeout_seconds
 
     async def send(self, request: FcmRequest) -> SendResult:
         import firebase_admin
@@ -55,9 +61,21 @@ class FcmSender:
             ),
         )
         try:
-            msg_id = await asyncio.to_thread(messaging.send, msg, app=self._app)
+            msg_id = await asyncio.wait_for(
+                asyncio.to_thread(messaging.send, msg, app=self._app),
+                timeout=self._send_timeout,
+            )
             return SendResult(
                 success=True, status="200", description=msg_id
+            )
+        except asyncio.TimeoutError:
+            # The to_thread worker is still running underneath us; we've just
+            # detached. That's intentional — better to leak a daemon thread
+            # than to keep the dispatcher tick blocked forever.
+            return SendResult(
+                success=False,
+                status="TIMEOUT",
+                description=f"FCM send exceeded {self._send_timeout}s",
             )
         except messaging.UnregisteredError as e:
             return SendResult(
@@ -80,10 +98,99 @@ class FcmSender:
                 success=False, status="UNKNOWN", description=str(e)
             )
 
+    async def send_multi(self, requests: list[FcmRequest]) -> list[SendResult]:
+        """Fan one bulletin out to many devices in a single batched RPC.
+
+        firebase-admin's `messaging.send` opens a fresh TLS connection per
+        call, which scales linearly in the number of subscribers. For the
+        bulletin path every request in a batch shares title/body/data and
+        only differs by token, so `send_each_for_multicast` collapses the
+        whole fan-out into ~ceil(N/500) round trips with internal
+        thread-pool concurrency. Returns one SendResult per input request,
+        in the same order.
+
+        Empty input is a no-op (no RPC). All requests in `requests` MUST
+        share the same title/body/data/ttl — caller's responsibility (the
+        bulletin dispatcher already builds one per-(bulletin,device) but
+        every (bulletin,*) tuple has identical content).
+        """
+        import firebase_admin
+        from firebase_admin import messaging
+
+        if not requests:
+            return []
+
+        first = requests[0]
+        results: list[SendResult] = []
+        # Google caps `send_each_for_multicast` at 500 tokens per call.
+        chunk_size = 500
+        for start in range(0, len(requests), chunk_size):
+            chunk = requests[start : start + chunk_size]
+            msg = messaging.MulticastMessage(
+                tokens=[r.token for r in chunk],
+                notification=messaging.Notification(
+                    title=first.title, body=first.body
+                ),
+                data=first.data,
+                android=messaging.AndroidConfig(
+                    priority="high",
+                    ttl=timedelta(seconds=first.ttl_seconds),
+                    notification=messaging.AndroidNotification(channel_id="bulletins"),
+                ),
+            )
+            try:
+                batch = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        messaging.send_each_for_multicast, msg, app=self._app
+                    ),
+                    timeout=self._send_timeout,
+                )
+            except asyncio.TimeoutError:
+                # Same detach-and-move-on contract as `send`. One stuck
+                # batch can't wedge the whole dispatcher tick.
+                results.extend(
+                    SendResult(
+                        success=False,
+                        status="TIMEOUT",
+                        description=f"FCM batch exceeded {self._send_timeout}s",
+                    )
+                    for _ in chunk
+                )
+                continue
+
+            for resp in batch.responses:
+                results.append(_classify_batch_response(resp, firebase_admin, messaging))
+        return results
+
     async def close(self) -> None:
         import firebase_admin
 
         firebase_admin.delete_app(self._app)
+
+
+def _classify_batch_response(resp, firebase_admin, messaging) -> SendResult:
+    """Map one `messaging.SendResponse` to our SendResult shape.
+
+    Mirrors the per-exception classification in `FcmSender.send` so a
+    multicast call surfaces bad_token / transient / unknown the same way
+    the dispatcher already understands.
+    """
+    if resp.success:
+        return SendResult(success=True, status="200", description=resp.message_id)
+    exc = resp.exception
+    if isinstance(exc, messaging.UnregisteredError):
+        return SendResult(success=False, status="UNREGISTERED", description=str(exc))
+    if isinstance(exc, messaging.SenderIdMismatchError):
+        return SendResult(
+            success=False, status="SENDER_ID_MISMATCH", description=str(exc)
+        )
+    if isinstance(exc, firebase_admin.exceptions.InvalidArgumentError):
+        return SendResult(
+            success=False, status="INVALID_ARGUMENT", description=str(exc)
+        )
+    if isinstance(exc, (messaging.QuotaExceededError, messaging.ThirdPartyAuthError)):
+        return SendResult(success=False, status="TRANSIENT", description=str(exc))
+    return SendResult(success=False, status="UNKNOWN", description=str(exc))
 
 
 class RecordingFcmSender:
@@ -106,6 +213,9 @@ class RecordingFcmSender:
             data_keys=sorted(request.data.keys()),
         )
         return SendResult(success=True, status="200", description="recorded")
+
+    async def send_multi(self, requests: list[FcmRequest]) -> list[SendResult]:
+        return [await self.send(r) for r in requests]
 
     async def close(self) -> None:
         pass

--- a/backend/server/push/fcm_client.py
+++ b/backend/server/push/fcm_client.py
@@ -1,0 +1,105 @@
+"""firebase-admin wrapper — service-account auth + alert send path.
+
+Mirrors `apns_client.py` so the dispatcher / router code can treat both
+platforms with the same `PushSender` protocol. firebase-admin's `messaging`
+API is sync, so `send` is dispatched to a thread to avoid blocking the
+asyncio loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import structlog
+
+from server.push.apns_client import SendResult
+from server.push.payload import FcmRequest
+
+logger = structlog.get_logger(__name__)
+
+
+class FcmSender:
+    """Real FCM sender — requires a Firebase service-account JSON file."""
+
+    def __init__(self, credentials_path: Path, project_id: str) -> None:
+        # Import lazily so test envs without firebase-admin installed can
+        # still import this module to grab `RecordingFcmSender`.
+        import firebase_admin
+        from firebase_admin import credentials
+
+        cred = credentials.Certificate(str(credentials_path))
+        # Named app so we don't collide with any other firebase_admin
+        # initialization that might happen elsewhere in the process.
+        self._app = firebase_admin.initialize_app(
+            cred,
+            name="tigerduck-fcm",
+            options={"projectId": project_id},
+        )
+
+    async def send(self, request: FcmRequest) -> SendResult:
+        from firebase_admin import messaging
+
+        msg = messaging.Message(
+            token=request.token,
+            notification=messaging.Notification(
+                title=request.title, body=request.body
+            ),
+            data=request.data,
+            android=messaging.AndroidConfig(
+                priority="high",
+                ttl=request.ttl_seconds,
+                notification=messaging.AndroidNotification(channel_id="bulletins"),
+            ),
+        )
+        try:
+            msg_id = await asyncio.to_thread(messaging.send, msg, app=self._app)
+            return SendResult(
+                success=True, status="200", description=msg_id
+            )
+        except messaging.UnregisteredError as e:
+            return SendResult(
+                success=False, status="UNREGISTERED", description=str(e)
+            )
+        except messaging.SenderIdMismatchError as e:
+            return SendResult(
+                success=False, status="SENDER_ID_MISMATCH", description=str(e)
+            )
+        except (messaging.QuotaExceededError, messaging.ThirdPartyAuthError) as e:
+            return SendResult(
+                success=False, status="TRANSIENT", description=str(e)
+            )
+        except Exception as e:  # noqa: BLE001 — last-ditch catch mirrors APNs client
+            return SendResult(
+                success=False, status="UNKNOWN", description=str(e)
+            )
+
+    async def close(self) -> None:
+        import firebase_admin
+
+        firebase_admin.delete_app(self._app)
+
+
+class RecordingFcmSender:
+    """Test/dev double — captures requests instead of hitting Google.
+
+    Mirrors `RecordingSender` for APNs so a backend running without
+    Firebase service-account creds still presents the same interface to
+    the dispatcher.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[FcmRequest] = []
+
+    async def send(self, request: FcmRequest) -> SendResult:
+        self.requests.append(request)
+        logger.info(
+            "fcm.recorded",
+            token_head=request.token[:8],
+            ttl=request.ttl_seconds,
+            data_keys=sorted(request.data.keys()),
+        )
+        return SendResult(success=True, status="200", description="recorded")
+
+    async def close(self) -> None:
+        pass

--- a/backend/server/push/payload.py
+++ b/backend/server/push/payload.py
@@ -249,6 +249,47 @@ def build_alert_request(
     )
 
 
+@dataclass(frozen=True)
+class FcmRequest:
+    """Transport-level view of a single FCM call. Mirrors `ApnsRequest` so
+    the dispatcher can branch on platform without leaking SDK types."""
+
+    token: str
+    title: str
+    body: str
+    data: dict[str, str]
+    ttl_seconds: int = 7 * 24 * 3600
+
+
+def build_fcm_alert_request(
+    *,
+    fcm_token: str,
+    title: str,
+    body: str,
+    bulletin_id: int,
+    source_url: str,
+    canonical_org: str,
+    ttl_seconds: int = 7 * 24 * 3600,
+) -> FcmRequest:
+    """Build an FCM alert request for a bulletin notification.
+
+    FCM `data` values must all be strings; the Android client parses
+    `bulletin_id` back to int. Keeps shape parity with `build_alert_request`
+    for APNs.
+    """
+    return FcmRequest(
+        token=fcm_token,
+        title=title,
+        body=body,
+        data={
+            "bulletin_id": str(bulletin_id),
+            "source_url": source_url,
+            "canonical_org": canonical_org,
+        },
+        ttl_seconds=ttl_seconds,
+    )
+
+
 def build_apns_request(
     *,
     device_token: str,

--- a/backend/server/push/router.py
+++ b/backend/server/push/router.py
@@ -35,6 +35,13 @@ class PushRouter:
     async def send_android(self, request: FcmRequest) -> SendResult:
         return await self._android.send(request)
 
+    async def send_android_multi(
+        self, requests: list[FcmRequest]
+    ) -> list[SendResult]:
+        """Batched fan-out for one bulletin to many tokens. Returns one
+        result per request, in the same order. Empty input → empty list."""
+        return await self._android.send_multi(requests)
+
     async def close(self) -> None:
         try:
             await self._apple.close()
@@ -56,7 +63,11 @@ def build_router(settings: Settings) -> PushRouter:
         from server.push.fcm_client import FcmSender
 
         logger.info("fcm.using_real_sender", project_id=settings.fcm_project_id)
-        android = FcmSender(settings.fcm_credentials_path, settings.fcm_project_id)
+        android = FcmSender(
+            settings.fcm_credentials_path,
+            settings.fcm_project_id,
+            send_timeout_seconds=settings.fcm_send_timeout_seconds,
+        )
     else:
         from server.push.fcm_client import RecordingFcmSender
 

--- a/backend/server/push/router.py
+++ b/backend/server/push/router.py
@@ -1,0 +1,66 @@
+"""Platform-aware push router.
+
+Wraps the APNs and FCM senders behind one object so the dispatcher /
+scheduler can branch on `device.platform` without importing either SDK
+directly. Each sender is a `PushSender`-shaped duck (async `send`,
+async `close`); the router does not interpret the request payloads, it
+just hands them to the right channel.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from server.config import Settings
+from server.push.apns_client import PushSender, SendResult, build_sender
+from server.push.payload import ApnsRequest, FcmRequest
+
+logger = structlog.get_logger(__name__)
+
+
+class PushRouter:
+    def __init__(self, *, apple: PushSender, android: PushSender) -> None:
+        self._apple = apple
+        self._android = android
+
+    @property
+    def apple(self) -> PushSender:
+        """Expose the APNs sender directly for paths that don't need the
+        platform branch (Live Activities, scheduled iOS pushes)."""
+        return self._apple
+
+    async def send_apple(self, request: ApnsRequest) -> SendResult:
+        return await self._apple.send(request)
+
+    async def send_android(self, request: FcmRequest) -> SendResult:
+        return await self._android.send(request)
+
+    async def close(self) -> None:
+        await self._apple.close()
+        await self._android.close()
+
+
+def build_router(settings: Settings) -> PushRouter:
+    """Construct a router with real or recording senders based on settings.
+
+    Apple side is delegated to `build_sender` so the same APNs cred check
+    keeps working. Android side spins up `FcmSender` only when both the
+    project id and credentials file are present, otherwise falls back to
+    `RecordingFcmSender` — mirrors the APNs dev-fallback behavior so a
+    laptop without Firebase creds can still boot the server.
+    """
+    apple = build_sender(settings)
+    if settings.fcm_project_id and settings.fcm_credentials_path.exists():
+        from server.push.fcm_client import FcmSender
+
+        logger.info("fcm.using_real_sender", project_id=settings.fcm_project_id)
+        android = FcmSender(settings.fcm_credentials_path, settings.fcm_project_id)
+    else:
+        from server.push.fcm_client import RecordingFcmSender
+
+        logger.warning(
+            "fcm.using_recording_sender",
+            reason="FCM credentials missing; android pushes will not be delivered",
+        )
+        android = RecordingFcmSender()
+    return PushRouter(apple=apple, android=android)

--- a/backend/server/push/router.py
+++ b/backend/server/push/router.py
@@ -36,8 +36,10 @@ class PushRouter:
         return await self._android.send(request)
 
     async def close(self) -> None:
-        await self._apple.close()
-        await self._android.close()
+        try:
+            await self._apple.close()
+        finally:
+            await self._android.close()
 
 
 def build_router(settings: Settings) -> PushRouter:

--- a/backend/server/routes/devices.py
+++ b/backend/server/routes/devices.py
@@ -30,6 +30,11 @@ async def register_device(
     session: SessionDep,
 ) -> DeviceRegisterResponse:
     """Upsert a device registration. Idempotent — called on every app launch."""
+    # attrs_type / apns_env are non-null in the DB but meaningless on
+    # android. Persist empty strings so the column constraint stays
+    # satisfied without a migration.
+    attrs_type = payload.attrs_type or ""
+    apns_env = payload.apns_env or ""
     stmt = (
         pg_insert(DeviceRegistration)
         .values(
@@ -39,8 +44,8 @@ async def register_device(
             pts_token_hex=payload.pts_token_hex,
             device_token_hex=payload.device_token_hex,
             bundle_id=payload.bundle_id,
-            attrs_type=payload.attrs_type,
-            apns_env=payload.apns_env,
+            attrs_type=attrs_type,
+            apns_env=apns_env,
         )
         .on_conflict_do_update(
             index_elements=[DeviceRegistration.device_id],
@@ -50,8 +55,8 @@ async def register_device(
                 "pts_token_hex": payload.pts_token_hex,
                 "device_token_hex": payload.device_token_hex,
                 "bundle_id": payload.bundle_id,
-                "attrs_type": payload.attrs_type,
-                "apns_env": payload.apns_env,
+                "attrs_type": attrs_type,
+                "apns_env": apns_env,
                 "updated_at": func.now(),
             },
         )

--- a/backend/server/scheduler/runtime.py
+++ b/backend/server/scheduler/runtime.py
@@ -15,7 +15,7 @@ from server.bulletins import jobs as bulletin_jobs
 from server.bulletins.llm.base import LLMProvider
 from server.bulletins.llm.openai_compat import OpenAICompatibleProvider
 from server.config import Settings
-from server.push.apns_client import PushSender
+from server.push.router import PushRouter
 from server.scheduler.dispatcher import dispatch_due_pushes
 from server.scheduler.retention import prune_terminal_activity_tokens
 
@@ -33,7 +33,7 @@ def build_llm_provider(settings: Settings) -> LLMProvider:
 
 def build_scheduler(
     session_factory: async_sessionmaker[AsyncSession],
-    sender: PushSender,
+    router: PushRouter,
     settings: Settings,
     *,
     llm: LLMProvider | None = None,
@@ -54,7 +54,8 @@ def build_scheduler(
     llm_provider = llm if llm is not None else build_llm_provider(settings)
 
     async def pts_tick() -> None:
-        await dispatch_due_pushes(session_factory, sender, settings)
+        # Live Activity / scheduled iOS pushes only need APNs.
+        await dispatch_due_pushes(session_factory, router.apple, settings)
 
     async def bulletin_scrape() -> None:
         await bulletin_jobs.scrape_job(session_factory, settings)
@@ -63,7 +64,7 @@ def build_scheduler(
         await bulletin_jobs.process_job(session_factory, settings, llm_provider)
 
     async def bulletin_dispatch() -> None:
-        await bulletin_jobs.dispatch_job(session_factory, sender, settings)
+        await bulletin_jobs.dispatch_job(session_factory, router, settings)
 
     async def bulletin_retention() -> None:
         await bulletin_jobs.retention_job(session_factory, settings)

--- a/backend/server/schemas.py
+++ b/backend/server/schemas.py
@@ -25,8 +25,20 @@ class DeviceRegisterRequest(BaseModel):
     pts_token_hex: str = Field(min_length=1, max_length=512)
     device_token_hex: str | None = Field(default=None, max_length=512)
     bundle_id: str = Field(default="org.ntust.app.TigerDuck", max_length=128)
-    attrs_type: str = Field(default="TigerDuckActivityAttributes", max_length=128)
-    apns_env: str = Field(default="development", pattern="^(development|production)$")
+    # attrs_type / apns_env only have meaning on apple. Optional at the wire
+    # level so android clients don't have to fabricate values; the validator
+    # below fills the apple defaults.
+    attrs_type: str | None = Field(default=None, max_length=128)
+    apns_env: str | None = Field(default=None, pattern="^(development|production)$")
+
+    @model_validator(mode="after")
+    def _require_apple_fields(self) -> "DeviceRegisterRequest":
+        if self.platform == "apple":
+            if not self.attrs_type:
+                self.attrs_type = "TigerDuckActivityAttributes"
+            if not self.apns_env:
+                self.apns_env = "development"
+        return self
 
 
 class DeviceRegisterResponse(BaseModel):

--- a/backend/server/tests/test_bulletin_pipeline.py
+++ b/backend/server/tests/test_bulletin_pipeline.py
@@ -39,7 +39,9 @@ from server.bulletins.taxonomy import (
 from server.config import Settings
 from server.models import DeviceRegistration
 from server.push.apns_client import RecordingSender
+from server.push.fcm_client import RecordingFcmSender
 from server.push.payload import PushKind
+from server.push.router import PushRouter
 
 _async = pytest.mark.asyncio(loop_scope="session")
 
@@ -222,7 +224,11 @@ async def test_full_pipeline_fans_out_to_matching_device(
     assert "【重要】新獎學金開放申請" in llm_titles
     assert "【活動】免費便當來領餐券" in llm_titles
 
-    await bulletin_jobs.dispatch_job(factory, sender, settings)
+    await bulletin_jobs.dispatch_job(
+        factory,
+        PushRouter(apple=sender, android=RecordingFcmSender()),
+        settings,
+    )
 
     # --- Assert
     # Leftover fixtures from sibling tests may also match — what we pin
@@ -339,13 +345,21 @@ async def test_dispatch_is_idempotent(
         await session.commit()
 
     sender = RecordingSender()
-    await bulletin_jobs.dispatch_job(factory, sender, settings)
+    await bulletin_jobs.dispatch_job(
+        factory,
+        PushRouter(apple=sender, android=RecordingFcmSender()),
+        settings,
+    )
     first_count = len(sender.requests)
     assert first_count >= 1  # matches >=1 device, depending on leftover fixtures
     # The device under test must receive exactly one push.
     assert sum(1 for r in sender.requests if r.device_token == "alert-idem") == 1
 
-    await bulletin_jobs.dispatch_job(factory, sender, settings)
+    await bulletin_jobs.dispatch_job(
+        factory,
+        PushRouter(apple=sender, android=RecordingFcmSender()),
+        settings,
+    )
     # Second run is a no-op — notified_at is stamped and dispatch rows are
     # terminal, so nothing new hits the sender.
     assert len(sender.requests) == first_count

--- a/backend/server/tests/test_bulletin_routes.py
+++ b/backend/server/tests/test_bulletin_routes.py
@@ -1,4 +1,4 @@
-"""HTTP integration tests for /v1/bulletins and subscription CRUD.
+"""HTTP integration tests for /v2/bulletins and subscription CRUD.
 
 Uses the `client` fixture from conftest which swaps in a fresh DB per test
 (unlike the session-scoped `prepared_engine` used by lower-level tests),
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 
 async def test_taxonomy_lists_every_org_and_tag(client: AsyncClient) -> None:
-    resp = await client.get("/v1/bulletins/taxonomy")
+    resp = await client.get("/v2/bulletins/taxonomy")
     assert resp.status_code == 200
     body = resp.json()
     assert {o["id"] for o in body["orgs"]} == {o.value for o in CanonicalOrg}
@@ -73,7 +73,7 @@ async def _seed_bulletins(client: AsyncClient, count: int = 3) -> list[int]:
 
 async def test_list_bulletins_newest_first_paginates(client: AsyncClient) -> None:
     ids = await _seed_bulletins(client, count=5)
-    resp = await client.get("/v1/bulletins?limit=2")
+    resp = await client.get("/v2/bulletins?limit=2")
     assert resp.status_code == 200
     body = resp.json()
     returned_ids = [item["id"] for item in body["items"]]
@@ -82,7 +82,7 @@ async def test_list_bulletins_newest_first_paginates(client: AsyncClient) -> Non
     assert body["next_cursor"] == returned_ids[-1]
 
     # Fetch the next page via cursor
-    resp2 = await client.get(f"/v1/bulletins?limit=2&cursor={body['next_cursor']}")
+    resp2 = await client.get(f"/v2/bulletins?limit=2&cursor={body['next_cursor']}")
     next_ids = [item["id"] for item in resp2.json()["items"]]
     assert max(next_ids) < min(returned_ids)
 
@@ -98,19 +98,19 @@ async def test_list_bulletins_hides_deleted_by_default(client: AsyncClient) -> N
         )
         await session.commit()
 
-    resp = await client.get("/v1/bulletins")
+    resp = await client.get("/v2/bulletins")
     returned_ids = {item["id"] for item in resp.json()["items"]}
     assert ids[0] not in returned_ids
     assert ids[1] in returned_ids
 
-    resp_with_deleted = await client.get("/v1/bulletins?include_deleted=true")
+    resp_with_deleted = await client.get("/v2/bulletins?include_deleted=true")
     with_ids = {item["id"] for item in resp_with_deleted.json()["items"]}
     assert ids[0] in with_ids
 
 
 async def test_get_bulletin_returns_detail(client: AsyncClient) -> None:
     ids = await _seed_bulletins(client, count=1)
-    resp = await client.get(f"/v1/bulletins/{ids[0]}")
+    resp = await client.get(f"/v2/bulletins/{ids[0]}")
     assert resp.status_code == 200
     body = resp.json()
     assert body["id"] == ids[0]
@@ -120,7 +120,7 @@ async def test_get_bulletin_returns_detail(client: AsyncClient) -> None:
 
 
 async def test_get_bulletin_404s_when_missing(client: AsyncClient) -> None:
-    resp = await client.get("/v1/bulletins/999999999")
+    resp = await client.get("/v2/bulletins/999999999")
     assert resp.status_code == 404
 
 
@@ -129,7 +129,7 @@ async def test_get_bulletin_404s_when_missing(client: AsyncClient) -> None:
 
 async def _register_device(client: AsyncClient, device_id: str = "dev-routes") -> None:
     resp = await client.post(
-        "/v1/devices/register",
+        "/v2/devices/register",
         json={
             "user_id": "u1",
             "device_id": device_id,
@@ -148,12 +148,12 @@ async def test_list_subscriptions_empty_then_after_put(
 ) -> None:
     await _register_device(client)
 
-    empty = await client.get("/v1/devices/dev-routes/subscriptions")
+    empty = await client.get("/v2/devices/dev-routes/subscriptions")
     assert empty.status_code == 200
     assert empty.json()["rules"] == []
 
     put = await client.put(
-        "/v1/devices/dev-routes/subscriptions",
+        "/v2/devices/dev-routes/subscriptions",
         json={
             "rules": [
                 {
@@ -179,7 +179,7 @@ async def test_list_subscriptions_empty_then_after_put(
     assert {r["name"] for r in saved} == {"學務處獎學金", "任何免費便當"}
     assert all(r["id"] for r in saved)
 
-    again = await client.get("/v1/devices/dev-routes/subscriptions")
+    again = await client.get("/v2/devices/dev-routes/subscriptions")
     assert [r["name"] for r in again.json()["rules"]] == [
         "學務處獎學金",
         "任何免費便當",
@@ -193,7 +193,7 @@ async def test_put_subscriptions_is_snapshot_replacement(
     await _register_device(client, device_id="dev-snap")
 
     await client.put(
-        "/v1/devices/dev-snap/subscriptions",
+        "/v2/devices/dev-snap/subscriptions",
         json={
             "rules": [
                 {"orgs": [CanonicalOrg.library.value], "tags": [], "mode": "AND"},
@@ -202,14 +202,14 @@ async def test_put_subscriptions_is_snapshot_replacement(
         },
     )
     await client.put(
-        "/v1/devices/dev-snap/subscriptions",
+        "/v2/devices/dev-snap/subscriptions",
         json={
             "rules": [
                 {"orgs": [CanonicalOrg.library.value], "tags": [], "mode": "AND"}
             ]
         },
     )
-    got = await client.get("/v1/devices/dev-snap/subscriptions")
+    got = await client.get("/v2/devices/dev-snap/subscriptions")
     rules = got.json()["rules"]
     assert len(rules) == 1
     assert rules[0]["orgs"] == [CanonicalOrg.library.value]
@@ -221,7 +221,7 @@ async def test_subscriptions_get_returns_empty_when_device_missing(
     """GET tolerates the first-launch race where subscriptions load fires
     before APNs token registration finishes — returning 200 empty lets the
     editor render immediately without the client special-casing 404."""
-    resp = await client.get("/v1/devices/ghost-device/subscriptions")
+    resp = await client.get("/v2/devices/ghost-device/subscriptions")
     assert resp.status_code == 200
     assert resp.json() == {"device_id": "ghost-device", "rules": []}
 
@@ -232,7 +232,7 @@ async def test_subscriptions_put_requires_registered_device(
     """PUT still 404s for unknown devices so a saved ruleset can't end up
     orphaned with no DeviceRegistration to push to."""
     put = await client.put(
-        "/v1/devices/ghost-device/subscriptions",
+        "/v2/devices/ghost-device/subscriptions",
         json={"rules": []},
     )
     assert put.status_code == 404
@@ -241,7 +241,7 @@ async def test_subscriptions_put_requires_registered_device(
 async def test_put_rejects_unknown_org_value(client: AsyncClient) -> None:
     await _register_device(client, device_id="dev-bad")
     resp = await client.put(
-        "/v1/devices/dev-bad/subscriptions",
+        "/v2/devices/dev-bad/subscriptions",
         json={
             "rules": [
                 {"orgs": ["not_a_real_org"], "tags": [], "mode": "AND"}
@@ -261,7 +261,7 @@ async def test_register_accepts_device_token_hex_end_to_end(
     # Subscription that would match anything — ensures the device is in
     # the matcher's eligible pool (which gates on device_token_hex).
     put = await client.put(
-        "/v1/devices/dev-token-smoke/subscriptions",
+        "/v2/devices/dev-token-smoke/subscriptions",
         json={"rules": [{"orgs": [], "tags": [], "mode": "AND"}]},
     )
     assert put.status_code == 200

--- a/backend/server/tests/test_devices.py
+++ b/backend/server/tests/test_devices.py
@@ -23,7 +23,7 @@ async def _register_payload(**overrides) -> dict:
 
 async def test_register_device_creates_row(client: AsyncClient):
     payload = await _register_payload()
-    response = await client.post("/v1/devices/register", json=payload)
+    response = await client.post("/v2/devices/register", json=payload)
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["device_id"] == "device-xyz"
@@ -35,31 +35,31 @@ async def test_register_is_idempotent_upsert(client: AsyncClient):
     p1 = await _register_payload(pts_token_hex="aa" * 32)
     p2 = await _register_payload(pts_token_hex="bb" * 32)
 
-    r1 = await client.post("/v1/devices/register", json=p1)
+    r1 = await client.post("/v2/devices/register", json=p1)
     assert r1.status_code == 200
 
-    r2 = await client.post("/v1/devices/register", json=p2)
+    r2 = await client.post("/v2/devices/register", json=p2)
     assert r2.status_code == 200
 
-    got = await client.get("/v1/devices/device-xyz")
+    got = await client.get("/v2/devices/device-xyz")
     assert got.status_code == 200
 
 
 async def test_unregister_device_cascade(client: AsyncClient):
     payload = await _register_payload()
-    await client.post("/v1/devices/register", json=payload)
+    await client.post("/v2/devices/register", json=payload)
 
     unreg = await client.post(
-        "/v1/devices/unregister",
+        "/v2/devices/unregister",
         json={"device_id": "device-xyz"},
     )
     assert unreg.status_code == 204
 
-    got = await client.get("/v1/devices/device-xyz")
+    got = await client.get("/v2/devices/device-xyz")
     assert got.status_code == 404
 
 
 async def test_register_rejects_invalid_apns_env(client: AsyncClient):
     payload = await _register_payload(apns_env="staging")
-    response = await client.post("/v1/devices/register", json=payload)
+    response = await client.post("/v2/devices/register", json=payload)
     assert response.status_code == 422

--- a/backend/server/tests/test_dispatcher.py
+++ b/backend/server/tests/test_dispatcher.py
@@ -30,7 +30,7 @@ DEVICE_ID = "dev-dispatcher"
 
 async def _register_device(client: AsyncClient) -> None:
     resp = await client.post(
-        "/v1/devices/register",
+        "/v2/devices/register",
         json={
             "user_id": "user-dispatcher",
             "device_id": DEVICE_ID,

--- a/backend/server/tests/test_dispatcher_android.py
+++ b/backend/server/tests/test_dispatcher_android.py
@@ -1,0 +1,194 @@
+"""End-to-end check that the bulletin dispatcher fans out to android
+devices via the FCM channel rather than the APNs one.
+
+Uses the recording stubs on both sides so no network I/O happens; the
+assertion pins (a) the dispatch row reaching `sent`, (b) the FCM
+recording sender seeing the device's `pts_token_hex` (Android stores
+the FCM registration token there), and (c) the APNs recording sender
+staying empty so we never accidentally cross channels.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from server.bulletins import jobs as bulletin_jobs
+from server.bulletins.models import (
+    Bulletin,
+    BulletinDispatch,
+    BulletinDispatchStatus,
+    BulletinProcessingState,
+    BulletinSubscription,
+)
+from server.bulletins.taxonomy import (
+    CanonicalOrg,
+    ContentTag,
+    Importance,
+    SubscriptionMode,
+)
+from server.config import Settings
+from server.models import DevicePlatform, DeviceRegistration
+from server.push.apns_client import RecordingSender
+from server.push.fcm_client import RecordingFcmSender
+from server.push.router import PushRouter
+
+_async = pytest.mark.asyncio(loop_scope="session")
+
+
+@_async
+async def test_android_device_receives_fcm_push(
+    prepared_engine: AsyncEngine, test_settings: Settings
+) -> None:
+    factory = async_sessionmaker(prepared_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        session.add(
+            DeviceRegistration(
+                device_id="dev-android-1",
+                user_id="u-android",
+                platform=DevicePlatform.android.value,
+                # Android stores the FCM registration token in the same
+                # `pts_token_hex` column the iOS PTS token lives in — the
+                # column is platform-overloaded by design.
+                pts_token_hex="fcm-token-android",
+                device_token_hex=None,
+                bundle_id="org.ntust.app.tigerduck",
+                # Empty strings are how the device-register route persists
+                # the apple-only fields for android rows.
+                attrs_type="",
+                apns_env="",
+            )
+        )
+        await session.flush()
+        session.add(
+            BulletinSubscription(
+                device_id="dev-android-1",
+                name="library-watch",
+                orgs=[CanonicalOrg.library.value],
+                tags=[],
+                mode=SubscriptionMode.AND.value,
+            )
+        )
+        bulletin = Bulletin(
+            source="ntust_general",
+            external_id="900100",
+            source_url="https://x/900100",
+            title="圖書館公告",
+            title_clean="圖書館公告",
+            body_md="body",
+            body_clean="body",
+            canonical_org=CanonicalOrg.library.value,
+            content_tags=[],
+            summary="圖書館今日延後開放",
+            importance=Importance.normal.value,
+            processing_state=BulletinProcessingState.processed.value,
+        )
+        session.add(bulletin)
+        await session.commit()
+        bulletin_id = bulletin.id
+
+    apple = RecordingSender()
+    android = RecordingFcmSender()
+    router = PushRouter(apple=apple, android=android)
+
+    await bulletin_jobs.dispatch_job(factory, router, test_settings)
+
+    # FCM channel saw exactly our android device's token.
+    our_fcm = [r for r in android.requests if r.data.get("bulletin_id") == str(bulletin_id)]
+    assert len(our_fcm) == 1
+    sent = our_fcm[0]
+    assert sent.token == "fcm-token-android"
+    assert sent.title == "圖書館公告"
+    assert sent.data["canonical_org"] == CanonicalOrg.library.value
+    assert sent.data["source_url"] == "https://x/900100"
+
+    # APNs channel must not have been called for the android device.
+    assert all(
+        r.message.get("bulletin_id") != bulletin_id for r in apple.requests
+    )
+
+    async with factory() as session:
+        dispatch = (
+            await session.execute(
+                select(BulletinDispatch).where(
+                    BulletinDispatch.bulletin_id == bulletin_id,
+                    BulletinDispatch.device_id == "dev-android-1",
+                )
+            )
+        ).scalar_one()
+        assert dispatch.status == BulletinDispatchStatus.sent.value
+        assert dispatch.last_error is None
+
+
+@_async
+async def test_android_device_without_token_is_cancelled(
+    prepared_engine: AsyncEngine, test_settings: Settings
+) -> None:
+    """An android row that somehow lost its FCM token cancels the dispatch
+    rather than retrying forever."""
+    factory = async_sessionmaker(prepared_engine, expire_on_commit=False)
+
+    async with factory() as session:
+        session.add(
+            DeviceRegistration(
+                device_id="dev-android-empty",
+                user_id="u-empty",
+                platform=DevicePlatform.android.value,
+                # Empty token must not be allowed by the schema constraint
+                # (min_length=1 at the API layer), but the model column
+                # tolerates "" — exercise that defensive path.
+                pts_token_hex="",
+                device_token_hex=None,
+                bundle_id="org.ntust.app.tigerduck",
+                attrs_type="",
+                apns_env="",
+            )
+        )
+        await session.flush()
+        session.add(
+            BulletinSubscription(
+                device_id="dev-android-empty",
+                name="any-scholarship",
+                orgs=[],
+                tags=[ContentTag.scholarship.value],
+                mode=SubscriptionMode.AND.value,
+            )
+        )
+        bulletin = Bulletin(
+            source="ntust_general",
+            external_id="900200",
+            source_url="https://x/900200",
+            title="獎學金通知",
+            title_clean="獎學金通知",
+            body_md="body",
+            body_clean="body",
+            canonical_org=CanonicalOrg.student_affairs.value,
+            content_tags=[ContentTag.scholarship.value],
+            summary="新獎學金",
+            importance=Importance.normal.value,
+            processing_state=BulletinProcessingState.processed.value,
+        )
+        session.add(bulletin)
+        await session.commit()
+        bulletin_id = bulletin.id
+
+    android = RecordingFcmSender()
+    router = PushRouter(apple=RecordingSender(), android=android)
+
+    await bulletin_jobs.dispatch_job(factory, router, test_settings)
+
+    assert android.requests == []
+
+    async with factory() as session:
+        dispatch = (
+            await session.execute(
+                select(BulletinDispatch).where(
+                    BulletinDispatch.bulletin_id == bulletin_id,
+                    BulletinDispatch.device_id == "dev-android-empty",
+                )
+            )
+        ).scalar_one()
+        assert dispatch.status == BulletinDispatchStatus.cancelled.value
+        assert "android" in (dispatch.last_error or "").lower()

--- a/backend/server/tests/test_dispatcher_classify.py
+++ b/backend/server/tests/test_dispatcher_classify.py
@@ -1,0 +1,49 @@
+"""Pinning the platform-aware classifier in `bulletins/dispatcher.py`.
+
+The dispatcher uses `_classify` to decide whether a failed send should
+flip the dispatch row to `bad_token` (drop the device) or stay
+retry-eligible. APNs and FCM speak different error vocabularies, so the
+classifier is parameterised by platform — these tests guard the FCM
+branch specifically.
+"""
+
+from __future__ import annotations
+
+from server.bulletins.dispatcher import _classify
+from server.push.apns_client import SendResult
+
+
+def _fail(status: str, description: str = "") -> SendResult:
+    return SendResult(success=False, status=status, description=description)
+
+
+def test_android_unregistered_is_bad_token() -> None:
+    assert _classify(_fail("UNREGISTERED", "token not registered"), platform="android") == "bad_token"
+
+
+def test_android_sender_id_mismatch_is_bad_token() -> None:
+    assert _classify(_fail("SENDER_ID_MISMATCH"), platform="android") == "bad_token"
+
+
+def test_android_invalid_argument_is_bad_token() -> None:
+    assert _classify(_fail("INVALID_ARGUMENT"), platform="android") == "bad_token"
+
+
+def test_android_unknown_status_is_transient() -> None:
+    assert _classify(_fail("UNKNOWN", "boom"), platform="android") == "transient"
+
+
+def test_android_quota_exceeded_is_transient() -> None:
+    # Surface the firebase-admin transient bucket as retry-eligible.
+    assert _classify(_fail("TRANSIENT", "rate limited"), platform="android") == "transient"
+
+
+def test_apple_410_is_bad_token() -> None:
+    # Existing APNs behaviour — keep a regression pin alongside the FCM ones.
+    assert _classify(_fail("410", "Unregistered"), platform="apple") == "bad_token"
+
+
+def test_success_is_sent_regardless_of_platform() -> None:
+    ok = SendResult(success=True, status="200")
+    assert _classify(ok, platform="apple") == "sent"
+    assert _classify(ok, platform="android") == "sent"

--- a/backend/server/tests/test_fcm_payload.py
+++ b/backend/server/tests/test_fcm_payload.py
@@ -1,0 +1,57 @@
+"""Pure-unit tests for `build_fcm_alert_request`.
+
+FCM rejects messages whose `data` map contains non-string values, so the
+builder must stringify everything (notably `bulletin_id`). These tests
+pin that contract.
+"""
+
+from __future__ import annotations
+
+from server.push.payload import FcmRequest, build_fcm_alert_request
+
+
+def test_data_values_are_all_strings() -> None:
+    req = build_fcm_alert_request(
+        fcm_token="fcm-tok",
+        title="t",
+        body="b",
+        bulletin_id=42,
+        source_url="https://x/42",
+        canonical_org="oaa",
+    )
+    assert isinstance(req, FcmRequest)
+    assert req.token == "fcm-tok"
+    assert req.title == "t"
+    assert req.body == "b"
+    assert req.data == {
+        "bulletin_id": "42",
+        "source_url": "https://x/42",
+        "canonical_org": "oaa",
+    }
+    assert all(isinstance(v, str) for v in req.data.values())
+
+
+def test_bulletin_id_is_stringified_int() -> None:
+    req = build_fcm_alert_request(
+        fcm_token="t",
+        title="t",
+        body="b",
+        bulletin_id=7,
+        source_url="",
+        canonical_org="",
+    )
+    assert req.data["bulletin_id"] == "7"
+    # round-trip — Android client parses back to int.
+    assert int(req.data["bulletin_id"]) == 7
+
+
+def test_default_ttl_is_seven_days() -> None:
+    req = build_fcm_alert_request(
+        fcm_token="t",
+        title="t",
+        body="b",
+        bulletin_id=1,
+        source_url="",
+        canonical_org="",
+    )
+    assert req.ttl_seconds == 7 * 24 * 3600

--- a/backend/server/tests/test_live_activities.py
+++ b/backend/server/tests/test_live_activities.py
@@ -39,7 +39,7 @@ def _snapshot(countdown_target: datetime) -> dict:
 
 async def _register_device(client: AsyncClient) -> None:
     response = await client.post(
-        "/v1/devices/register",
+        "/v2/devices/register",
         json={
             "user_id": "user-live",
             "device_id": DEVICE_ID,
@@ -53,7 +53,7 @@ async def _register_device(client: AsyncClient) -> None:
 async def test_register_live_activity_token_requires_device(client: AsyncClient):
     target = datetime.now(timezone.utc) + timedelta(minutes=15)
     response = await client.post(
-        "/v1/live-activities/register",
+        "/v2/live-activities/register",
         json={
             "device_id": "missing-device",
             "activity_id": "classPreparing::slot-live",
@@ -79,7 +79,7 @@ async def test_register_live_activity_token_rejects_mismatched_source_id(
     snapshot = _snapshot(target)
     snapshot["sourceId"] = "slot-other"  # deliberately mismatched
     response = await client.post(
-        "/v1/live-activities/register",
+        "/v2/live-activities/register",
         json={
             "device_id": DEVICE_ID,
             "activity_id": "classPreparing::slot-live",
@@ -101,7 +101,7 @@ async def test_register_live_activity_token_upserts(
     target = datetime.now(timezone.utc) + timedelta(minutes=15)
 
     first = await client.post(
-        "/v1/live-activities/register",
+        "/v2/live-activities/register",
         json={
             "device_id": DEVICE_ID,
             "activity_id": "classPreparing::slot-live",
@@ -116,7 +116,7 @@ async def test_register_live_activity_token_upserts(
 
     second_target = target + timedelta(minutes=5)
     second = await client.post(
-        "/v1/live-activities/register",
+        "/v2/live-activities/register",
         json={
             "device_id": DEVICE_ID,
             "activity_id": "classPreparing::slot-live",

--- a/backend/server/tests/test_retention.py
+++ b/backend/server/tests/test_retention.py
@@ -23,7 +23,7 @@ DEVICE_ID = "device-retention"
 
 async def _register_device(client: AsyncClient) -> None:
     response = await client.post(
-        "/v1/devices/register",
+        "/v2/devices/register",
         json={
             "user_id": "user-retention",
             "device_id": DEVICE_ID,

--- a/backend/server/tests/test_schedule.py
+++ b/backend/server/tests/test_schedule.py
@@ -35,7 +35,7 @@ def _snapshot(title: str) -> dict:
 
 async def _register(client: AsyncClient) -> None:
     await client.post(
-        "/v1/devices/register",
+        "/v2/devices/register",
         json={
             "user_id": USER_ID,
             "device_id": DEVICE_ID,
@@ -47,7 +47,7 @@ async def _register(client: AsyncClient) -> None:
 
 async def test_sync_requires_registered_device(client: AsyncClient):
     response = await client.post(
-        "/v1/schedule/sync",
+        "/v2/schedule/sync",
         json={"device_id": "never-registered", "events": []},
     )
     assert response.status_code == 404
@@ -57,7 +57,7 @@ async def test_sync_inserts_and_reports_counts(client: AsyncClient):
     await _register(client)
     fire = datetime.now(timezone.utc) + timedelta(minutes=15)
     response = await client.post(
-        "/v1/schedule/sync",
+        "/v2/schedule/sync",
         json={
             "device_id": DEVICE_ID,
             "events": [
@@ -88,7 +88,7 @@ async def test_sync_replaces_previous_events(client: AsyncClient):
     fire = datetime.now(timezone.utc) + timedelta(hours=1)
 
     first = await client.post(
-        "/v1/schedule/sync",
+        "/v2/schedule/sync",
         json={
             "device_id": DEVICE_ID,
             "events": [
@@ -111,7 +111,7 @@ async def test_sync_replaces_previous_events(client: AsyncClient):
 
     # Second sync keeps only slot-2, so slot-1 should be cancelled
     second = await client.post(
-        "/v1/schedule/sync",
+        "/v2/schedule/sync",
         json={
             "device_id": DEVICE_ID,
             "events": [
@@ -147,7 +147,7 @@ async def test_resync_does_not_revive_already_sent_push(
     fire = datetime.now(timezone.utc) + timedelta(minutes=5)
 
     await client.post(
-        "/v1/schedule/sync",
+        "/v2/schedule/sync",
         json={
             "device_id": DEVICE_ID,
             "events": [
@@ -175,7 +175,7 @@ async def test_resync_does_not_revive_already_sent_push(
 
     # Re-sync — same push_id, same content. Must NOT flip status back.
     await client.post(
-        "/v1/schedule/sync",
+        "/v2/schedule/sync",
         json={
             "device_id": DEVICE_ID,
             "events": [
@@ -202,7 +202,7 @@ async def test_cancel_by_source_removes_all_scenarios(client: AsyncClient):
     fire = datetime.now(timezone.utc) + timedelta(hours=2)
 
     await client.post(
-        "/v1/schedule/sync",
+        "/v2/schedule/sync",
         json={
             "device_id": DEVICE_ID,
             "events": [
@@ -228,13 +228,13 @@ async def test_cancel_by_source_removes_all_scenarios(client: AsyncClient):
         },
     )
 
-    cancel = await client.delete(f"/v1/schedule/{DEVICE_ID}/slot-1")
+    cancel = await client.delete(f"/v2/schedule/{DEVICE_ID}/slot-1")
     assert cancel.status_code == 200
     assert cancel.json()["deleted"] == 2
 
     # Now re-sync with empty to count remaining
     final = await client.post(
-        "/v1/schedule/sync",
+        "/v2/schedule/sync",
         json={
             "device_id": DEVICE_ID,
             "events": [

--- a/backend/server/tests/test_v1_alias.py
+++ b/backend/server/tests/test_v1_alias.py
@@ -1,0 +1,44 @@
+"""Legacy /v1 prefix is mounted alongside /v2 with deprecation headers."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def test_v1_ping_works_and_is_deprecated(client: AsyncClient):
+    response = await client.get("/v1/ping")
+    assert response.status_code == 200
+    assert response.json() == {"pong": "tigerduck"}
+    assert response.headers.get("Deprecation") == "true"
+    assert response.headers.get("Link") == '</v2/ping>; rel="successor-version"'
+
+
+async def test_v1_register_without_platform_defaults_to_apple(client: AsyncClient):
+    # Pre-platform-header iOS clients omit the field; schema default fills it.
+    payload = {
+        "user_id": "legacy-user",
+        "device_id": "legacy-device",
+        "pts_token_hex": "ab" * 32,
+        "bundle_id": "org.ntust.app.TigerDuck",
+        "attrs_type": "TigerDuckActivityAttributes",
+        "apns_env": "development",
+    }
+    response = await client.post("/v1/devices/register", json=payload)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["platform"] == "apple"
+    assert response.headers.get("Deprecation") == "true"
+    assert (
+        response.headers.get("Link")
+        == '</v2/devices/register>; rel="successor-version"'
+    )
+
+
+async def test_v2_responses_have_no_deprecation_headers(client: AsyncClient):
+    response = await client.get("/v2/ping")
+    assert response.status_code == 200
+    assert "Deprecation" not in response.headers
+    assert "Link" not in response.headers

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "aioapns"
@@ -123,6 +127,7 @@ dependencies = [
     { name = "apscheduler" },
     { name = "asyncpg" },
     { name = "fastapi" },
+    { name = "firebase-admin" },
     { name = "httpx", extra = ["http2"] },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -146,6 +151,7 @@ requires-dist = [
     { name = "apscheduler", specifier = ">=3.10.4" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "firebase-admin", specifier = ">=6.5.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.0" },
@@ -160,6 +166,19 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
 ]
 
 [[package]]
@@ -393,6 +412,147 @@ wheels = [
 ]
 
 [[package]]
+name = "firebase-admin"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol" },
+    { name = "google-api-core", extra = ["grpc"], marker = "platform_python_implementation != 'PyPy'" },
+    { name = "google-cloud-firestore", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "google-cloud-storage" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "pyjwt", extra = ["crypto"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/ab/2c551264041ddaff7dedd53893ab4642b19008bfb986567fb6ded6380831/firebase_admin-7.4.0.tar.gz", hash = "sha256:08d7550efdba32fbd306141ce82150f9ffb91c1550e07aa4ed5757af4895d1ff", size = 201086, upload-time = "2026-04-09T20:53:08.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/40/87f412ce2df5e57feb456b3b9b3427b2af3a35e1eaa14addfb283f5247fb/firebase_admin-7.4.0-py3-none-any.whl", hash = "sha256:416967d1aacd30cfece2a5b0c606a52ba7614eb3093f054399be3868489cd7a8", size = 140987, upload-time = "2026-04-09T20:53:06.568Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/24/6ca08b0a03c7b0c620427503ab00353a4ae806b848b93bcea18b6b76fde6/google_cloud_core-2.5.1.tar.gz", hash = "sha256:3dc94bdec9d05a31d9f355045ed0f369fbc0d8c665076c734f065d729800f811", size = 36078, upload-time = "2026-03-30T22:50:08.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/d9/5bb050cb32826466aa9b25f79e2ca2879fe66cb76782d4ed798dd7506151/google_cloud_core-2.5.1-py3-none-any.whl", hash = "sha256:ea62cdf502c20e3e14be8a32c05ed02113d7bef454e40ff3fab6fe1ec9f1f4e7", size = 29452, upload-time = "2026-03-30T22:48:31.567Z" },
+]
+
+[[package]]
+name = "google-cloud-firestore"
+version = "2.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/83/bdfd4387fadc5f44de1d0f97b456c648b6f87ec0b1818a9f7f477e6e6eab/google_cloud_firestore-2.27.0.tar.gz", hash = "sha256:5633cb164ef56ca6c73a807822191a56a98f6f10e76978c4f2eb197ae03383d2", size = 649244, upload-time = "2026-04-13T22:55:43.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/db/fc72c4279887cc95011f16e70200d021030f0261e6391fa52e3adfaaea25/google_cloud_firestore-2.27.0-py3-none-any.whl", hash = "sha256:cc2ea78bc2d4dcc928016d56802deacfda3c9bbda0a7d691ee73b41a2f1a80d7", size = 429806, upload-time = "2026-04-13T22:55:41.726Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/47/205eb8e9a1739b5345843e5a425775cbdc472cc38e7eda082ba5b8d02450/google_cloud_storage-3.10.1.tar.gz", hash = "sha256:97db9aa4460727982040edd2bd13ff3d5e2260b5331ad22895802da1fc2a5286", size = 17309950, upload-time = "2026-03-23T09:35:23.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/ff/ca9ab2417fa913d75aae38bf40bf856bb2749a604b2e0f701b37cfcd23cc/google_cloud_storage-3.10.1-py3-none-any.whl", hash = "sha256:a72f656759b7b99bda700f901adcb3425a828d4a29f911bc26b3ea79c5b1217f", size = 324453, upload-time = "2026-03-23T09:35:21.368Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/d1/b1ea14b93b6b78f57fc580125de44e9f593ab88dd2460f1a8a8d18f74754/google_resumable_media-2.8.2.tar.gz", hash = "sha256:f3354a182ebd193ae3f42e3ef95e6c9b10f128320de23ac7637236713b1acd70", size = 2164510, upload-time = "2026-03-30T23:34:25.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f8/50bfaf4658431ff9de45c5c3935af7ab01157a4903c603cd0eee6e78e087/google_resumable_media-2.8.2-py3-none-any.whl", hash = "sha256:82b6d8ccd11765268cdd2a2123f417ec806b8eef3000a9a38dfe3033da5fb220", size = 81511, upload-time = "2026-03-30T23:34:09.671Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -427,6 +587,51 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ed/105f619bdd00cb47a49aa2feea6232ea2bbb04199d52a22cc6a7d603b5cb/grpcio_status-1.80.0.tar.gz", hash = "sha256:df73802a4c89a3ea88aa2aff971e886fccce162bc2e6511408b3d67a144381cd", size = 13901, upload-time = "2026-03-30T08:54:34.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/80/58cd2dfc19a07d022abe44bde7c365627f6c7cb6f692ada6c65ca437d09a/grpcio_status-1.80.0-py3-none-any.whl", hash = "sha256:4b56990363af50dbf2c2ebb80f1967185c07d87aa25aa2bea45ddb75fc181dbe", size = 14638, upload-time = "2026-03-30T08:54:01.569Z" },
 ]
 
 [[package]]
@@ -714,6 +919,41 @@ wheels = [
 ]
 
 [[package]]
+name = "msgpack"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
+    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
+    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
+    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
+    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -729,6 +969,54 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204, upload-time = "2026-03-26T22:18:57.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450, upload-time = "2026-03-26T22:13:42.927Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1024,6 +1312,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/eb/ef32dcd2cb69b69bc0c3e55205bce94a7def48d495358946bc42186dcccc/regex-2026.4.4-cp314-cp314t-win32.whl", hash = "sha256:385edaebde5db5be103577afc8699fea73a0e36a734ba24870be7ffa61119d74", size = 275709, upload-time = "2026-04-03T20:56:20.996Z" },
     { url = "https://files.pythonhosted.org/packages/a0/86/c291bf740945acbf35ed7dbebf8e2eea2f3f78041f6bd7cdab80cb274dc0/regex-2026.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:5d354b18839328927832e2fa5f7c95b7a3ccc39e7a681529e1685898e6436d45", size = 285622, upload-time = "2026-04-03T20:56:23.641Z" },
     { url = "https://files.pythonhosted.org/packages/d5/e7/ec846d560ae6a597115153c02ca6138a7877a1748b2072d9521c10a93e58/regex-2026.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:af0384cb01a33600c49505c27c6c57ab0b27bf84a74e28524c92ca897ebdac9d", size = 275773, upload-time = "2026-04-03T20:56:26.07Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]

--- a/swift/TigerDuck/App/AppConstants.swift
+++ b/swift/TigerDuck/App/AppConstants.swift
@@ -25,7 +25,7 @@ nonisolated enum AppConstants {
     /// the nginx-proxy-manager + Cloudflare-fronted Mac mini. Override via
     /// ``UserDefaultsKeys/pushServerURLOverride`` during development to talk
     /// to a LAN instance.
-    static let defaultPushServerURL = URL(string: "https://api.tigerduck.app/v1")!
+    static let defaultPushServerURL = URL(string: "https://api.tigerduck.app/v2")!
 
     enum UserDefaultsKeys {
         static let hasCompletedOnboarding = "hasCompletedOnboarding"

--- a/swift/TigerDuck/Services/API/Bulletin/BulletinAPIDTO.swift
+++ b/swift/TigerDuck/Services/API/Bulletin/BulletinAPIDTO.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Request/response DTOs for `/v1/bulletins` and related subscription
+/// Request/response DTOs for `/v2/bulletins` and related subscription
 /// routes. Mirrors `backend/server/bulletins/schemas.py`. Keep both sides
 /// in sync when evolving the API contract.
 ///

--- a/swift/TigerDuck/Services/Push/PushAPIDTO.swift
+++ b/swift/TigerDuck/Services/Push/PushAPIDTO.swift
@@ -8,6 +8,7 @@ enum PushAPI {
     struct DeviceRegisterRequest: Codable, Sendable {
         let userId: String
         let deviceId: String
+        let platform: String
         let ptsTokenHex: String
         let deviceTokenHex: String?
         let bundleId: String
@@ -17,6 +18,7 @@ enum PushAPI {
         enum CodingKeys: String, CodingKey {
             case userId = "user_id"
             case deviceId = "device_id"
+            case platform
             case ptsTokenHex = "pts_token_hex"
             case deviceTokenHex = "device_token_hex"
             case bundleId = "bundle_id"

--- a/swift/TigerDuck/Services/Push/PushRegistrationService.swift
+++ b/swift/TigerDuck/Services/Push/PushRegistrationService.swift
@@ -169,6 +169,7 @@ actor PushRegistrationService {
         let request = PushAPI.DeviceRegisterRequest(
             userId: identity.userId,
             deviceId: identity.deviceId,
+            platform: "apple",
             ptsTokenHex: pts,
             deviceTokenHex: deviceTokenHex,
             bundleId: bundleId,

--- a/swift/TigerDuck/Services/Push/ScheduleSyncService.swift
+++ b/swift/TigerDuck/Services/Push/ScheduleSyncService.swift
@@ -3,7 +3,7 @@ import Foundation
 import os
 
 /// Builds a 48-hour event list from the same resolver the on-device Live
-/// Activity uses, and POSTs it to `/v1/schedule/sync`.
+/// Activity uses, and POSTs it to `/v2/schedule/sync`.
 ///
 /// Why 48 hours: enough headroom to cover overnight + next day without
 /// letting the server hold a huge pending queue. The app is expected to


### PR DESCRIPTION
# feat(announcement): adapt bulletin push pipeline for Android

## Summary

Extends the bulletin announcement pipeline to deliver to Android devices via FCM in addition to APNs, and bumps the public API base path from `/v1` to `/v2` to reflect the new platform-aware device contract. Also rolls up the i18n + name-abbreviation work that landed on this branch ahead of the dev cut.

## Backend — Android push adaptation

- **New FCM sender** (`backend/server/push/fcm_client.py`): firebase-admin wrapper exposing the same `PushSender` protocol as the APNs client. `RecordingFcmSender` mirrors the APNs dev fallback so the server still boots without Firebase credentials.
- **PushRouter** (`backend/server/push/router.py`): platform-aware façade over the APNs and FCM senders. `build_router` constructs a real `FcmSender` only when `fcm_project_id` and `fcm_credentials_path` are both set; otherwise falls back to the recording stub.
- **Dispatcher branches by `device.platform`** (`bulletins/dispatcher.py`): Android rows use `pts_token_hex` as the FCM registration token (column is platform-overloaded — no schema change needed), build an `FcmRequest` via `build_fcm_alert_request`, and classify FCM-specific errors (`unregistered`, `sender_id_mismatch`, `invalid_argument`) as `bad_token`.
- **Device registration** (`routes/devices.py`, `schemas.py`): `attrs_type` and `apns_env` are now optional on the request and stored as empty strings for Android so the existing NOT NULL columns stay satisfied without a migration.
- **Settings** (`config.py`): adds `fcm_project_id` and `fcm_credentials_path`.
- **Wiring** (`main.py`, `scheduler/runtime.py`): lifespan builds a `PushRouter` instead of a single APNs sender; `app.state.sender` is preserved as an alias to `router.apple` so Live Activity / iOS-only paths keep working unchanged.

## API version bump

- `api_base_path` default flipped from `/v1` to `/v2` (`config.py`, `__init__.py`, `main.py` docstrings). The platform-aware device contract is the breaking change behind the bump.

## iOS

- **Device registration sends `platform=apple` explicitly** so the backend can dispatch the new branch correctly.
- **Marketing version → 1.6.0** (`project.pbxproj`).
- Rolled-up i18n + name-abbreviation work (already reviewed via PR #78 contributors / PR #79 i18n merges into this branch): `LanguageManager`, `LanguagePickerView`, `NameAbbrService`, locale-scoped course cache, RTL fixes, hardcoded-Chinese-string sweep across Settings/AddCourse/etc., and the `localization` + `name-abbr` submodules.

## Tests

- `backend/server/tests/test_dispatcher_android.py` — Android dispatch happy path, missing-token cancellation, bad-token vs transient classification.
- `backend/server/tests/test_dispatcher_classify.py` — `_classify` matrix for both platforms.
- `backend/server/tests/test_fcm_payload.py` — `build_fcm_alert_request` shape.
- Existing dispatcher / devices / schedule tests updated to construct a `PushRouter` instead of a bare sender.

## Test plan

- [ ] CI green (backend pytest, swift build/test)
- [ ] Verify FCM env vars documented for prod deploy (`TIGERDUCK_FCM_PROJECT_ID`, `TIGERDUCK_FCM_CREDENTIALS_PATH`)
- [ ] Smoke `POST /v2/devices/register` with `platform=android` against staging
- [ ] Confirm announcement push delivers to an Android test device
- [ ] Confirm iOS announcement / Live Activity paths still work after router refactor
- [ ] Confirm `/v1/...` callers have been migrated or proxied before deploy