### PR TITLE
ci: gate merges on submodule freshness and version bumps

### DIFF
--- a/.github/workflows/submodules-up-to-date.yaml
+++ b/.github/workflows/submodules-up-to-date.yaml
@@ -1,0 +1,37 @@
+name: Submodules up to date
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          submodules: true
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check each submodule is at upstream tip
+        run: |
+          set -e
+          stale=0
+          while IFS= read -r name; do
+            path=$(git config -f .gitmodules "submodule.$name.path")
+            branch=$(git config -f .gitmodules "submodule.$name.branch" || echo main)
+            (
+              cd "$path"
+              git fetch origin "$branch" --quiet
+              pinned=$(git rev-parse HEAD)
+              latest=$(git rev-parse "origin/$branch")
+              if [ "$pinned" != "$latest" ]; then
+                echo "::error::Submodule '$name' ($path) is behind origin/$branch (pinned $pinned, latest $latest). Bump before merging."
+                exit 1
+              else
+                echo "OK $name up to date with origin/$branch"
+              fi
+            ) || stale=1
+          done < <(git config --file .gitmodules --get-regexp '^submodule\..*\.path$' | sed -E 's/^submodule\.(.*)\.path .*/\1/')
+          exit $stale

--- a/.github/workflows/version-bumped.yaml
+++ b/.github/workflows/version-bumped.yaml
@@ -54,7 +54,19 @@ jobs:
 
           fail=0
 
-          if ! version_gt "$new_marketing" "$old_marketing"; then
+          # Validate both marketing versions are dotted-numeric (optional
+          # `-suffix`) before letting `sort -V` rank them. Without this guard
+          # values like "abc" or "1.6.1+bad" can sort greater than a clean
+          # base like "1.6.1" and slip past the bump gate as long as the
+          # build number is also bumped.
+          marketing_re='^[0-9]+(\.[0-9]+)+(-[A-Za-z0-9._-]+)?$'
+          if ! [[ "$new_marketing" =~ $marketing_re ]]; then
+            echo "::error file=$pbxproj::MARKETING_VERSION must be dotted numeric (e.g. 1.6.1, optionally with -suffix); got '$new_marketing'."
+            fail=1
+          elif ! [[ "$old_marketing" =~ $marketing_re ]]; then
+            echo "::error file=$pbxproj::base MARKETING_VERSION is not dotted numeric (got '$old_marketing'); cannot verify bump."
+            fail=1
+          elif ! version_gt "$new_marketing" "$old_marketing"; then
             echo "::error file=$pbxproj::MARKETING_VERSION must be bumped (current $new_marketing, base $old_marketing). Run /release-bump to bump."
             fail=1
           fi

--- a/.github/workflows/version-bumped.yaml
+++ b/.github/workflows/version-bumped.yaml
@@ -1,0 +1,67 @@
+name: Version bumped
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check MARKETING_VERSION and CURRENT_PROJECT_VERSION are bumped
+        run: |
+          set -e
+          base="origin/${{ github.base_ref }}"
+          git fetch origin "${{ github.base_ref }}" --quiet --depth=1
+
+          pbxproj="swift/TigerDuck.xcodeproj/project.pbxproj"
+
+          # The pbxproj repeats MARKETING_VERSION per build configuration *per*
+          # target (main app, Live Activity extension, etc). We gate releases
+          # on the main TigerDuck target — that's always the first occurrence
+          # because Xcode writes target sections in dependency order.
+          extract_marketing() {
+            grep -E '^[[:space:]]*MARKETING_VERSION[[:space:]]*=' "$1" \
+              | head -n1 \
+              | sed -E 's/.*=[[:space:]]*([^;[:space:]]+).*/\1/'
+          }
+          extract_build() {
+            grep -E '^[[:space:]]*CURRENT_PROJECT_VERSION[[:space:]]*=' "$1" \
+              | head -n1 \
+              | sed -E 's/.*=[[:space:]]*([^;[:space:]]+).*/\1/'
+          }
+
+          # Semver compare: returns 0 iff $1 > $2 (numeric per dot segment,
+          # ignores any -suffix). Matches the Android workflow's behavior.
+          version_gt() {
+            local a="${1%%-*}" b="${2%%-*}"
+            [ "$a" = "$b" ] && return 1
+            [ "$(printf '%s\n%s\n' "$a" "$b" | sort -V | tail -n1)" = "$a" ]
+          }
+
+          new_marketing=$(extract_marketing "$pbxproj")
+          new_build=$(extract_build "$pbxproj")
+          old_marketing=$(git show "$base:$pbxproj" | extract_marketing /dev/stdin)
+          old_build=$(git show "$base:$pbxproj" | extract_build /dev/stdin)
+
+          echo "MARKETING_VERSION:       $old_marketing -> $new_marketing"
+          echo "CURRENT_PROJECT_VERSION: $old_build -> $new_build"
+
+          fail=0
+
+          if ! version_gt "$new_marketing" "$old_marketing"; then
+            echo "::error file=$pbxproj::MARKETING_VERSION must be bumped (current $new_marketing, base $old_marketing). Run /release-bump to bump."
+            fail=1
+          fi
+
+          if [ "$new_build" -le "$old_build" ] 2>/dev/null; then
+            echo "::error file=$pbxproj::CURRENT_PROJECT_VERSION must be bumped (current $new_build, base $old_build)."
+            fail=1
+          fi
+
+          exit $fail

--- a/.github/workflows/version-bumped.yaml
+++ b/.github/workflows/version-bumped.yaml
@@ -59,7 +59,19 @@ jobs:
             fail=1
           fi
 
-          if [ "$new_build" -le "$old_build" ] 2>/dev/null; then
+          # Validate both build numbers are non-empty positive integers before
+          # comparing. `[ -le ]` exits with status 2 on non-integer operands;
+          # without this guard a malformed CURRENT_PROJECT_VERSION (e.g. "1.0",
+          # "abc", or an unresolved "$(VAR)") would skip the if-body and let
+          # the check pass silently.
+          int_re='^[0-9]+$'
+          if ! [[ "$new_build" =~ $int_re ]]; then
+            echo "::error file=$pbxproj::CURRENT_PROJECT_VERSION must be a positive integer (got '$new_build')."
+            fail=1
+          elif ! [[ "$old_build" =~ $int_re ]]; then
+            echo "::error file=$pbxproj::base CURRENT_PROJECT_VERSION is not a positive integer (got '$old_build'); cannot verify bump."
+            fail=1
+          elif [ "$new_build" -le "$old_build" ]; then
             echo "::error file=$pbxproj::CURRENT_PROJECT_VERSION must be bumped (current $new_build, base $old_build)."
             fail=1
           fi


### PR DESCRIPTION
Two PR-gating workflows ported from tigerduck-app-android:

- submodules-up-to-date.yaml (PRs into dev/main): walks every entry in .gitmodules, fetches origin and compares the pinned commit against origin/<branch> (defaulting to main). Fails the check with an actionable message if any submodule is stale, so a PR can't merge with a localization or name-abbr pointer behind upstream.

- version-bumped.yaml (PRs into main): parses swift/TigerDuck.xcodeproj/ project.pbxproj for the main app target's MARKETING_VERSION and CURRENT_PROJECT_VERSION (first occurrence — Xcode writes the main app before extensions) and requires both to be strictly greater than base. Translated from the Android workflow's gradle/fdroid logic to pbxproj.

Also bumps the localization submodule pointer to its latest main so this PR doesn't fail its own submodule check at merge time.

Closes #93, #94