### PR TITLE
feat(class-table): customName overlay on SDCourse, propagated everywhere

### DIFF
--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -104,6 +104,7 @@ final class AppState {
             await MoodleTokenMigration.runIfNeeded()
             HomeSectionTitleMigration.runIfNeeded()
             ClassroomAbbrCacheMigration.runIfNeeded()
+            CustomNameCacheMigration.runIfNeeded()
             // Add future migrations here in sequence.
         }
     }

--- a/swift/TigerDuck/Extensions/SDAssignment+DisplayName.swift
+++ b/swift/TigerDuck/Extensions/SDAssignment+DisplayName.swift
@@ -1,17 +1,28 @@
 import Foundation
 
 extension SDAssignment {
-    /// Course label to render in assignment cells, notification bodies, and
-    /// Live Activity rows. Respects the user's course-rename override
-    /// (`SDCourse.customName`) so a renamed course keeps its alias on every
-    /// assignment surface, not just the class table. Falls back to the API
-    /// course name embedded in the assignment when no override exists.
+    /// Course label resolution with optional in-memory course context.
     ///
-    /// The lookup reads `DataCache.loadCourseCustomNames()` (a JSON dict on
-    /// disk). Dict is keyed by courseNo and typically a handful of entries
-    /// — a single read per render is fine.
-    var displayCourseName: String {
+    /// When a caller already holds the canonical `SDCourse` (with
+    /// `customName` applied in-memory), pass it via `matching:` so the
+    /// label reflects the freshest alias. Without context, fall back to the
+    /// on-disk override dictionary, then to the cached `courseName` on the
+    /// assignment.
+    ///
+    /// The on-disk path reads `DataCache.loadCourseCustomNames()` (a JSON
+    /// dict). It can be stale relative to in-memory `SDCourse` state — e.g.
+    /// right after a rename, before persistence settles — which is why an
+    /// explicit `matching` course wins when supplied.
+    func displayCourseName(matching course: SDCourse?) -> String {
+        if let course, course.courseNo == courseNo {
+            return course.displayName
+        }
         let overrides = DataCache.shared.loadCourseCustomNames()
         return overrides[courseNo] ?? courseName
     }
+
+    /// Convenience for callers without course context. Prefer
+    /// `displayCourseName(matching:)` when the canonical course list is
+    /// already in scope.
+    var displayCourseName: String { displayCourseName(matching: nil) }
 }

--- a/swift/TigerDuck/Extensions/SDAssignment+DisplayName.swift
+++ b/swift/TigerDuck/Extensions/SDAssignment+DisplayName.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension SDAssignment {
+    /// Course label to render in assignment cells, notification bodies, and
+    /// Live Activity rows. Respects the user's course-rename override
+    /// (`SDCourse.customName`) so a renamed course keeps its alias on every
+    /// assignment surface, not just the class table. Falls back to the API
+    /// course name embedded in the assignment when no override exists.
+    ///
+    /// The lookup reads `DataCache.loadCourseCustomNames()` (a JSON dict on
+    /// disk). Dict is keyed by courseNo and typically a handful of entries
+    /// — a single read per render is fine.
+    var displayCourseName: String {
+        let overrides = DataCache.shared.loadCourseCustomNames()
+        return overrides[courseNo] ?? courseName
+    }
+}

--- a/swift/TigerDuck/Features/Bulletins/Components/SubscriptionRuleEditorView.swift
+++ b/swift/TigerDuck/Features/Bulletins/Components/SubscriptionRuleEditorView.swift
@@ -151,7 +151,7 @@ struct SubscriptionRuleEditorView: View {
     }
 
     private func commit() {
-        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         let sanitizedName = trimmed.isEmpty ? nil : trimmed
         let updated = BulletinAPI.SubscriptionRule(
             id: original.id,

--- a/swift/TigerDuck/Features/ClassTable/ClassTableView.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableView.swift
@@ -107,8 +107,17 @@ struct ClassTableView: View {
                 Button(String(localized: "action_confirm")) {
                     viewModel.confirmRename()
                 }
+                if let course = viewModel.courseToRename, course.customName != nil {
+                    Button(String(localized: "class_table_rename_revert"), role: .destructive) {
+                        viewModel.revertRename(course)
+                    }
+                }
                 Button(String(localized: "action_cancel"), role: .cancel) {
                     viewModel.courseToRename = nil
+                }
+            } message: {
+                if let course = viewModel.courseToRename {
+                    Text(String(format: String(localized: "class_table_rename_default_label"), course.courseName))
                 }
             }
             .sheet(item: $viewModel.courseToRecolor) { course in

--- a/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
@@ -395,7 +395,10 @@ final class ClassTableViewModel {
 
     func confirmRename() {
         guard let course = courseToRename else { return }
-        let trimmed = renameText.trimmingCharacters(in: .whitespaces)
+        // Trim whitespace *and* newlines so a pasted "\nDefault\n" still
+        // collapses to empty and routes through the revert path instead of
+        // saving an invisible/line-breaking alias.
+        let trimmed = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
         // Empty (or unchanged-from-default) means the user wants to revert to
         // the canonical name. Clearing the override is also what the explicit
         // "Revert to default" button does.

--- a/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
@@ -356,11 +356,11 @@ final class ClassTableViewModel {
             classroomMandarinDisplay: Defaults[.classroomMandarinDisplay]
         )
 
-        // Custom name override comes after relabelInPlace so it survives
-        // (relabelInPlace would otherwise overwrite it from the cached raw).
-        if let customName = courseCustomNames[course.courseNo] {
-            course.courseName = customName
-        }
+        // Apply the custom-name overlay if one persists for this course
+        // (e.g. user removed and re-added). Stored separately from the
+        // canonical courseName so abbreviation toggles and refreshes still
+        // round-trip the API value through `NameAbbrService`.
+        course.customName = courseCustomNames[course.courseNo]
 
         courses.append(course)
         persistUserAddedCourses()
@@ -374,10 +374,8 @@ final class ClassTableViewModel {
 
     private func applyCustomizations(_ courses: inout [SDCourse]) {
         courses.removeAll { deletedCourseNos.contains($0.courseNo) }
-        for i in courses.indices {
-            if let customName = courseCustomNames[courses[i].courseNo] {
-                courses[i].courseName = customName
-            }
+        for course in courses {
+            course.customName = courseCustomNames[course.courseNo]
         }
     }
 
@@ -391,16 +389,33 @@ final class ClassTableViewModel {
 
     func startRename(_ course: SDCourse) {
         courseToRename = course
-        renameText = course.courseName
+        renameText = course.displayName
         showRenameAlert = true
     }
 
     func confirmRename() {
-        guard let course = courseToRename, !renameText.trimmingCharacters(in: .whitespaces).isEmpty else { return }
-        let newName = renameText.trimmingCharacters(in: .whitespaces)
-        courseCustomNames[course.courseNo] = newName
+        guard let course = courseToRename else { return }
+        let trimmed = renameText.trimmingCharacters(in: .whitespaces)
+        // Empty (or unchanged-from-default) means the user wants to revert to
+        // the canonical name. Clearing the override is also what the explicit
+        // "Revert to default" button does.
+        if trimmed.isEmpty || trimmed == course.courseName {
+            revertRename(course)
+            return
+        }
+        courseCustomNames[course.courseNo] = trimmed
         DataCache.shared.saveCourseCustomNames(courseCustomNames)
-        course.courseName = newName
+        course.customName = trimmed
+        rebuildLookup()
+        persistUserAddedCourses()
+        courseToRename = nil
+        broadcastLocalChange()
+    }
+
+    func revertRename(_ course: SDCourse) {
+        courseCustomNames.removeValue(forKey: course.courseNo)
+        DataCache.shared.saveCourseCustomNames(courseCustomNames)
+        course.customName = nil
         rebuildLookup()
         persistUserAddedCourses()
         courseToRename = nil

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseColorPickerSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseColorPickerSheet.swift
@@ -29,7 +29,7 @@ struct CourseColorPickerSheet: View {
                         .fill(course.color)
                         .frame(width: 36, height: 36)
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(course.courseName)
+                        Text(course.displayName)
                             .font(TigerDuckTheme.Typography.headline)
                             .foregroundStyle(Color.textPrimary)
                             .lineLimit(1)

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
@@ -72,7 +72,7 @@ struct CourseDetailSheet: View {
                 .padding(.vertical)
             }
             .background(Color.backgroundPrimary)
-            .navigationTitle(course.courseName)
+            .navigationTitle(course.displayName)
             .navigationBarTitleDisplayMode(.large)
         }
     }

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -78,7 +78,7 @@ struct TimetableGridView: View {
                                     .strokeBorder(course.color.opacity(0.4), lineWidth: 1)
                             }
                             .overlay {
-                                Text(course.courseName)
+                                Text(course.displayName)
                                     .font(.system(size: 11, weight: .medium))
                                     .foregroundStyle(Color.textPrimary)
                                     .lineLimit(spanCount > 1 ? 3 : 2)

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
@@ -59,7 +59,7 @@ struct CourseTimeCard: View {
                     }
                 }
 
-                Text(course.courseName)
+                Text(course.displayName)
                     .font(.headline)
                     .foregroundStyle(courseNameColor(for: course))
                     .lineLimit(1)

--- a/swift/TigerDuck/Features/Home/Components/TodayCourseCarousel.swift
+++ b/swift/TigerDuck/Features/Home/Components/TodayCourseCarousel.swift
@@ -116,7 +116,7 @@ private struct TodayCourseCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.sm) {
             HStack {
-                Text(course.courseName)
+                Text(course.displayName)
                     .font(TigerDuckTheme.Typography.headline)
                     .foregroundStyle(Color.textPrimary)
                     .lineLimit(1)

--- a/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
+++ b/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
@@ -167,7 +167,7 @@ struct UpcomingAssignmentsView: View {
                     .font(TigerDuckTheme.Typography.body)
                     .foregroundStyle(policy.primaryTextColor)
                     .lineLimit(1)
-                Text(assignment.courseName)
+                Text(assignment.displayCourseName)
                     .font(TigerDuckTheme.Typography.caption)
                     .foregroundStyle(policy.secondaryTextColor)
             }

--- a/swift/TigerDuck/LiveActivity/Providers/CanonicalCourseProvider.swift
+++ b/swift/TigerDuck/LiveActivity/Providers/CanonicalCourseProvider.swift
@@ -28,11 +28,10 @@ struct CanonicalCourseProvider {
 
     /// Merge function, exposed for unit testing.
     ///
-    /// NOTE: `SDCourse` is a SwiftData `@Model` (reference type). The custom-name
-    /// overlay step mutates `courseName` in place on the passed-in instances, so
-    /// callers MUST pass fresh, unmanaged `SDCourse` objects (as `DataCache` does)
-    /// — passing SwiftData-managed instances would silently persist the renamed
-    /// value back to the store and bypass the rename mechanism.
+    /// NOTE: `SDCourse` is a SwiftData `@Model` (reference type). The
+    /// custom-name overlay sets `customName` (a `@Transient` SwiftData
+    /// property) so the canonical `courseName` is never mutated and no
+    /// override leaks into persistence. Render `displayName` downstream.
     static func merge(
         primary: [SDCourse],
         userAdded: [SDCourse],
@@ -45,9 +44,7 @@ struct CanonicalCourseProvider {
         }
         merged.removeAll { deletedCourseNos.contains($0.courseNo) }
         for course in merged {
-            if let renamed = customNames[course.courseNo] {
-                course.courseName = renamed
-            }
+            course.customName = customNames[course.courseNo]
         }
         return merged
     }

--- a/swift/TigerDuck/LiveActivity/Resolvers/LiveActivityScenarioResolver.swift
+++ b/swift/TigerDuck/LiveActivity/Resolvers/LiveActivityScenarioResolver.swift
@@ -103,16 +103,15 @@ struct LiveActivityScenarioResolver {
         leadTime: TimeInterval,
         accentHex: Int
     ) -> LiveActivitySnapshot {
-        let instructor = courses
-            .first { $0.courseNo == assignment.courseNo }
-            .flatMap { nonEmpty($0.instructor) }
+        let matchingCourse = courses.first { $0.courseNo == assignment.courseNo }
+        let instructor = matchingCourse.flatMap { nonEmpty($0.instructor) }
         let progressStart: Date? = leadTime > 0
             ? assignment.dueDate.addingTimeInterval(-leadTime)
             : nil
         return LiveActivitySnapshot(
             scenario: .assignmentUrgent,
             title: assignment.title,
-            subtitle: assignment.displayCourseName,
+            subtitle: assignment.displayCourseName(matching: matchingCourse),
             locationText: nil,
             instructor: instructor,
             countdownTarget: assignment.dueDate,

--- a/swift/TigerDuck/LiveActivity/Resolvers/LiveActivityScenarioResolver.swift
+++ b/swift/TigerDuck/LiveActivity/Resolvers/LiveActivityScenarioResolver.swift
@@ -69,7 +69,7 @@ struct LiveActivityScenarioResolver {
         let weekday = slot.date.scheduleWeekday
         return LiveActivitySnapshot(
             scenario: .inClass,
-            title: slot.course.courseName,
+            title: slot.course.displayName,
             subtitle: slot.course.timeRange(for: weekday) ?? "",
             locationText: slot.course.classroom(for: weekday),
             instructor: nonEmpty(slot.course.instructor),
@@ -85,7 +85,7 @@ struct LiveActivityScenarioResolver {
         let weekday = slot.date.scheduleWeekday
         return LiveActivitySnapshot(
             scenario: .classPreparing,
-            title: slot.course.courseName,
+            title: slot.course.displayName,
             subtitle: slot.course.timeRange(for: weekday) ?? "",
             locationText: slot.course.classroom(for: weekday),
             instructor: nonEmpty(slot.course.instructor),
@@ -112,7 +112,7 @@ struct LiveActivityScenarioResolver {
         return LiveActivitySnapshot(
             scenario: .assignmentUrgent,
             title: assignment.title,
-            subtitle: assignment.courseName,
+            subtitle: assignment.displayCourseName,
             locationText: nil,
             instructor: instructor,
             countdownTarget: assignment.dueDate,

--- a/swift/TigerDuck/LiveActivity/Scheduling/AssignmentReminderScheduler.swift
+++ b/swift/TigerDuck/LiveActivity/Scheduling/AssignmentReminderScheduler.swift
@@ -220,10 +220,10 @@ final class AssignmentReminderScheduler {
                     ReminderPayload(
                         id: "\(assignment.assignmentId)::\(offset.rawValue)",
                         fireDate: fireDate,
-                        title: String(format: String(localized: "notification_assignment_reminder_title"), assignment.courseName),
+                        title: String(format: String(localized: "notification_assignment_reminder_title"), assignment.displayCourseName),
                         body: offset.notificationBody(
                             assignmentTitle: assignment.title,
-                            courseName: assignment.courseName
+                            courseName: assignment.displayCourseName
                         ),
                         assignmentId: assignment.assignmentId,
                         offset: offset

--- a/swift/TigerDuck/Models/SwiftData/SDCourse.swift
+++ b/swift/TigerDuck/Models/SwiftData/SDCourse.swift
@@ -12,6 +12,19 @@ final class SDCourse: Identifiable {
     var enrolledCount: Int
     var maxCount: Int
 
+    /// User-supplied alias for `courseName`. Kept transient because the
+    /// canonical store is `DataCache.loadCourseCustomNames()`; persisting it
+    /// here would let SwiftData round-trip the override through cache rebuilds
+    /// and bypass the rename mechanism (see `CanonicalCourseProvider.merge`).
+    /// Read via `displayName`.
+    @Transient var customName: String? = nil
+
+    /// What to show to the user — custom name when set, otherwise the
+    /// canonical API name. Use this anywhere a course label is rendered
+    /// (UI / widget / Live Activity / notification body); keep
+    /// `courseName` for matching, persistence, and search.
+    var displayName: String { customName ?? courseName }
+
     /// Schedule stored as JSON: {"1":["3","4"],"3":["6","7"]}
     /// Keys = weekday (1=Mon..7=Sun), Values = period IDs
     var scheduleJSON: String {

--- a/swift/TigerDuck/Services/Core/DataCache.swift
+++ b/swift/TigerDuck/Services/Core/DataCache.swift
@@ -52,9 +52,7 @@ final class DataCache {
         let dtos: [CachedCourse] = load(from: coursesFilename(semester, currentCourseApiLanguage())) ?? []
         let customNames = loadCourseCustomNames()
         return dtos.map { dto in
-            let course = dto.toSDCourse()
-            course.customName = customNames[course.courseNo]
-            return course
+            applyCustomNameOverlay(dto.toSDCourse(), customNames: customNames)
         }
     }
 
@@ -77,10 +75,32 @@ final class DataCache {
         let dtos: [CachedCourse] = load(from: "user_added_courses.json", in: persistentDir) ?? []
         let customNames = loadCourseCustomNames()
         return dtos.map { dto in
-            let course = dto.toSDCourse()
-            course.customName = customNames[course.courseNo]
-            return course
+            applyCustomNameOverlay(dto.toSDCourse(), customNames: customNames)
         }
+    }
+
+    /// Apply the persisted alias overlay to a freshly-decoded SDCourse, with
+    /// a defensive guard for caches written by builds where the rename flow
+    /// overwrote `courseName` in place. Symptom: `customNames[courseNo]`
+    /// equals the cached `courseName`, meaning the cache no longer holds the
+    /// canonical API name. In that case clear `courseName` so `displayName`
+    /// resolves to the alias via `customName` only — and "Revert to default"
+    /// surfaces an empty canonical (instead of silently leaving the alias
+    /// behind) until the next network refresh repopulates the canonical
+    /// value. Semester course caches are also force-purged once via
+    /// `CustomNameCacheMigration`; this guard catches the user-added cache,
+    /// which has no network refresh source.
+    private func applyCustomNameOverlay(
+        _ course: SDCourse,
+        customNames: [String: String]
+    ) -> SDCourse {
+        if let alias = customNames[course.courseNo] {
+            if alias == course.courseName {
+                course.courseName = ""
+            }
+            course.customName = alias
+        }
+        return course
     }
 
     // MARK: - Assignments

--- a/swift/TigerDuck/Services/Core/DataCache.swift
+++ b/swift/TigerDuck/Services/Core/DataCache.swift
@@ -52,7 +52,11 @@ final class DataCache {
         let dtos: [CachedCourse] = load(from: coursesFilename(semester, currentCourseApiLanguage())) ?? []
         let customNames = loadCourseCustomNames()
         return dtos.map { dto in
-            applyCustomNameOverlay(dto.toSDCourse(), customNames: customNames)
+            applyCustomNameOverlay(
+                dto.toSDCourse(),
+                customNames: customNames,
+                clearPollutedCanonical: true
+            )
         }
     }
 
@@ -75,27 +79,39 @@ final class DataCache {
         let dtos: [CachedCourse] = load(from: "user_added_courses.json", in: persistentDir) ?? []
         let customNames = loadCourseCustomNames()
         return dtos.map { dto in
-            applyCustomNameOverlay(dto.toSDCourse(), customNames: customNames)
+            // User-added courses have no network refresh source, so we must
+            // never blank `courseName` even when it matches the alias — the
+            // cached value is the only fallback label after the user reverts
+            // the rename. The semester load path opts in via
+            // `clearPollutedCanonical: true` because a fresh API fetch will
+            // restore the real name.
+            applyCustomNameOverlay(
+                dto.toSDCourse(),
+                customNames: customNames,
+                clearPollutedCanonical: false
+            )
         }
     }
 
-    /// Apply the persisted alias overlay to a freshly-decoded SDCourse, with
-    /// a defensive guard for caches written by builds where the rename flow
-    /// overwrote `courseName` in place. Symptom: `customNames[courseNo]`
-    /// equals the cached `courseName`, meaning the cache no longer holds the
-    /// canonical API name. In that case clear `courseName` so `displayName`
-    /// resolves to the alias via `customName` only — and "Revert to default"
-    /// surfaces an empty canonical (instead of silently leaving the alias
-    /// behind) until the next network refresh repopulates the canonical
-    /// value. Semester course caches are also force-purged once via
-    /// `CustomNameCacheMigration`; this guard catches the user-added cache,
-    /// which has no network refresh source.
+    /// Apply the persisted alias overlay to a freshly-decoded SDCourse.
+    ///
+    /// When `clearPollutedCanonical` is true and `customNames[courseNo]`
+    /// equals the cached `courseName`, treat that as the pre-PR overwrite
+    /// signature (where the rename flow wrote the alias straight into
+    /// `courseName`) and clear `courseName` so `displayName` resolves to
+    /// the alias via `customName` only — and "Revert to default" surfaces
+    /// an empty canonical until the next network refresh repopulates it.
+    /// Callers that have no network refresh source (e.g. user-added
+    /// courses) MUST pass `false` so we never destroy the only available
+    /// fallback label; for those entries revert may visibly preserve the
+    /// alias-as-canonical, which is the most truthful recovery available.
     private func applyCustomNameOverlay(
         _ course: SDCourse,
-        customNames: [String: String]
+        customNames: [String: String],
+        clearPollutedCanonical: Bool
     ) -> SDCourse {
         if let alias = customNames[course.courseNo] {
-            if alias == course.courseName {
+            if clearPollutedCanonical, alias == course.courseName {
                 course.courseName = ""
             }
             course.customName = alias

--- a/swift/TigerDuck/Services/Core/DataCache.swift
+++ b/swift/TigerDuck/Services/Core/DataCache.swift
@@ -50,7 +50,12 @@ final class DataCache {
     /// network refresh will repopulate it.
     func loadCourses(semester: String) -> [SDCourse] {
         let dtos: [CachedCourse] = load(from: coursesFilename(semester, currentCourseApiLanguage())) ?? []
-        return dtos.map { $0.toSDCourse() }
+        let customNames = loadCourseCustomNames()
+        return dtos.map { dto in
+            let course = dto.toSDCourse()
+            course.customName = customNames[course.courseNo]
+            return course
+        }
     }
 
     private func coursesFilename(_ semester: String, _ language: String) -> String {
@@ -70,7 +75,12 @@ final class DataCache {
 
     func loadUserAddedCourses() -> [SDCourse] {
         let dtos: [CachedCourse] = load(from: "user_added_courses.json", in: persistentDir) ?? []
-        return dtos.map { $0.toSDCourse() }
+        let customNames = loadCourseCustomNames()
+        return dtos.map { dto in
+            let course = dto.toSDCourse()
+            course.customName = customNames[course.courseNo]
+            return course
+        }
     }
 
     // MARK: - Assignments

--- a/swift/TigerDuck/Services/Migrations/CustomNameCacheMigration.swift
+++ b/swift/TigerDuck/Services/Migrations/CustomNameCacheMigration.swift
@@ -18,6 +18,12 @@ enum CustomNameCacheMigration {
     static func runIfNeeded() {
         guard !UserDefaults.standard.bool(forKey: doneKey) else { return }
         defer { UserDefaults.standard.set(true, forKey: doneKey) }
+        // Pollution can only exist if the user has at least one persisted
+        // rename. Skipping the purge for users who never renamed a course
+        // preserves their offline timetable across the upgrade — they
+        // would otherwise see an empty class table on a cold launch with
+        // no network until the next successful course fetch.
+        guard !DataCache.shared.loadCourseCustomNames().isEmpty else { return }
         DataCache.shared.clearCourseCaches()
     }
 }

--- a/swift/TigerDuck/Services/Migrations/CustomNameCacheMigration.swift
+++ b/swift/TigerDuck/Services/Migrations/CustomNameCacheMigration.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// One-shot migration: drops cached `courses_<semester>_<lang>.json` files
+/// written by builds where the rename flow overwrote `SDCourse.courseName`
+/// in place with the user's alias. After the customName overlay refactor,
+/// those polluted cache entries would otherwise be treated as canonical —
+/// so tapping "Revert to default" would clear `customName` but leave the
+/// alias as `course.courseName`, with no way to recover the API name short
+/// of a successful network refresh. Clearing forces the next course fetch
+/// to repopulate the on-disk cache from the API.
+///
+/// Only the semester-scoped caches are touched here; `user_added_courses.json`
+/// has no network refresh source and is handled defensively at load time
+/// in `DataCache.loadUserAddedCourses`.
+enum CustomNameCacheMigration {
+    private static let doneKey = "CustomNameCacheMigration.v1.done"
+
+    static func runIfNeeded() {
+        guard !UserDefaults.standard.bool(forKey: doneKey) else { return }
+        defer { UserDefaults.standard.set(true, forKey: doneKey) }
+        DataCache.shared.clearCourseCaches()
+    }
+}


### PR DESCRIPTION
Previously the rename mechanism overwrote SDCourse.courseName in place, mixing the API source-of-truth with the user override and forcing every read site (widgets, Live Activity, notifications, more views) to remember the abbreviation pipeline ordering before reading. Refactor to keep the canonical name immutable:

- SDCourse gains @Transient customName: String? and a displayName computed property (customName ?? courseName). Persisted via the existing courseCustomNames dict, applied on every DataCache load.
- ClassTableViewModel.confirmRename now sets course.customName and the dict; revertRename (and an empty/unchanged input) clears the override.
- CanonicalCourseProvider.merge writes customName, not courseName, so Live Activity reads the alias without persisting it to the model store.
- All display sites (TodayCourseCarousel, CourseTimeCard, TimetableGrid, CourseDetailSheet, CourseColorPickerSheet) switched to displayName.
- SDAssignment gains displayCourseName extension reading the dict so assignment cells / reminders / Live Activity show the renamed course label on every surface.
- Rename alert exposes the canonical default and a "Revert to default" destructive button using the bumped localization keys (class_table_rename_default_label / class_table_rename_revert).

Closes #99