### PR TITLE
feat(auth): password visibility toggle and larger onboarding buttons

### DIFF
--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -22,6 +22,7 @@ struct OnboardingView: View {
                     withAnimation { currentPage = 1 }
                 }
                 .buttonStyle(.borderedProminent)
+                .controlSize(.large)
             }
             .tag(0)
 
@@ -58,12 +59,12 @@ struct OnboardingView: View {
                             Image(systemName: "lock.fill")
                                 .foregroundStyle(.secondary)
                                 .frame(width: 20)
-                            SecureField(String(localized: "login_password"), text: $password)
-                                .keyboardType(.asciiCapable)
-                                .focused($focusedField, equals: .password)
-                                .textContentType(.password)
-                                .submitLabel(.go)
-                                .onSubmit {
+                            PasswordField(
+                                placeholder: String(localized: "login_password"),
+                                text: $password,
+                                focusBinding: $focusedField,
+                                focusValue: .password,
+                                onSubmit: {
                                     let trimmedId = studentId.trimmingCharacters(in: .whitespaces)
                                     let trimmedPwd = password.trimmingCharacters(in: .whitespaces)
                                     guard !trimmedId.isEmpty, !trimmedPwd.isEmpty, !appState.authService.isLoggingIn else { return }
@@ -72,6 +73,7 @@ struct OnboardingView: View {
                                         if success { withAnimation { currentPage = 2 } }
                                     }
                                 }
+                            )
                         }
                         .padding(.horizontal, TigerDuckTheme.Spacing.lg)
                         .padding(.vertical, TigerDuckTheme.Spacing.md)
@@ -115,6 +117,7 @@ struct OnboardingView: View {
                         }
                     }
                     .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
                     .disabled(studentId.isEmpty || password.isEmpty || appState.authService.isLoggingIn)
                 }
             }
@@ -131,6 +134,7 @@ struct OnboardingView: View {
                     withAnimation { currentPage = 3 }
                 }
                 .buttonStyle(.borderedProminent)
+                .controlSize(.large)
             }
             .tag(2)
 

--- a/swift/TigerDuck/Features/Settings/Components/LoginSheet.swift
+++ b/swift/TigerDuck/Features/Settings/Components/LoginSheet.swift
@@ -51,12 +51,13 @@ struct LoginSheet: View {
                         .submitLabel(.next)
                         .onSubmit { focusedField = .password }
 
-                    SecureField(passwordPlaceholder, text: $password)
-                        .keyboardType(.asciiCapable)
-                        .textContentType(.password)
-                        .focused($focusedField, equals: .password)
-                        .submitLabel(.go)
-                        .onSubmit { submitIfReady() }
+                    PasswordField(
+                        placeholder: passwordPlaceholder,
+                        text: $password,
+                        focusBinding: $focusedField,
+                        focusValue: .password,
+                        onSubmit: { submitIfReady() }
+                    )
                 } footer: {
                     if let subtitle {
                         Label(subtitle, systemImage: "info.circle")

--- a/swift/TigerDuck/Shared/Components/PasswordField.swift
+++ b/swift/TigerDuck/Shared/Components/PasswordField.swift
@@ -35,7 +35,16 @@ struct PasswordField<Field: Hashable>: View {
             .onSubmit(onSubmit)
 
             Button {
+                let wasFocused = focusBinding.wrappedValue == focusValue
                 isVisible.toggle()
+                if wasFocused {
+                    // Swapping between SecureField and TextField rebuilds the
+                    // input view and drops first responder. Re-assert focus on
+                    // the next runloop tick so the keyboard stays up.
+                    DispatchQueue.main.async {
+                        focusBinding.wrappedValue = focusValue
+                    }
+                }
             } label: {
                 Image(systemName: isVisible ? "eye.slash" : "eye")
                     .foregroundStyle(.secondary)

--- a/swift/TigerDuck/Shared/Components/PasswordField.swift
+++ b/swift/TigerDuck/Shared/Components/PasswordField.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// Password input with a trailing eye toggle that flips between
+/// SecureField (default) and TextField. Autofill / password-AutoFill keep
+/// working because both branches set `textContentType(.password)`.
+///
+/// The visibility flag is owned by the field itself so the parent doesn't
+/// need a stash variable just to render the icon. Process backgrounding
+/// still wipes the bound `text`, same as a bare SecureField.
+struct PasswordField<Field: Hashable>: View {
+    let placeholder: String
+    @Binding var text: String
+    var focusBinding: FocusState<Field?>.Binding
+    let focusValue: Field
+    var submitLabel: SubmitLabel = .go
+    var onSubmit: () -> Void = {}
+
+    @State private var isVisible = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Group {
+                if isVisible {
+                    TextField(placeholder, text: $text)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                } else {
+                    SecureField(placeholder, text: $text)
+                }
+            }
+            .keyboardType(.asciiCapable)
+            .textContentType(.password)
+            .focused(focusBinding, equals: focusValue)
+            .submitLabel(submitLabel)
+            .onSubmit(onSubmit)
+
+            Button {
+                isVisible.toggle()
+            } label: {
+                Image(systemName: isVisible ? "eye.slash" : "eye")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 24, height: 24)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(isVisible
+                ? String(localized: "password_hide")
+                : String(localized: "password_show"))
+        }
+    }
+}


### PR DESCRIPTION
Two related fixes on the onboarding/login surfaces:

- Add a reusable PasswordField with an eye/eye.slash toggle so users can verify a typed password on the iPhone keyboard. SecureField and TextField both set textContentType(.password) so AutoFill still works in either mode. Wired into LoginSheet and the onboarding login page.
- Bump the onboarding Welcome / Choose-features / Sign-in buttons to .controlSize(.large) so the tap target matches the final "Start using TigerDuck" button. Reports on iOS 18 had the Welcome Next button effectively unhittable.

Bump localization submodule to pick up password_show/password_hide.

Closes #96, #98