### PR TITLE
feat(course-search): live, bilingual, simplified-aware add-course flow

### DIFF
--- a/swift/TigerDuck/Features/ClassTable/ClassTableView.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableView.swift
@@ -100,9 +100,13 @@ struct ClassTableView: View {
                     existingCourseNos: Set(viewModel.courses.map(\.courseNo)),
                     onAdd: { viewModel.addCourse($0) },
                     onRemove: { courseNo in
-                        if let course = viewModel.courses.first(where: { $0.courseNo == courseNo }) {
-                            viewModel.deleteCourse(course)
-                        }
+                        // AddCourseSheet only invokes onRemove for courses
+                        // added in this session, so route through the
+                        // user-added-only path. Using deleteCourse here
+                        // would tombstone the courseNo in deletedCourseNos
+                        // and later hide any real enrolled course sharing
+                        // the same code from cache/network merges.
+                        viewModel.removeUserAddedCourse(courseNo: courseNo)
                     }
                 )
                 .presentationDetents([.medium, .large])

--- a/swift/TigerDuck/Features/ClassTable/ClassTableView.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableView.swift
@@ -98,7 +98,12 @@ struct ClassTableView: View {
                 AddCourseSheet(
                     semester: viewModel.currentSemester,
                     existingCourseNos: Set(viewModel.courses.map(\.courseNo)),
-                    onAdd: { viewModel.addCourse($0) }
+                    onAdd: { viewModel.addCourse($0) },
+                    onRemove: { courseNo in
+                        if let course = viewModel.courses.first(where: { $0.courseNo == courseNo }) {
+                            viewModel.deleteCourse(course)
+                        }
+                    }
                 )
                 .presentationDetents([.medium, .large])
             }

--- a/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
@@ -389,6 +389,26 @@ final class ClassTableViewModel {
         broadcastLocalChange()
     }
 
