### PR TITLE
fix(live): show location row only if available

### DIFF
--- a/swift/TigerDuck/Features/Score/Components/ScoreCourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/Score/Components/ScoreCourseDetailSheet.swift
@@ -202,7 +202,7 @@ struct ScoreCourseDetailSheet: View {
         case .exempted:
             return Color(hex: 0x85C1E9)
         case .passed:
-            return course.grade == String(localized: "score_grade_failed") ? Color(hex: 0xE74C3C) : Color(hex: 0x4ECDC4)
+            return course.isPassStatusPassed ? Color(hex: 0x4ECDC4) : Color(hex: 0xE74C3C)
         case .graded:
             let upper = course.grade.uppercased()
             if upper.hasPrefix("A") { return Color(hex: 0x2ECC71) }

--- a/swift/TigerDuck/Features/Score/Components/ScoreCourseRow.swift
+++ b/swift/TigerDuck/Features/Score/Components/ScoreCourseRow.swift
@@ -93,7 +93,7 @@ private struct GradeChip: View {
         case .exempted:
             return (String(localized: "score_grade_exempted"), Color(hex: 0x85C1E9), "checkmark.seal")
         case .passed:
-            let passed = course.grade == String(localized: "score_grade_passed")
+            let passed = course.isPassStatusPassed
             return (
                 passed
                     ? String(localized: "score_grade_passed")

--- a/swift/TigerDuck/Services/API/NTUST/NTUSTScoreModels.swift
+++ b/swift/TigerDuck/Services/API/NTUST/NTUSTScoreModels.swift
@@ -55,6 +55,20 @@ struct CourseGrade: Codable, Equatable, Sendable, Identifiable {
     /// Composite key — NTUST can legitimately reissue the same code across
     /// terms when a student retakes, so `code` alone is not unique.
     var id: String { "\(term)-\(code)-\(index ?? -1)" }
+
+    /// The school backend returns pass/fail text in its own language
+    /// ("通過"/"不通過"), so this must be derived from raw payload values
+    /// rather than UI localization.
+    var isPassStatusPassed: Bool {
+        let normalized = grade.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized.isEmpty { return true }
+
+        let failedMarkers: Set<String> = ["不通過", "未通過", "FAIL", "FAILED"]
+        if failedMarkers.contains(normalized.uppercased()) || failedMarkers.contains(normalized) {
+            return false
+        }
+        return true
+    }
 }
 
 enum CreditType: String, Codable, Equatable, Sendable, CaseIterable {

--- a/swift/TigerDuckLiveActivity/TigerDuckLiveActivityLiveActivity.swift
+++ b/swift/TigerDuckLiveActivity/TigerDuckLiveActivityLiveActivity.swift
@@ -207,7 +207,7 @@ private struct MetadataRowView: View {
 
                 if hasLocation {
                     HStack(spacing: 4) {
-                        if let loc = snapshot.locationText, !loc.isEmpty {
+                        if let loc = snapshot.locationText {
                             Image(systemName: "mappin.and.ellipse")
                             Text(loc)
                         }

--- a/swift/TigerDuckLiveActivity/TigerDuckLiveActivityLiveActivity.swift
+++ b/swift/TigerDuckLiveActivity/TigerDuckLiveActivityLiveActivity.swift
@@ -203,14 +203,18 @@ private struct MetadataRowView: View {
                 }
 
             case .inClass, .classPreparing:
-                HStack(spacing: 4) {
-                    if let loc = snapshot.locationText, !loc.isEmpty {
-                        Image(systemName: "mappin.and.ellipse")
-                        Text(loc)
-                    }
-                }
+                let hasLocation = snapshot.locationText?.isEmpty == false
 
-                Spacer(minLength: 8)
+                if hasLocation {
+                    HStack(spacing: 4) {
+                        if let loc = snapshot.locationText, !loc.isEmpty {
+                            Image(systemName: "mappin.and.ellipse")
+                            Text(loc)
+                        }
+                    }
+
+                    Spacer(minLength: 8)
+                }
 
                 HStack(spacing: 4) {
                     if !snapshot.subtitle.isEmpty {


### PR DESCRIPTION
Fix https://github.com/tigerduck-app/tigerduck-app/issues/101: Introduce a hasLocation flag and wrap the location HStack (and its Spacer) in a conditional so the location icon/text and spacing are only rendered when snapshot.locationText is non-empty. This avoids empty layout spacing when no location is provided and clarifies the conditional logic.