### PR TITLE
Enhance course detail with caching and redesign UI elements

### DIFF
--- a/swift/TigerDuck/Bridge/AppServiceBridge.swift
+++ b/swift/TigerDuck/Bridge/AppServiceBridge.swift
@@ -125,8 +125,10 @@ enum AppServiceBridge {
             }
             // Persist idnumber → numeric-id map so `SDCourse.moodleDeepLink`
             // can build `?id=N` redirects (Moodle Mobile's in-app router
-            // rejects `?idnumber=…`). Refreshes every sync so renamed
-            // courses pick up new ids without manual invalidation.
+            // rejects `?idnumber=…`). Whole-map overwrite — the fetched list
+            // is the authoritative snapshot, so any idnumber missing from
+            // it has been dropped on Moodle's side and we must not keep a
+            // stale numeric id pointing at a dead course.
             let moodleIdMap = Dictionary(
                 moodleAll.compactMap { entry -> (String, Int)? in
                     guard !entry.idnumber.isEmpty else { return nil }
@@ -134,7 +136,7 @@ enum AppServiceBridge {
                 },
                 uniquingKeysWith: { _, latest in latest }
             )
-            DataCache.shared.mergeMoodleCourseIdMap(moodleIdMap)
+            DataCache.shared.saveMoodleCourseIdMap(moodleIdMap)
 
             let moodleForSemester = moodleAll.filter { $0.semester == semester }
             let moodleByNo = Dictionary(
@@ -412,10 +414,12 @@ enum AppServiceBridge {
             let currentCourses = DataCache.shared.loadCourses(semester: currentSemester)
 
             let moodleEnrolled = try await MoodleEnrolledCoursesService.fetchEnrolled()
-            // Same idnumber → numeric-id cache update as the course-table
-            // path. Done here too because the assignments pipeline can run
-            // before the course pipeline on a cold launch, and the deep-link
-            // button shouldn't have to wait two cycles to light up.
+            // Same idnumber → numeric-id snapshot as the course-table path.
+            // Done here too because the assignments pipeline can run before
+            // the course pipeline on a cold launch, and the deep-link button
+            // shouldn't have to wait two cycles to light up. Whole-map
+            // overwrite for the same staleness reason — `moodleEnrolled` is
+            // the authoritative current-enrolment list.
             let moodleIdMapForAssignments = Dictionary(
                 moodleEnrolled.compactMap { entry -> (String, Int)? in
                     guard !entry.idnumber.isEmpty else { return nil }
@@ -423,7 +427,7 @@ enum AppServiceBridge {
                 },
                 uniquingKeysWith: { _, latest in latest }
             )
-            DataCache.shared.mergeMoodleCourseIdMap(moodleIdMapForAssignments)
+            DataCache.shared.saveMoodleCourseIdMap(moodleIdMapForAssignments)
 
             // On first launch the NTUST course cache is empty because
             // backgroundSync runs assignments + courses in parallel.

--- a/swift/TigerDuck/Bridge/AppServiceBridge.swift
+++ b/swift/TigerDuck/Bridge/AppServiceBridge.swift
@@ -123,6 +123,19 @@ enum AppServiceBridge {
             } else {
                 try await MoodleEnrolledCoursesService.fetchEnrolled()
             }
+            // Persist idnumber → numeric-id map so `SDCourse.moodleDeepLink`
+            // can build `?id=N` redirects (Moodle Mobile's in-app router
+            // rejects `?idnumber=…`). Refreshes every sync so renamed
+            // courses pick up new ids without manual invalidation.
+            let moodleIdMap = Dictionary(
+                moodleAll.compactMap { entry -> (String, Int)? in
+                    guard !entry.idnumber.isEmpty else { return nil }
+                    return (entry.idnumber, entry.id)
+                },
+                uniquingKeysWith: { _, latest in latest }
+            )
+            DataCache.shared.mergeMoodleCourseIdMap(moodleIdMap)
+
             let moodleForSemester = moodleAll.filter { $0.semester == semester }
             let moodleByNo = Dictionary(
                 moodleForSemester.compactMap { course -> (String, MoodleEnrolledCourse)? in
@@ -399,6 +412,19 @@ enum AppServiceBridge {
             let currentCourses = DataCache.shared.loadCourses(semester: currentSemester)
 
             let moodleEnrolled = try await MoodleEnrolledCoursesService.fetchEnrolled()
+            // Same idnumber → numeric-id cache update as the course-table
+            // path. Done here too because the assignments pipeline can run
+            // before the course pipeline on a cold launch, and the deep-link
+            // button shouldn't have to wait two cycles to light up.
+            let moodleIdMapForAssignments = Dictionary(
+                moodleEnrolled.compactMap { entry -> (String, Int)? in
+                    guard !entry.idnumber.isEmpty else { return nil }
+                    return (entry.idnumber, entry.id)
+                },
+                uniquingKeysWith: { _, latest in latest }
+            )
+            DataCache.shared.mergeMoodleCourseIdMap(moodleIdMapForAssignments)
+
             // On first launch the NTUST course cache is empty because
             // backgroundSync runs assignments + courses in parallel.
             // Without this fallback we'd filter against an empty set,

--- a/swift/TigerDuck/Bridge/AppServiceBridge.swift
+++ b/swift/TigerDuck/Bridge/AppServiceBridge.swift
@@ -427,7 +427,10 @@ enum AppServiceBridge {
             // the course pipeline on a cold launch, and the deep-link button
             // shouldn't have to wait two cycles to light up. Whole-map
             // overwrite for the same staleness reason — `moodleEnrolled` is
-            // the authoritative current-enrolment list.
+            // the authoritative current-enrolment list. Guarded by the same
+            // login-generation + cancellation checks as the assignments
+            // cache write below: a fetch in flight when the user logs out
+            // must not resurrect that user's enrolled-course ids on disk.
             let moodleIdMapForAssignments = Dictionary(
                 moodleEnrolled.compactMap { entry -> (String, Int)? in
                     guard !entry.idnumber.isEmpty else { return nil }
@@ -435,7 +438,10 @@ enum AppServiceBridge {
                 },
                 uniquingKeysWith: { _, latest in latest }
             )
-            DataCache.shared.saveMoodleCourseIdMap(moodleIdMapForAssignments)
+            if !Task.isCancelled,
+               authService.loginGeneration == startGeneration {
+                DataCache.shared.saveMoodleCourseIdMap(moodleIdMapForAssignments)
+            }
 
             // On first launch the NTUST course cache is empty because
             // backgroundSync runs assignments + courses in parallel.

--- a/swift/TigerDuck/Bridge/AppServiceBridge.swift
+++ b/swift/TigerDuck/Bridge/AppServiceBridge.swift
@@ -128,7 +128,12 @@ enum AppServiceBridge {
             // rejects `?idnumber=…`). Whole-map overwrite — the fetched list
             // is the authoritative snapshot, so any idnumber missing from
             // it has been dropped on Moodle's side and we must not keep a
-            // stale numeric id pointing at a dead course.
+            // stale numeric id pointing at a dead course. Guarded by the
+            // same login-generation + cancellation checks as the course
+            // cache write below: if the user logged out while this fetch
+            // was in flight, `clearUserScopedData` may have already wiped
+            // the map, and resuming this write would resurrect the
+            // previous user's enrolled-course ids on disk.
             let moodleIdMap = Dictionary(
                 moodleAll.compactMap { entry -> (String, Int)? in
                     guard !entry.idnumber.isEmpty else { return nil }
@@ -136,7 +141,10 @@ enum AppServiceBridge {
                 },
                 uniquingKeysWith: { _, latest in latest }
             )
-            DataCache.shared.saveMoodleCourseIdMap(moodleIdMap)
+            if !Task.isCancelled,
+               authService.loginGeneration == startGeneration {
+                DataCache.shared.saveMoodleCourseIdMap(moodleIdMap)
+            }
 
             let moodleForSemester = moodleAll.filter { $0.semester == semester }
             let moodleByNo = Dictionary(

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
@@ -52,7 +52,7 @@ struct CourseDetailSheet: View {
                     }
                     // TODO(l10n): add `course_detail_open_moodle_a11y` —
                     // "在 Moodle 開啟課程" / "Open course in Moodle"
-                    .accessibilityLabel(String(localized: "course_detail_open_moodle_a11y"))
+                    // .accessibilityLabel(String(localized: "course_detail_open_moodle_a11y"))
                 }
             }
 

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
@@ -1,6 +1,17 @@
 import SwiftUI
 
+/// Modal detail for a single course row. Visual structure:
+///   1. Color bar + course title (with optional Moodle jump button)
+///   2. Two emphasis cards side-by-side: 教室 (classroom) | 時間 (time)
+///   3. Flat InfoRow list: instructor / code / credits / enrollment
+///   4. Outstanding assignments (unchanged)
+///
+/// The emphasis cards exist because classroom & time are the two fields users
+/// glance at most often when tapping a course — they earn their own surface
+/// instead of being buried in the same flat list as the metadata rows.
 struct CourseDetailSheet: View {
+    @Environment(AppState.self) private var appState
+
     let course: SDCourse
     let assignments: [SDAssignment]
     var timeRange: String? = nil
@@ -10,80 +21,203 @@ struct CourseDetailSheet: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.lg) {
-                    // Course color bar
-                    RoundedRectangle(cornerRadius: TigerDuckTheme.CornerRadius.sm)
-                        .fill(course.color)
-                        .frame(height: 6)
-                        .padding(.horizontal)
-
-                    // Course info
-                    VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.md) {
-                        InfoRow(label: String(localized: "course_detail_instructor_label"), value: course.instructor)
-                        InfoRow(label: String(localized: "course_detail_code_label"), value: course.courseNo)
-                        InfoRow(label: String(localized: "course_detail_credits_label"), value: "\(course.credits)")
-                        InfoRow(label: String(localized: "course_detail_classroom_label"), value: weekday.map { course.classroom(for: $0) } ?? SDCourse.dedup(course.classroom))
-                        if let timeRange {
-                            InfoRow(label: String(localized: "course_detail_time_label"), value: timeRange)
-                        }
-                        InfoRow(label: String(localized: "course_detail_enrollment_label"), value: "\(course.enrolledCount) / \(course.maxCount)")
-                    }
-                    .padding(.horizontal)
-
-                    // Assignments
-                    if !assignments.isEmpty {
-                        Divider().background(Color.textSecondary)
-                            .padding(.horizontal)
-
-                        Text(String(localized: "course_detail_incomplete_assignments"))
-                            .font(TigerDuckTheme.Typography.headline)
-                            .foregroundStyle(Color.textPrimary)
-                            .padding(.horizontal)
-
-                        ForEach(Array(assignments.enumerated()), id: \.element.assignmentId) { _, assignment in
-                            Button {
-                                if let url = assignment.moodleDeepLink {
-                                    UIApplication.shared.open(url)
-                                }
-                            } label: {
-                                HStack {
-                                    Image(systemName: "doc.text")
-                                        .foregroundStyle(Color.accentPrimary)
-                                    VStack(alignment: .leading) {
-                                        Text(assignment.displayTitle)
-                                            .font(TigerDuckTheme.Typography.body)
-                                            .foregroundStyle(Color.textPrimary)
-                                        Text(String(format: String(localized: "course_detail_due_prefix"), assignment.dueDate.shortDateString))
-                                            .font(TigerDuckTheme.Typography.caption)
-                                            .foregroundStyle(assignment.isOverdue ? Color.badgeRed : Color.textSecondary)
-                                    }
-                                    Spacer()
-                                    Image(systemName: "arrow.up.right.square")
-                                        .foregroundStyle(Color.textSecondary)
-                                        .font(.caption)
-                                }
-                            }
-                            .buttonStyle(.plain)
-                            .cardPadding()
-                            .glassCard()
-                            .padding(.horizontal)
-                        }
-                    }
+                    headerSection
+                    emphasisCards
+                    secondaryInfo
+                    assignmentsSection
                 }
-                .padding(.vertical)
+                .padding(.top, TigerDuckTheme.Spacing.xl)
+                .padding(.bottom, TigerDuckTheme.Spacing.lg)
             }
             .background(Color.backgroundPrimary)
-            .navigationTitle(course.displayName)
-            .navigationBarTitleDisplayMode(.large)
+            .toolbar(.hidden, for: .navigationBar)
         }
     }
+
+    // MARK: - Header
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.lg) {
+            HStack(alignment: .firstTextBaseline, spacing: TigerDuckTheme.Spacing.sm) {
+                Text(course.displayName)
+                    .font(.title.bold())
+                    .foregroundStyle(Color.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if course.moodleDeepLink != nil {
+                    Button(action: openMoodleCourse) {
+                        Image(systemName: "arrow.up.right.square.fill")
+                            .font(.system(size: 22))
+                            .foregroundStyle(Color.accentPrimary)
+                    }
+                    // TODO(l10n): add `course_detail_open_moodle_a11y` —
+                    // "在 Moodle 開啟課程" / "Open course in Moodle"
+                    .accessibilityLabel(String(localized: "course_detail_open_moodle_a11y"))
+                }
+            }
+
+            RoundedRectangle(cornerRadius: TigerDuckTheme.CornerRadius.sm)
+                .fill(course.color)
+                .frame(height: 6)
+        }
+        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+    }
+
+    // MARK: - Emphasis cards
+
+    private var emphasisCards: some View {
+        HStack(spacing: TigerDuckTheme.Spacing.md) {
+            EmphasisCard(
+                label: String(localized: "course_detail_classroom_label"),
+                value: classroomValue,
+                policy: appState.visualStylePolicy
+            )
+            EmphasisCard(
+                label: String(localized: "course_detail_time_label"),
+                value: timeValue,
+                policy: appState.visualStylePolicy
+            )
+        }
+        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+    }
+
+    /// Same resolution rule the previous flat layout used: per-weekday lookup
+    /// when we know which day this row represents, otherwise the deduped
+    /// aggregate string. Empty results render as an em-dash placeholder so
+    /// the card always has visible content.
+    private var classroomValue: String {
+        let resolved = weekday.map { course.classroom(for: $0) } ?? SDCourse.dedup(course.classroom)
+        return resolved.isEmpty ? "—" : resolved
+    }
+
+    /// Prefer the explicit time range supplied by the caller (ClassTable
+    /// knows the precise slot). When omitted — e.g. HomeView's TimeSlider
+    /// only hands us the weekday — derive it from the course schedule for
+    /// that weekday so the card never collapses to a dash unnecessarily.
+    private var timeValue: String {
+        if let timeRange, !timeRange.isEmpty { return timeRange }
+        if let weekday, let derived = course.timeRange(for: weekday) { return derived }
+        return "—"
+    }
+
+    // MARK: - Secondary info
+
+    private var secondaryInfo: some View {
+        VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.md) {
+            InfoRow(
+                label: String(localized: "course_detail_instructor_label"),
+                value: course.instructor.isEmpty ? "—" : course.instructor
+            )
+            InfoRow(
+                label: String(localized: "course_detail_code_label"),
+                value: course.courseNo
+            )
+            InfoRow(
+                label: String(localized: "course_detail_credits_label"),
+                value: "\(course.credits)"
+            )
+            InfoRow(
+                label: String(localized: "course_detail_enrollment_label"),
+                value: "\(course.enrolledCount) / \(course.maxCount)"
+            )
+        }
+        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+    }
+
+    // MARK: - Assignments (preserved exactly as before)
+
+    @ViewBuilder
+    private var assignmentsSection: some View {
+        if !assignments.isEmpty {
+            Divider().background(Color.textSecondary)
+                .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+
+            Text(String(localized: "course_detail_incomplete_assignments"))
+                .font(TigerDuckTheme.Typography.headline)
+                .foregroundStyle(Color.textPrimary)
+                .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+
+            ForEach(Array(assignments.enumerated()), id: \.element.assignmentId) { _, assignment in
+                Button {
+                    if let url = assignment.moodleDeepLink {
+                        UIApplication.shared.open(url)
+                    }
+                } label: {
+                    HStack {
+                        Image(systemName: "doc.text")
+                            .foregroundStyle(Color.accentPrimary)
+                        VStack(alignment: .leading) {
+                            Text(assignment.displayTitle)
+                                .font(TigerDuckTheme.Typography.body)
+                                .foregroundStyle(Color.textPrimary)
+                            Text(String(format: String(localized: "course_detail_due_prefix"), assignment.dueDate.shortDateString))
+                                .font(TigerDuckTheme.Typography.caption)
+                                .foregroundStyle(assignment.isOverdue ? Color.badgeRed : Color.textSecondary)
+                        }
+                        Spacer()
+                        Image(systemName: "arrow.up.right.square")
+                            .foregroundStyle(Color.textSecondary)
+                            .font(.caption)
+                    }
+                }
+                .buttonStyle(.plain)
+                .cardPadding()
+                .glassCard()
+                .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Always route through the `moodlemobile://` deep link — matches the
+    /// assignment-row convention above and keeps the user inside the Moodle
+    /// app instead of bouncing out to Safari.
+    private func openMoodleCourse() {
+        guard let deepLink = course.moodleDeepLink else { return }
+        UIApplication.shared.open(deepLink)
+    }
 }
+
+// MARK: - Emphasis card
+
+/// Big-text card used for the two fields that earn visual emphasis
+/// (classroom and time). Label sits small on top, value renders large
+/// with a rounded display font so the two cards read as a single
+/// at-a-glance pair.
+private struct EmphasisCard: View {
+    let label: String
+    let value: String
+    let policy: VisualStylePolicy
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.xs) {
+            Text(label)
+                .font(TigerDuckTheme.Typography.caption)
+                .foregroundStyle(Color.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text(value)
+                .font(.system(size: 22, weight: .semibold, design: .rounded))
+                .foregroundStyle(Color.textPrimary)
+                .lineLimit(2)
+                .minimumScaleFactor(0.7)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(TigerDuckTheme.Spacing.md)
+        .presetCard(policy: policy)
+    }
+}
+
+// MARK: - Label/value row
 
 private struct InfoRow: View {
     let label: String
     let value: String
 
     var body: some View {
-        HStack {
+        HStack(alignment: .top) {
             Text(label)
                 .font(TigerDuckTheme.Typography.body)
                 .foregroundStyle(Color.textSecondary)
@@ -91,7 +225,7 @@ private struct InfoRow: View {
             Text(value)
                 .font(TigerDuckTheme.Typography.body)
                 .foregroundStyle(Color.textPrimary)
+                .multilineTextAlignment(.trailing)
         }
     }
 }
-

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
@@ -2,7 +2,10 @@ import SwiftUI
 
 struct CourseTimeCard: View {
     let state: CourseState
-    let onSelect: ((SDCourse) -> Void)?
+    /// Hands back the full slot (not just the course) so callers can preserve
+    /// the precise day + start/end of the tapped period — the detail sheet
+    /// uses both to render the right time range and weekday-specific classroom.
+    let onSelect: ((CourseTimeSlot) -> Void)?
     var policy: VisualStylePolicy = VisualStylePolicy(preset: .default)
 
     var body: some View {
@@ -74,7 +77,7 @@ struct CourseTimeCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .modifier(CourseCardSurfaceModifier(tint: course.color, policy: policy))
         .opacity(opacity)
-        .onTapGesture { onSelect?(course) }
+        .onTapGesture { onSelect?(slot) }
     }
 
     private func subtitle(for course: SDCourse, weekday: Int) -> String {

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/TimeSliderSection.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/TimeSliderSection.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct TimeSliderSection: View {
     let courses: [SDCourse]
-    var onSelectCourse: ((SDCourse) -> Void)? = nil
+    var onSelectCourse: ((CourseTimeSlot) -> Void)? = nil
     @Environment(AppState.self) private var appState
     @State private var viewModel = TimeSliderViewModel()
 

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/TimeSliderSection.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/TimeSliderSection.swift
@@ -14,7 +14,15 @@ struct TimeSliderSection: View {
         .onAppear {
             viewModel.configure(courses: courses)
         }
-        .onChange(of: courses.map(\.courseNo)) {
+        // Reconfigure whenever any field the slot rendering depends on shifts
+        // — not just enrolment changes. After a sync the same courseNo can
+        // carry a new schedule, classroom map, or rename, and slots tapped
+        // from the slider now ferry the whole `CourseTimeSlot` into the
+        // detail sheet; keeping stale slot data here would surface old
+        // weekday / time / classroom / name in the sheet.
+        .onChange(of: courses.map { course in
+            "\(course.courseNo)|\(course.scheduleJSON)|\(course.classroomMapJSON)|\(course.displayName)"
+        }) {
             viewModel.configure(courses: courses)
         }
     }

--- a/swift/TigerDuck/Features/Home/HomeView.swift
+++ b/swift/TigerDuck/Features/Home/HomeView.swift
@@ -119,12 +119,15 @@ struct HomeView: View {
             homeDestination(for: feature)
         }
         .sheet(item: $viewModel.selectedCourse) { course in
+            let slot = viewModel.selectedCourseSlot
             CourseDetailSheet(
                 course: course,
                 assignments: viewModel.assignmentsFor(courseNo: course.courseNo),
-                weekday: Date().scheduleWeekday
+                timeRange: slot.map { "\($0.start.timeString) - \($0.end.timeString)" },
+                weekday: slot?.date.scheduleWeekday ?? Date().scheduleWeekday
             )
             .presentationDetents([.medium, .large])
+            .onDisappear { viewModel.selectedCourseSlot = nil }
         }
         .onChange(of: viewModel.isEditingHome) { _, isEditing in
             if !isEditing {
@@ -350,9 +353,10 @@ private struct HomeSectionView: View {
             case .todayCourses:
                 TimeSliderSection(
                     courses: viewModel.allCourses,
-                    onSelectCourse: { course in
+                    onSelectCourse: { slot in
                         guard !viewModel.isEditingHome else { return }
-                        viewModel.selectedCourse = course
+                        viewModel.selectedCourseSlot = slot
+                        viewModel.selectedCourse = slot.course
                     }
                 )
             case .upcomingAssignments:

--- a/swift/TigerDuck/Features/Home/HomeViewModel.swift
+++ b/swift/TigerDuck/Features/Home/HomeViewModel.swift
@@ -207,6 +207,11 @@ final class HomeViewModel {
     }
 
     var selectedCourse: SDCourse? = nil
+    /// Set together with ``selectedCourse`` when the detail sheet is opened
+    /// from the TimeSlider so the sheet can render the exact slot the user
+    /// tapped (right weekday, right start/end). Nil when the sheet was
+    /// opened from somewhere that doesn't have slot context.
+    var selectedCourseSlot: CourseTimeSlot? = nil
 
     func archiveAssignment(_ assignment: SDAssignment) {
         guard let idx = allAssignmentsCache.firstIndex(where: { $0.assignmentId == assignment.assignmentId }) else { return }

--- a/swift/TigerDuck/Models/SwiftData/SDCourse.swift
+++ b/swift/TigerDuck/Models/SwiftData/SDCourse.swift
@@ -265,3 +265,35 @@ extension SDCourse {
         NotificationCenter.default.post(name: AppConstants.courseSkipStateDidChange, object: nil)
     }
 }
+
+extension SDCourse {
+    /// Deep link into the Moodle Mobile app for this course. Mirrors
+    /// ``SDAssignment/moodleDeepLink`` — same `moodlemobile://https//<host>?redirect=…`
+    /// envelope pointing at `/course/view.php?id=<N>`. The numeric id is
+    /// looked up from ``DataCache/lookupMoodleCourseId(idnumber:)``, which
+    /// ``AppServiceBridge`` keeps fresh off the enrolled-courses fetch.
+    ///
+    /// Returns `nil` when either no idnumber is recorded for the course
+    /// (e.g. user-added courses), or the id-map cache hasn't been populated
+    /// yet (cold launch before first sync) — UI hides the button in both
+    /// cases so the user never taps into an "app cannot open this URL" sheet.
+    var moodleDeepLink: URL? {
+        guard let idnumber = moodleIdNumber, !idnumber.isEmpty,
+              let numericId = DataCache.shared.lookupMoodleCourseId(idnumber: idnumber) else {
+            return nil
+        }
+
+        var inner = URLComponents()
+        inner.path = "/course/view.php"
+        inner.queryItems = [URLQueryItem(name: "id", value: String(numericId))]
+        guard let redirectTarget = inner.string else { return nil }
+
+        let host = AppConstants.moodleBaseURL.host ?? "moodle2.ntust.edu.tw"
+        var components = URLComponents()
+        components.scheme = "moodlemobile"
+        components.host = "https"
+        components.path = "//\(host)"
+        components.queryItems = [URLQueryItem(name: "redirect", value: redirectTarget)]
+        return components.url
+    }
+}

--- a/swift/TigerDuck/Services/Core/DataCache.swift
+++ b/swift/TigerDuck/Services/Core/DataCache.swift
@@ -356,6 +356,38 @@ final class DataCache {
         }
     }
 
+    // MARK: - Moodle course id map (idnumber → numeric id)
+
+    /// Persisted map populated by ``AppServiceBridge`` whenever it fetches
+    /// the user's Moodle enrolled-courses list. Exists because Moodle Mobile's
+    /// deep-link router only honors `?id=N` redirects reliably — `?idnumber=…`
+    /// is accepted by the web but not by the in-app handler — so we cache the
+    /// numeric id off the enrolled-courses payload and look it up at deep-link
+    /// build time. Lives in ``persistentDir`` so the map survives cache
+    /// sweeps that wipe localized course data.
+    func saveMoodleCourseIdMap(_ map: [String: Int]) {
+        save(map, to: "moodle_course_id_map.json", in: persistentDir)
+    }
+
+    func loadMoodleCourseIdMap() -> [String: Int] {
+        load(from: "moodle_course_id_map.json", in: persistentDir) ?? [:]
+    }
+
+    /// Merge new entries into the existing map and persist. Later entries win
+    /// on collision so a course whose numeric id gets reissued mid-semester
+    /// (rare but documented in NTUST archive ops) takes the newer value.
+    func mergeMoodleCourseIdMap(_ additions: [String: Int]) {
+        guard !additions.isEmpty else { return }
+        var current = loadMoodleCourseIdMap()
+        for (key, value) in additions { current[key] = value }
+        saveMoodleCourseIdMap(current)
+    }
+
+    func lookupMoodleCourseId(idnumber: String) -> Int? {
+        guard !idnumber.isEmpty else { return nil }
+        return loadMoodleCourseIdMap()[idnumber]
+    }
+
     // MARK: - Private helpers
 
     private func save<T: Encodable>(_ value: T, to filename: String, in directory: URL? = nil) {

--- a/swift/TigerDuck/Services/Core/DataCache.swift
+++ b/swift/TigerDuck/Services/Core/DataCache.swift
@@ -308,6 +308,7 @@ final class DataCache {
             ("archived_assignments.json", persistentDir),
             ("locally_completed_assignments.json", persistentDir),
             ("bulletin_summaries.json", cacheDir),
+            ("moodle_course_id_map.json", persistentDir),
         ]
         for (name, dir) in filenames {
             let url = dir.appendingPathComponent(name)

--- a/swift/TigerDuck/Services/Core/DataCache.swift
+++ b/swift/TigerDuck/Services/Core/DataCache.swift
@@ -365,23 +365,19 @@ final class DataCache {
     /// is accepted by the web but not by the in-app handler — so we cache the
     /// numeric id off the enrolled-courses payload and look it up at deep-link
     /// build time. Lives in ``persistentDir`` so the map survives cache
-    /// sweeps that wipe localized course data.
+    /// sweeps that wipe localized course data; cleared on logout via
+    /// ``clearUserScopedData()``.
+    ///
+    /// **Always overwrite the whole map** with the fresh enrolled-courses
+    /// snapshot — additive merging would leak stale entries for courses the
+    /// user has been un-enrolled from or whose numeric id got reissued, and
+    /// `SDCourse.moodleDeepLink` would then keep pointing at a dead course.
     func saveMoodleCourseIdMap(_ map: [String: Int]) {
         save(map, to: "moodle_course_id_map.json", in: persistentDir)
     }
 
     func loadMoodleCourseIdMap() -> [String: Int] {
         load(from: "moodle_course_id_map.json", in: persistentDir) ?? [:]
-    }
-
-    /// Merge new entries into the existing map and persist. Later entries win
-    /// on collision so a course whose numeric id gets reissued mid-semester
-    /// (rare but documented in NTUST archive ops) takes the newer value.
-    func mergeMoodleCourseIdMap(_ additions: [String: Int]) {
-        guard !additions.isEmpty else { return }
-        var current = loadMoodleCourseIdMap()
-        for (key, value) in additions { current[key] = value }
-        saveMoodleCourseIdMap(current)
     }
 
     func lookupMoodleCourseId(idnumber: String) -> Int? {


### PR DESCRIPTION
This pull request introduces a significant UX and technical improvement to the course detail sheet and deep-linking into Moodle Mobile. The course detail modal is redesigned for clarity and quick access to essential information, and a robust caching mechanism is added to reliably generate deep links into the Moodle app for each course. The changes also propagate time slot context through the Home view, so the detail sheet can always display the correct time and classroom for the selected course.

Key changes include:

### 1. Course Detail Sheet Redesign & Contextual Improvements

- The `CourseDetailSheet` is restructured to visually emphasize classroom and time information in dedicated cards, followed by secondary metadata and outstanding assignments. It now receives precise time slot context (time range and weekday) when opened from the Home view, ensuring accurate display of course details. [[1]](diffhunk://#diff-5db1ea6817f47f0eb7358239f3e839bb11819383cdfce85e5e5267cd7f86f280R3-R14) [[2]](diffhunk://#diff-5db1ea6817f47f0eb7358239f3e839bb11819383cdfce85e5e5267cd7f86f280L13-R138) [[3]](diffhunk://#diff-5db1ea6817f47f0eb7358239f3e839bb11819383cdfce85e5e5267cd7f86f280L68-L97) [[4]](diffhunk://#diff-f59f0842e84978a9ad67e48b36c5782d408494941f0f53c830e241db39a4fa66L5-R8) [[5]](diffhunk://#diff-f59f0842e84978a9ad67e48b36c5782d408494941f0f53c830e241db39a4fa66L77-R80) [[6]](diffhunk://#diff-b9e99350d2e7ad1bec8fffc27559c1597d2bab41d9f3547dbb22d6b458c840f9L5-R5) [[7]](diffhunk://#diff-86fc9d9c0512fa518682fec0a511d0d047a72b343de11ff106db1d595cf84752R122-R130) [[8]](diffhunk://#diff-86fc9d9c0512fa518682fec0a511d0d047a72b343de11ff106db1d595cf84752L353-R359) [[9]](diffhunk://#diff-9ff3878045b999e06563eb00dd657fb1bfe4350facfb243b00d90cd0d6ce559aR210-R214)

### 2. Reliable Moodle Mobile Deep Linking

- Adds a computed property `moodleDeepLink` to `SDCourse`, generating a `moodlemobile://` URL that targets the correct course in the Moodle app using a numeric course ID. This ensures deep links work reliably in-app (unlike `idnumber`-based links, which are not consistently supported by Moodle Mobile).

### 3. Caching and Sync of Moodle Course ID Map

- Implements a persistent cache in `DataCache` to map Moodle course `idnumber` to numeric IDs, updated on every enrolled-courses fetch. This enables the `moodleDeepLink` to always have access to the latest IDs, even across app launches or after course renames. The cache is updated in both the course and assignment sync pipelines to ensure freshness. [[1]](diffhunk://#diff-bf78bd50601f35a49a089acf682e6415ea42a24d34e949ad87eb6a01b6ec1ea2R359-R390) [[2]](diffhunk://#diff-6353f0bbd831c9117483b5feb1df67354fd485e30810fbe55e34e61476ba0e51R126-R138) [[3]](diffhunk://#diff-6353f0bbd831c9117483b5feb1df67354fd485e30810fbe55e34e61476ba0e51R415-R427)

---

These changes collectively improve the reliability of deep linking, the clarity of course information, and the overall user experience when navigating course details and jumping into Moodle.