+    /// Undo a not-yet-committed user-added course without tombstoning the
+    /// `courseNo`. Used by AddCourseSheet's tap-to-toggle path so the user
+    /// can add a course, then immediately tap it again to back out, without
+    /// poisoning `deletedCourseNos` — which would later hide any real
+    /// enrolled course sharing the same `courseNo` from cache/network merges
+    /// (see `applyCustomizations`).
+    ///
+    /// Defensive: only removes courses that came from the user-added cache
+    /// (`moodleIdNumber == nil`). A stray call against a real enrolled course
+    /// is a no-op, so callers can route through this without risking the
+    /// regular drop/hide flow.
+    func removeUserAddedCourse(courseNo: String) {
+        guard let course = courses.first(where: { $0.courseNo == courseNo }),
+              course.moodleIdNumber == nil
+        else { return }
+        courses.removeAll { $0.courseNo == courseNo }
+        persistUserAddedCourses()
+        broadcastLocalChange()
+    }
+
     func startRename(_ course: SDCourse) {
         courseToRename = course
         renameText = course.courseName

--- a/swift/TigerDuck/Features/ClassTable/Components/AddCourseSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/AddCourseSheet.swift
@@ -7,17 +7,23 @@ struct AddCourseSheet: View {
     let semester: String
     let existingCourseNos: Set<String>
     let onAdd: (SDCourse) -> Void
+    var onRemove: ((String) -> Void)? = nil
 
     /// Course codes are ASCII alphanumeric and always contain at least one digit
     /// (e.g., "EC1013701", "GE1002101"). Anything else is treated as a name or
     /// teacher query.
     private static let courseCodePattern = #"^[A-Za-z0-9]+$"#
 
+    /// Debounce window before firing an automatic search. Mirrors the Android
+    /// AddCourseSheet so the QueryCourse API isn't hammered on every keystroke.
+    private static let liveSearchDebounce: Duration = .milliseconds(350)
+
     @State private var searchText = ""
-    @State private var searchResults: [CourseSearchResult] = []
+    @State private var primaryResults: [CourseSearchResult] = []
+    @State private var secondaryNamesByNo: [String: String] = [:]
     @State private var isSearching = false
     @State private var errorMessage: String?
-    @State private var addedCourseNo: String?
+    @State private var sessionAddedCourseNos: Set<String> = []
     @State private var searchTask: Task<Void, Never>?
     @FocusState private var searchFocused: Bool
 
@@ -30,7 +36,8 @@ struct AddCourseSheet: View {
                         .textInputAutocapitalization(.never)
                         .focused($searchFocused)
                         .submitLabel(.search)
-                        .onSubmit { search() }
+                        .onSubmit { triggerSearch(debounced: false) }
+                        .onChange(of: searchText) { _, _ in triggerSearch(debounced: true) }
                 } footer: {
                     Label(String(localized: "add_course_example"), systemImage: "info.circle")
                         .font(.caption)
@@ -54,7 +61,7 @@ struct AddCourseSheet: View {
                     }
                 }
 
-                if !searchResults.isEmpty {
+                if !primaryResults.isEmpty {
                     Section {
                         resultRows
                     }
@@ -72,24 +79,24 @@ struct AddCourseSheet: View {
         }
     }
 
-    private func looksLikeCourseCode(_ text: String) -> Bool {
-        guard text.range(of: Self.courseCodePattern, options: .regularExpression) != nil else { return false }
-        return text.contains(where: { $0.isNumber })
-    }
-
     @ViewBuilder
     private var resultRows: some View {
         let grouped = groupedResults
         ForEach(grouped, id: \.courseNo) { group in
-            let alreadyExists = existingCourseNos.contains(group.courseNo)
-                || addedCourseNo == group.courseNo
+            let isPreExisting = existingCourseNos.contains(group.courseNo)
+            let isSessionAdded = sessionAddedCourseNos.contains(group.courseNo)
+            let isPresent = isPreExisting || isSessionAdded
             Button {
-                guard !alreadyExists else { return }
-                addCourse(from: group)
+                if isSessionAdded {
+                    sessionAddedCourseNos.remove(group.courseNo)
+                    onRemove?(group.courseNo)
+                } else if !isPreExisting {
+                    addCourse(from: group)
+                }
             } label: {
                 HStack {
                     VStack(alignment: .leading, spacing: 4) {
-                        Text(group.courseName)
+                        Text(group.displayName)
                             .font(TigerDuckTheme.Typography.headline)
                             .foregroundStyle(Color.textPrimary)
                         Text(String(format: String(localized: "add_course_result_meta"), group.courseNo, group.instructor, group.credits))
@@ -107,7 +114,7 @@ struct AddCourseSheet: View {
                         }
                     }
                     Spacer()
-                    if alreadyExists {
+                    if isPresent {
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundStyle(.green)
                     } else {
@@ -116,68 +123,149 @@ struct AddCourseSheet: View {
                     }
                 }
             }
-            .disabled(alreadyExists)
+            // Pre-existing enrolled courses are not removable from this sheet
+            // — the user already has them, and tap-to-remove here would be a
+            // dangerous escape hatch. Only courses added in *this* session
+            // can be toggled off.
+            .disabled(isPreExisting && !isSessionAdded)
         }
     }
 
-    // MARK: - Search
+    // MARK: - Search dispatch
 
-    private func search() {
+    private func triggerSearch(debounced: Bool) {
         let trimmed = searchText.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return }
-        errorMessage = nil
-        isSearching = true
-        searchResults = []
-        addedCourseNo = nil
         searchTask?.cancel()
 
-        let isCourseCode = looksLikeCourseCode(trimmed)
-
-        let language = LanguageManager.resolvedCourseApiLanguage(
-            appLanguage: Defaults[.appLanguage]
-        )
+        if trimmed.isEmpty {
+            primaryResults = []
+            secondaryNamesByNo = [:]
+            errorMessage = nil
+            isSearching = false
+            return
+        }
 
         searchTask = Task {
-            do {
-                let results: [CourseSearchResult]
-                if isCourseCode {
-                    results = try await CourseLookupService.lookupCourse(
-                        semester: semester, courseNo: trimmed, language: language
-                    )
-                } else {
-                    async let byName = CourseLookupService.searchCourses(
-                        semester: semester, courseName: trimmed, language: language
-                    )
-                    async let byTeacher = CourseLookupService.searchByTeacher(
-                        semester: semester, teacher: trimmed, language: language
-                    )
-                    let nameResults = (try? await byName) ?? []
-                    try Task.checkCancellation()
-                    let teacherResults = (try? await byTeacher) ?? []
-                    try Task.checkCancellation()
-                    results = Self.merge(nameResults, teacherResults)
-                }
-                try Task.checkCancellation()
-                await MainActor.run {
-                    searchResults = results
-                    isSearching = false
-                    if results.isEmpty {
-                        errorMessage = String(localized: "add_course_not_found")
-                    }
-                }
-            } catch is CancellationError {
-                return
-            } catch {
-                AppLogger.captureError(error, context: [
-                    "feature": "addCourseSheet.search",
-                    "mode": isCourseCode ? "courseCode" : "nameOrTeacher",
-                ])
-                await MainActor.run {
-                    isSearching = false
-                    errorMessage = String(format: String(localized: "add_course_search_failed"), error.localizedDescription)
+            if debounced {
+                try? await Task.sleep(for: Self.liveSearchDebounce)
+                if Task.isCancelled { return }
+            }
+            await runSearch(query: trimmed)
+        }
+    }
+
+    @MainActor
+    private func runSearch(query: String) async {
+        errorMessage = nil
+        isSearching = true
+        primaryResults = []
+        secondaryNamesByNo = [:]
+
+        let isCourseCode = Self.looksLikeCourseCode(query)
+        let uiLanguage = LanguageManager.resolvedCourseApiLanguage(
+            appLanguage: Defaults[.appLanguage]
+        )
+        // Send the traditional form to the zh API so simplified queries
+        // ("隐私") still match traditional course names ("隱私與資訊安全").
+        let zhQuery = Self.toTraditional(query)
+        let enQuery = query
+
+        do {
+            async let zhTask = Self.fetchResults(
+                semester: semester, query: zhQuery, language: "zh", isCourseCode: isCourseCode
+            )
+            async let enTask = Self.fetchResults(
+                semester: semester, query: enQuery, language: "en", isCourseCode: isCourseCode
+            )
+            let zhResults = await zhTask
+            try Task.checkCancellation()
+            let enResults = await enTask
+            try Task.checkCancellation()
+
+            // The name-search API matches against the queried language only,
+            // so searching "隱私" against the EN endpoint returns nothing even
+            // when the course exists. Fill any cross-language gaps via the
+            // language-agnostic lookupCourse (keyed by code).
+            let (zhFilled, enFilled) = await Self.fillCrossLanguage(
+                semester: semester, zhResults: zhResults, enResults: enResults
+            )
+            try Task.checkCancellation()
+
+            // The primary list (what we show + group) comes from the UI
+            // language; the secondary map carries the parenthetical name.
+            let primary = uiLanguage == "en" ? enFilled : zhFilled
+            let secondary = uiLanguage == "en" ? zhFilled : enFilled
+            let secondaryByNo = Dictionary(
+                secondary.map { ($0.CourseNo, $0.CourseName) },
+                uniquingKeysWith: { first, _ in first }
+            )
+
+            primaryResults = primary
+            secondaryNamesByNo = secondaryByNo
+            isSearching = false
+            if primary.isEmpty {
+                errorMessage = String(localized: "add_course_not_found")
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            AppLogger.captureError(error, context: [
+                "feature": "addCourseSheet.search",
+                "mode": isCourseCode ? "courseCode" : "nameOrTeacher",
+            ])
+            isSearching = false
+            errorMessage = String(format: String(localized: "add_course_search_failed"), error.localizedDescription)
+        }
+    }
+
+    private static func fetchResults(
+        semester: String, query: String, language: String, isCourseCode: Bool
+    ) async -> [CourseSearchResult] {
+        if isCourseCode {
+            return (try? await CourseLookupService.lookupCourse(
+                semester: semester, courseNo: query, language: language
+            )) ?? []
+        }
+        async let byName = (try? CourseLookupService.searchCourses(
+            semester: semester, courseName: query, language: language
+        )) ?? []
+        async let byTeacher = (try? CourseLookupService.searchByTeacher(
+            semester: semester, teacher: query, language: language
+        )) ?? []
+        return merge(await byName, await byTeacher)
+    }
+
+    private static func fillCrossLanguage(
+        semester: String,
+        zhResults: [CourseSearchResult],
+        enResults: [CourseSearchResult]
+    ) async -> ([CourseSearchResult], [CourseSearchResult]) {
+        let zhByNo = Set(zhResults.map(\.CourseNo))
+        let enByNo = Set(enResults.map(\.CourseNo))
+        let missingZh = enByNo.subtracting(zhByNo)
+        let missingEn = zhByNo.subtracting(enByNo)
+
+        async let zhExtras: [CourseSearchResult] = withTaskGroup(of: [CourseSearchResult].self) { group in
+            for no in missingZh {
+                group.addTask {
+                    (try? await CourseLookupService.lookupCourse(
+                        semester: semester, courseNo: no, language: "zh"
+                    )) ?? []
                 }
             }
+            return await group.reduce(into: []) { $0.append(contentsOf: $1) }
         }
+        async let enExtras: [CourseSearchResult] = withTaskGroup(of: [CourseSearchResult].self) { group in
+            for no in missingEn {
+                group.addTask {
+                    (try? await CourseLookupService.lookupCourse(
+                        semester: semester, courseNo: no, language: "en"
+                    )) ?? []
+                }
+            }
+            return await group.reduce(into: []) { $0.append(contentsOf: $1) }
+        }
+        return (zhResults + (await zhExtras), enResults + (await enExtras))
     }
 
     /// Merge name and teacher results preserving order; name results come first,
@@ -197,11 +285,25 @@ struct AddCourseSheet: View {
         return merged
     }
 
+    // MARK: - Heuristics
+
+    private static func looksLikeCourseCode(_ text: String) -> Bool {
+        guard text.range(of: courseCodePattern, options: .regularExpression) != nil else { return false }
+        return text.contains(where: { $0.isNumber })
+    }
+
+    private static let hansHantTransform = StringTransform(rawValue: "Hans-Hant")
+
+    private static func toTraditional(_ text: String) -> String {
+        text.applyingTransform(hansHantTransform, reverse: false) ?? text
+    }
+
     // MARK: - Group & Add
 
     private struct GroupedCourse {
         let courseNo: String
-        let courseName: String
+        let primaryName: String
+        let secondaryName: String?
         let instructor: String
         let credits: Int
         let classroom: String
@@ -209,13 +311,21 @@ struct AddCourseSheet: View {
         let maxCount: Int
         let schedule: [Int: [String]]
         let nodeDisplay: String
+
+        var displayName: String {
+            guard let secondary = secondaryName,
+                  !secondary.isEmpty,
+                  secondary != primaryName
+            else { return primaryName }
+            return "\(primaryName) (\(secondary))"
+        }
     }
 
     private var groupedResults: [GroupedCourse] {
         var seen: [String: GroupedCourse] = [:]
         var order: [String] = []
 
-        for result in searchResults {
+        for result in primaryResults {
             let key = result.CourseNo
             if var existing = seen[key] {
                 let partial = CourseLookupService.parseNodeToSchedule(result.Node)
@@ -234,7 +344,8 @@ struct AddCourseSheet: View {
 
                 existing = GroupedCourse(
                     courseNo: existing.courseNo,
-                    courseName: existing.courseName,
+                    primaryName: existing.primaryName,
+                    secondaryName: existing.secondaryName,
                     instructor: existing.instructor,
                     credits: existing.credits,
                     classroom: newClassroom,
@@ -248,7 +359,8 @@ struct AddCourseSheet: View {
                 order.append(key)
                 seen[key] = GroupedCourse(
                     courseNo: result.CourseNo,
-                    courseName: result.CourseName,
+                    primaryName: result.CourseName,
+                    secondaryName: secondaryNamesByNo[result.CourseNo],
                     instructor: result.CourseTeacher,
                     credits: Int(result.CreditPoint) ?? 0,
                     classroom: result.ClassRoomNo ?? "",
@@ -266,7 +378,7 @@ struct AddCourseSheet: View {
     private func addCourse(from group: GroupedCourse) {
         let course = SDCourse(
             courseNo: group.courseNo,
-            courseName: group.courseName,
+            courseName: group.primaryName,
             instructor: group.instructor,
             credits: group.credits,
             classroom: group.classroom,
@@ -276,6 +388,6 @@ struct AddCourseSheet: View {
             moodleIdNumber: nil
         )
         onAdd(course)
-        addedCourseNo = group.courseNo
+        sessionAddedCourseNos.insert(group.courseNo)
     }
 }

--- a/swift/TigerDuck/Features/ClassTable/Components/AddCourseSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/AddCourseSheet.swift
@@ -177,9 +177,9 @@ struct AddCourseSheet: View {
             async let enTask = Self.fetchResults(
                 semester: semester, query: enQuery, language: "en", isCourseCode: isCourseCode
             )
-            let zhResults = await zhTask
+            let zhResults = try await zhTask
             try Task.checkCancellation()
-            let enResults = await enTask
+            let enResults = try await enTask
             try Task.checkCancellation()
 
             // The name-search API matches against the queried language only,
@@ -220,19 +220,35 @@ struct AddCourseSheet: View {
 
     private static func fetchResults(
         semester: String, query: String, language: String, isCourseCode: Bool
-    ) async -> [CourseSearchResult] {
+    ) async throws -> [CourseSearchResult] {
         if isCourseCode {
-            return (try? await CourseLookupService.lookupCourse(
+            return try await CourseLookupService.lookupCourse(
                 semester: semester, courseNo: query, language: language
-            )) ?? []
+            )
         }
-        async let byName = (try? CourseLookupService.searchCourses(
+        async let byNameTask = CourseLookupService.searchCourses(
             semester: semester, courseName: query, language: language
-        )) ?? []
-        async let byTeacher = (try? CourseLookupService.searchByTeacher(
+        )
+        async let byTeacherTask = CourseLookupService.searchByTeacher(
             semester: semester, teacher: query, language: language
-        )) ?? []
-        return merge(await byName, await byTeacher)
+        )
+
+        // Best-effort merge of the two name endpoints: tolerate one failing
+        // (the teacher endpoint commonly throws when the query is clearly
+        // not a teacher name), but if BOTH fail propagate the error so the
+        // caller can surface `add_course_search_failed` instead of the
+        // misleading `add_course_not_found` empty-results path.
+        var nameResults: [CourseSearchResult] = []
+        var teacherResults: [CourseSearchResult] = []
+        var nameError: Error?
+        var teacherError: Error?
+        do { nameResults = try await byNameTask } catch { nameError = error }
+        do { teacherResults = try await byTeacherTask } catch { teacherError = error }
+
+        if let nameError, teacherError != nil {
+            throw nameError
+        }
+        return merge(nameResults, teacherResults)
     }
 
     private static func fillCrossLanguage(

--- a/swift/TigerDuck/Features/ClassTable/Components/AddCourseSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/AddCourseSheet.swift
@@ -323,6 +323,13 @@ struct AddCourseSheet: View {
         let instructor: String
         let credits: Int
         let classroom: String
+        /// Per-(weekday, period) classroom map, mirroring the structure that
+        /// ``AppServiceBridge.buildSDCourse`` produces for the normal fetch
+        /// path. Required so a newly-added course that meets in different
+        /// rooms on different days shows the correct location in
+        /// ``CourseDetailSheet``, Home time cards, and the Live Activity
+        /// (all of which call ``SDCourse.classroom(for:)``).
+        let classroomMap: [String: String]
         let enrolledCount: Int
         let maxCount: Int
         let schedule: [Int: [String]]
@@ -343,8 +350,17 @@ struct AddCourseSheet: View {
 
         for result in primaryResults {
             let key = result.CourseNo
+            let partial = CourseLookupService.parseNodeToSchedule(result.Node)
+            // Mirror AppServiceBridge.buildSDCourse: dedupe a row's rooms,
+            // then assign the joined string to every (day, period) the row
+            // covers. Without this, `classroom(for:)` falls back to the
+            // combined room list and can display the wrong day's room.
+            var rowSeen = Set<String>()
+            let rowRoomParts = SDCourse.splitRoom(result.ClassRoomNo ?? "")
+                .filter { rowSeen.insert($0).inserted }
+            let rowRoom = rowRoomParts.joined(separator: ", ")
+
             if var existing = seen[key] {
-                let partial = CourseLookupService.parseNodeToSchedule(result.Node)
                 var merged = existing.schedule
                 for (day, periods) in partial {
                     merged[day, default: []].append(contentsOf: periods)
@@ -358,6 +374,15 @@ struct AddCourseSheet: View {
                     (result.Node == nil || result.Node!.isEmpty) ? existing.nodeDisplay :
                     "\(existing.nodeDisplay), \(result.Node!)"
 
+                var mergedMap = existing.classroomMap
+                if !rowRoom.isEmpty {
+                    for (day, periods) in partial {
+                        for period in periods {
+                            mergedMap["\(day)-\(period)"] = rowRoom
+                        }
+                    }
+                }
+
                 existing = GroupedCourse(
                     courseNo: existing.courseNo,
                     primaryName: existing.primaryName,
@@ -365,6 +390,7 @@ struct AddCourseSheet: View {
                     instructor: existing.instructor,
                     credits: existing.credits,
                     classroom: newClassroom,
+                    classroomMap: mergedMap,
                     enrolledCount: existing.enrolledCount,
                     maxCount: existing.maxCount,
                     schedule: merged,
@@ -372,6 +398,14 @@ struct AddCourseSheet: View {
                 )
                 seen[key] = existing
             } else {
+                var initialMap: [String: String] = [:]
+                if !rowRoom.isEmpty {
+                    for (day, periods) in partial {
+                        for period in periods {
+                            initialMap["\(day)-\(period)"] = rowRoom
+                        }
+                    }
+                }
                 order.append(key)
                 seen[key] = GroupedCourse(
                     courseNo: result.CourseNo,
@@ -380,9 +414,10 @@ struct AddCourseSheet: View {
                     instructor: result.CourseTeacher,
                     credits: Int(result.CreditPoint) ?? 0,
                     classroom: result.ClassRoomNo ?? "",
+                    classroomMap: initialMap,
                     enrolledCount: result.ChooseStudent ?? 0,
                     maxCount: Int(result.Restrict2 ?? "0") ?? 0,
-                    schedule: CourseLookupService.parseNodeToSchedule(result.Node),
+                    schedule: partial,
                     nodeDisplay: result.Node ?? ""
                 )
             }
@@ -401,7 +436,9 @@ struct AddCourseSheet: View {
             enrolledCount: group.enrolledCount,
             maxCount: group.maxCount,
             schedule: group.schedule,
-            moodleIdNumber: nil
+            moodleIdNumber: nil,
+            semester: semester,
+            classroomMap: group.classroomMap
         )
         onAdd(course)
         sessionAddedCourseNos.insert(group.courseNo)


### PR DESCRIPTION
Three related Class Table improvements bundled into one rewrite of
AddCourseSheet:

- Live search: drop the Enter-key gate. .onChange(of: searchText)
  debounces 350ms (matching Android's AddCourseSheet) before firing
  QueryCourse, with each keystroke cancelling the prior task. Clearing
  the field resets results immediately.
- Bilingual results: query the zh and en endpoints in parallel, then
  fill cross-language gaps via the language-agnostic lookupCourse so
  results carry both names. UI locale picks the primary; the other
  language renders as "(English Course Name)" / "(中文課堂名稱)".
- Simplified→Traditional: apply the Hans-Hant ICU transform before
  hitting the zh endpoint so queries like "隐私" still match
  "隱私與資訊安全".
- Toggle: tapping a course added in this session removes it
  (sessionAddedCourseNos). Pre-existing enrolled courses remain
  non-removable from this sheet — that path stays in the class table.

Closes #82, #84, #89