### PR TITLE
feat(tabbar): use short labels in bottom tab bar

### DIFF
--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -32,12 +32,12 @@ struct MainTabView: View {
     var body: some View {
         TabView(selection: $selectedTab) {
             ForEach(visibleTabs) { feature in
-                Tab(feature.displayName, systemImage: feature.iconName, value: feature) {
+                Tab(feature.tabBarDisplayName, systemImage: feature.iconName, value: feature) {
                     viewForFeature(feature)
                 }
             }
 
-            Tab(AppFeature.more.displayName, systemImage: AppFeature.more.iconName, value: .more) {
+            Tab(AppFeature.more.tabBarDisplayName, systemImage: AppFeature.more.iconName, value: .more) {
                 MoreView()
             }
         }

--- a/swift/TigerDuck/Models/Domain/AppFeature.swift
+++ b/swift/TigerDuck/Models/Domain/AppFeature.swift
@@ -54,6 +54,32 @@ enum AppFeature: String, CaseIterable, Identifiable, Codable {
         }
     }
 
+    /// Tab-bar label. English locales otherwise truncate long labels (e.g.
+    /// "Course selection") unevenly across tabs; the `_short` variants are
+    /// hand-tuned in the localization repo. Settings has no short form
+    /// because it never appears in the tab bar.
+    var tabBarDisplayName: String {
+        switch self {
+        case .home: String(localized: "feature_home_short")
+        case .classTable: String(localized: "feature_class_table_short")
+        case .calendar: String(localized: "feature_calendar_short")
+        case .announcements: String(localized: "feature_announcements_short")
+        case .library: String(localized: "feature_library_short")
+        case .gpa: String(localized: "feature_score_short")
+        case .courseSelection: String(localized: "feature_course_selection_short")
+        case .graduationRequirements: String(localized: "feature_graduation_requirements_short")
+        case .discussionRoom: String(localized: "feature_discussion_room_short")
+        case .libraryLecture: String(localized: "feature_library_lecture_short")
+        case .freeLunch: String(localized: "feature_free_lunch_short")
+        case .clubs: String(localized: "feature_clubs_short")
+        case .emptyClassroom: String(localized: "feature_empty_classroom_short")
+        case .scholarship: String(localized: "feature_scholarship_short")
+        case .englishVocab: String(localized: "feature_english_vocab_short")
+        case .more: String(localized: "feature_more_short")
+        case .settings: displayName
+        }
+    }
+
     var iconName: String {
         switch self {
         case .home: "house.fill"


### PR DESCRIPTION
The bottom tab bar showed full feature names ("Course selection",
"Graduation requirements", ...), which truncate unevenly in English and
leave the tabs visually lopsided. Localization repo already maintains
hand-tuned `feature_*_short` keys for this purpose.

Add an AppFeature.tabBarDisplayName that maps each case to its short
key, and route MainTabView through it. Other surfaces (More page, tab
editor, navigation titles) keep displayName so the full text remains
where it fits. Bump localization submodule to pick up the short keys.

Closes https://github.com/tigerduck-app/tigerduck-app/issues/91