### PR TITLE
fix(library): lock orientation to portrait on Library page

### DIFF
--- a/swift/TigerDuck/App/OrientationLock.swift
+++ b/swift/TigerDuck/App/OrientationLock.swift
@@ -1,16 +1,19 @@
 import SwiftUI
 import UIKit
 
-/// Process-wide orientation lock consulted by `PushAppDelegate`'s
+/// Per-scene orientation lock consulted by `PushAppDelegate`'s
 /// `application(_:supportedInterfaceOrientationsFor:)`. Views push a mask via
 /// `.lockOrientation(...)` while they're on screen and receive a token; the
 /// lock falls back to the device-default mask (taken from Info.plist) when
-/// nothing is pushed.
+/// nothing is pushed for that scene.
 ///
-/// Locks are kept on a stack so that two concurrently visible owners (e.g.
-/// multiple `LibraryView` instances reachable from the tab bar, Home
-/// shortcuts, and More navigation) don't clear each other's lock when one
-/// disappears.
+/// Locks are stacked per `UIWindowScene` so that:
+///  - Multiple concurrently visible owners in the same scene (e.g. multiple
+///    `LibraryView` instances reachable from the tab bar, Home shortcuts,
+///    and More navigation) don't clear each other's lock when one
+///    disappears.
+///  - On iPad multi-window setups, locking in one scene doesn't affect the
+///    other scenes' supported orientations.
 @MainActor
 final class OrientationLock {
     static let shared = OrientationLock()
@@ -25,40 +28,53 @@ final class OrientationLock {
         let mask: UIInterfaceOrientationMask
     }
 
-    private var stack: [Entry] = []
+    /// Per-scene push stacks, keyed by scene identity. The top of each stack
+    /// is that scene's active mask. Empty stacks are cleared so vanished
+    /// scenes don't linger in the dictionary.
+    private var stacks: [ObjectIdentifier: [Entry]] = [:]
 
     private init() {}
 
-    /// The currently active mask — the top of the stack, or the device
-    /// default when nothing is pushed.
-    var mask: UIInterfaceOrientationMask {
-        stack.last?.mask ?? Self.deviceDefaultMask()
+    /// The active mask for the given window/scene, or the device default
+    /// when nothing is pushed for that scene.
+    func mask(for scene: UIWindowScene?) -> UIInterfaceOrientationMask {
+        guard let scene,
+              let top = stacks[ObjectIdentifier(scene)]?.last
+        else { return Self.deviceDefaultMask() }
+        return top.mask
     }
 
-    /// Push `newMask` and return a token the caller must hand back to
-    /// `release(_:)` so later locks aren't accidentally cleared.
+    /// Push `newMask` onto `scene`'s stack and request the OS to honor it.
+    /// Returns a token the caller must hand back to `release(_:from:)` so
+    /// later locks aren't accidentally cleared.
     @discardableResult
-    func push(_ newMask: UIInterfaceOrientationMask) -> Token {
+    func push(_ newMask: UIInterfaceOrientationMask, on scene: UIWindowScene) -> Token {
         let entry = Entry(token: Token(), mask: newMask)
-        stack.append(entry)
-        applyToActiveWindowScene(mask)
+        stacks[ObjectIdentifier(scene), default: []].append(entry)
+        apply(to: scene)
         return entry.token
     }
 
-    /// Remove the entry identified by `token`. If it was the top of the
-    /// stack, the next mask down (or the device default) takes over.
-    func release(_ token: Token) {
+    /// Remove the entry identified by `token` from `scene`'s stack. If it
+    /// was the top of the stack, the next mask down (or the device default)
+    /// takes over.
+    func release(_ token: Token, from scene: UIWindowScene) {
+        let key = ObjectIdentifier(scene)
+        guard var stack = stacks[key] else { return }
         let before = stack.count
         stack.removeAll { $0.token == token }
         guard stack.count != before else { return }
-        applyToActiveWindowScene(mask)
+        if stack.isEmpty {
+            stacks.removeValue(forKey: key)
+        } else {
+            stacks[key] = stack
+        }
+        apply(to: scene)
     }
 
-    private func applyToActiveWindowScene(_ mask: UIInterfaceOrientationMask) {
-        guard let scene = UIApplication.shared.connectedScenes
-            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
-        else { return }
-        scene.requestGeometryUpdate(.iOS(interfaceOrientations: mask)) { _ in }
+    private func apply(to scene: UIWindowScene) {
+        let active = mask(for: scene)
+        scene.requestGeometryUpdate(.iOS(interfaceOrientations: active)) { _ in }
         scene.keyWindow?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
     }
 
@@ -69,29 +85,90 @@ final class OrientationLock {
 
 private struct OrientationLockModifier: ViewModifier {
     let mask: UIInterfaceOrientationMask
-    @State private var token: OrientationLock.Token?
+    @State private var registration: Registration?
 
     func body(content: Content) -> some View {
         content
-            .onAppear {
-                if token == nil {
-                    token = OrientationLock.shared.push(mask)
+            .background(
+                SceneFinder { newScene in
+                    bind(to: newScene)
                 }
-            }
-            .onDisappear {
-                if let token {
-                    OrientationLock.shared.release(token)
-                }
-                token = nil
-            }
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+            )
+            .onDisappear { releaseRegistration() }
+    }
+
+    private func bind(to scene: UIWindowScene?) {
+        if registration?.scene === scene { return }
+        releaseRegistration()
+        guard let scene else { return }
+        let token = OrientationLock.shared.push(mask, on: scene)
+        registration = Registration(token: token, scene: scene)
+    }
+
+    private func releaseRegistration() {
+        if let current = registration, let scene = current.scene {
+            OrientationLock.shared.release(current.token, from: scene)
+        }
+        registration = nil
+    }
+
+    @MainActor
+    private final class Registration {
+        let token: OrientationLock.Token
+        weak var scene: UIWindowScene?
+
+        init(token: OrientationLock.Token, scene: UIWindowScene) {
+            self.token = token
+            self.scene = scene
+        }
+    }
+}
+
+/// Tracks the `UIWindowScene` that owns the host SwiftUI view by observing
+/// `didMoveToWindow`. Reports `nil` when the view leaves its window so the
+/// modifier can release any lock owned by the previous scene.
+private struct SceneFinder: UIViewRepresentable {
+    let onScene: (UIWindowScene?) -> Void
+
+    func makeUIView(context: Context) -> SceneTrackingView {
+        SceneTrackingView(onScene: onScene)
+    }
+
+    func updateUIView(_ uiView: SceneTrackingView, context: Context) {
+        uiView.onScene = onScene
+    }
+}
+
+private final class SceneTrackingView: UIView {
+    var onScene: (UIWindowScene?) -> Void
+
+    init(onScene: @escaping (UIWindowScene?) -> Void) {
+        self.onScene = onScene
+        super.init(frame: .zero)
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not available")
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        onScene(window?.windowScene)
     }
 }
 
 extension View {
-    /// Locks the active scene to `mask` while the view is on screen and
-    /// stacks with other concurrently pushed locks; reverts to the device
-    /// default once the last lock is released. Used by Library QR code to
-    /// keep the pass aligned regardless of device rotation.
+    /// Locks the owning window scene to `mask` while the view is on screen,
+    /// stacking with other concurrently pushed locks on the same scene;
+    /// reverts to the device default for that scene once the last lock is
+    /// released. Other scenes (on iPad multi-window) are unaffected. Used by
+    /// Library QR code to keep the pass aligned regardless of device
+    /// rotation.
     func lockOrientation(_ mask: UIInterfaceOrientationMask) -> some View {
         modifier(OrientationLockModifier(mask: mask))
     }

--- a/swift/TigerDuck/App/OrientationLock.swift
+++ b/swift/TigerDuck/App/OrientationLock.swift
@@ -3,27 +3,55 @@ import UIKit
 
 /// Process-wide orientation lock consulted by `PushAppDelegate`'s
 /// `application(_:supportedInterfaceOrientationsFor:)`. Views push a mask via
-/// `.lockOrientation(...)` while they're on screen; the lock falls back to the
-/// device-default mask (taken from Info.plist) when nothing is pushed.
+/// `.lockOrientation(...)` while they're on screen and receive a token; the
+/// lock falls back to the device-default mask (taken from Info.plist) when
+/// nothing is pushed.
+///
+/// Locks are kept on a stack so that two concurrently visible owners (e.g.
+/// multiple `LibraryView` instances reachable from the tab bar, Home
+/// shortcuts, and More navigation) don't clear each other's lock when one
+/// disappears.
 @MainActor
 final class OrientationLock {
     static let shared = OrientationLock()
 
-    private(set) var mask: UIInterfaceOrientationMask
-
-    private init() {
-        mask = Self.deviceDefaultMask()
+    struct Token: Hashable, Sendable {
+        fileprivate let id: UUID
+        fileprivate init() { id = UUID() }
     }
 
-    func push(_ newMask: UIInterfaceOrientationMask) {
-        mask = newMask
-        applyToActiveWindowScene(newMask)
+    private struct Entry {
+        let token: Token
+        let mask: UIInterfaceOrientationMask
     }
 
-    func reset() {
-        let restored = Self.deviceDefaultMask()
-        mask = restored
-        applyToActiveWindowScene(restored)
+    private var stack: [Entry] = []
+
+    private init() {}
+
+    /// The currently active mask — the top of the stack, or the device
+    /// default when nothing is pushed.
+    var mask: UIInterfaceOrientationMask {
+        stack.last?.mask ?? Self.deviceDefaultMask()
+    }
+
+    /// Push `newMask` and return a token the caller must hand back to
+    /// `release(_:)` so later locks aren't accidentally cleared.
+    @discardableResult
+    func push(_ newMask: UIInterfaceOrientationMask) -> Token {
+        let entry = Entry(token: Token(), mask: newMask)
+        stack.append(entry)
+        applyToActiveWindowScene(mask)
+        return entry.token
+    }
+
+    /// Remove the entry identified by `token`. If it was the top of the
+    /// stack, the next mask down (or the device default) takes over.
+    func release(_ token: Token) {
+        let before = stack.count
+        stack.removeAll { $0.token == token }
+        guard stack.count != before else { return }
+        applyToActiveWindowScene(mask)
     }
 
     private func applyToActiveWindowScene(_ mask: UIInterfaceOrientationMask) {
@@ -41,18 +69,29 @@ final class OrientationLock {
 
 private struct OrientationLockModifier: ViewModifier {
     let mask: UIInterfaceOrientationMask
+    @State private var token: OrientationLock.Token?
 
     func body(content: Content) -> some View {
         content
-            .onAppear { OrientationLock.shared.push(mask) }
-            .onDisappear { OrientationLock.shared.reset() }
+            .onAppear {
+                if token == nil {
+                    token = OrientationLock.shared.push(mask)
+                }
+            }
+            .onDisappear {
+                if let token {
+                    OrientationLock.shared.release(token)
+                }
+                token = nil
+            }
     }
 }
 
 extension View {
-    /// Locks the active scene to `mask` while the view is on screen; reverts
-    /// to the device default when it disappears. Used by Library QR code to
-    /// keep the pass aligned on iPad regardless of device rotation.
+    /// Locks the active scene to `mask` while the view is on screen and
+    /// stacks with other concurrently pushed locks; reverts to the device
+    /// default once the last lock is released. Used by Library QR code to
+    /// keep the pass aligned regardless of device rotation.
     func lockOrientation(_ mask: UIInterfaceOrientationMask) -> some View {
         modifier(OrientationLockModifier(mask: mask))
     }

--- a/swift/TigerDuck/App/OrientationLock.swift
+++ b/swift/TigerDuck/App/OrientationLock.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+import UIKit
+
+/// Process-wide orientation lock consulted by `PushAppDelegate`'s
+/// `application(_:supportedInterfaceOrientationsFor:)`. Views push a mask via
+/// `.lockOrientation(...)` while they're on screen; the lock falls back to the
+/// device-default mask (taken from Info.plist) when nothing is pushed.
+@MainActor
+final class OrientationLock {
+    static let shared = OrientationLock()
+
+    private(set) var mask: UIInterfaceOrientationMask
+
+    private init() {
+        mask = Self.deviceDefaultMask()
+    }
+
+    func push(_ newMask: UIInterfaceOrientationMask) {
+        mask = newMask
+        applyToActiveWindowScene(newMask)
+    }
+
+    func reset() {
+        let restored = Self.deviceDefaultMask()
+        mask = restored
+        applyToActiveWindowScene(restored)
+    }
+
+    private func applyToActiveWindowScene(_ mask: UIInterfaceOrientationMask) {
+        guard let scene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+        else { return }
+        scene.requestGeometryUpdate(.iOS(interfaceOrientations: mask)) { _ in }
+        scene.keyWindow?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+    }
+
+    private static func deviceDefaultMask() -> UIInterfaceOrientationMask {
+        UIDevice.current.userInterfaceIdiom == .pad ? .all : .portrait
+    }
+}
+
+private struct OrientationLockModifier: ViewModifier {
+    let mask: UIInterfaceOrientationMask
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { OrientationLock.shared.push(mask) }
+            .onDisappear { OrientationLock.shared.reset() }
+    }
+}
+
+extension View {
+    /// Locks the active scene to `mask` while the view is on screen; reverts
+    /// to the device default when it disappears. Used by Library QR code to
+    /// keep the pass aligned on iPad regardless of device rotation.
+    func lockOrientation(_ mask: UIInterfaceOrientationMask) -> some View {
+        modifier(OrientationLockModifier(mask: mask))
+    }
+}

--- a/swift/TigerDuck/App/PushAppDelegate.swift
+++ b/swift/TigerDuck/App/PushAppDelegate.swift
@@ -29,7 +29,7 @@ final class PushAppDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication,
         supportedInterfaceOrientationsFor window: UIWindow?
     ) -> UIInterfaceOrientationMask {
-        OrientationLock.shared.mask
+        OrientationLock.shared.mask(for: window?.windowScene)
     }
 
     func application(

--- a/swift/TigerDuck/App/PushAppDelegate.swift
+++ b/swift/TigerDuck/App/PushAppDelegate.swift
@@ -27,6 +27,13 @@ final class PushAppDelegate: NSObject, UIApplicationDelegate {
 
     func application(
         _ application: UIApplication,
+        supportedInterfaceOrientationsFor window: UIWindow?
+    ) -> UIInterfaceOrientationMask {
+        OrientationLock.shared.mask
+    }
+
+    func application(
+        _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
         logger.info("APNs registered (len=\(deviceToken.count, privacy: .public))")

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -32,6 +32,7 @@ struct LibraryView: View {
             .padding(.bottom, TigerDuckTheme.Spacing.xxl)
         }
         .background(Color.backgroundPrimary)
+        .lockOrientation(.portrait)
         .onAppear {
             viewModel.load()
             viewModel.onAppear()


### PR DESCRIPTION
Library QR pass would shift off-center on iPad when the device rotated, because the app supports all orientations on iPad. Add a process-wide OrientationLock consulted by PushAppDelegate's supportedInterfaceOrientations hook; LibraryView pushes .portrait on appear and resets on disappear so the QR code stays aligned.

Closes #81