### PR TITLE
Enhance Debug build configuration for push notifications and local setup

### DIFF
--- a/docs/local-dev-backend.md
+++ b/docs/local-dev-backend.md
@@ -1,0 +1,170 @@
+# Local dev backend
+
+This guide is for contributors running a **local TigerDuck backend** on their
+own Mac while developing the iOS app. It is **not** for production deploys —
+production lives on a separate VPS behind nginx-proxy-manager, with its own
+`.env`, its own database, and its own APNs environment.
+
+The split exists because:
+
+- APNs has two parallel environments (sandbox / production) and a device
+  token from one cannot be used to push via the other. Xcode Debug builds
+  produce sandbox tokens; TestFlight / App Store builds produce production
+  tokens. Talking to the wrong backend → silent push failures.
+- Production database stores real device tokens for real users. Running
+  schema migrations or wiping data against it during development is not OK.
+- Iterating on the backend (restart, migrate, hack endpoints) should never
+  affect users.
+
+The iOS app auto-resolves which backend to talk to based on the build
+configuration. There is no UI toggle, no manual switch.
+
+## How endpoint selection works
+
+```
+Build configuration       APNs env        Backend URL
+─────────────────────────────────────────────────────────────────────────────
+Debug (Xcode Run)         development     Secrets.plist["DebugServerURL"]
+                                          fallback: http://localhost:40000/v2
+Release (TestFlight,      production      https://api.tigerduck.app/v2
+         Archive,
+         App Store)
+```
+
+The Debug-build resolution chain is `PushCoordinator.resolveServerURL()`:
+
+1. `Defaults[.pushServerURLOverride]` — UserDefaults escape hatch for
+   ad-hoc switching to staging. Gated by an allowlist
+   (`isOverrideAllowed`) — public hosts must be `api.tigerduck.app` or
+   `staging.api.tigerduck.app` over HTTPS; private targets must be
+   loopback or RFC1918 IPv4 (HTTP or HTTPS).
+2. `Secrets.plist["DebugServerURL"]` — your per-developer LAN backend.
+3. `http://localhost:40000/v2` — Simulator-friendly fallback.
+
+At launch `PushCoordinator.assertEnvConsistency()` crashes Debug builds if
+the resolved URL and `PushAPNsEnv.resolvedForBuild` disagree (e.g. a stale
+override pointing prod from a Debug build). Release builds strip the
+assert under `-O`.
+
+## One-time setup
+
+### 1. Pick a fixed LAN IP for your Mac
+
+Configure your router to give your Mac a static DHCP lease, or set a manual
+IP under System Settings → Network. You want it to survive WiFi reconnects
+and reboots without changing.
+
+Examples that work: `192.168.1.42`, `10.0.0.50`, `172.16.5.3`.
+
+The iOS app's override allowlist accepts anything in 10/8, 172.16/12,
+192.168/16, plus `localhost` / `127.0.0.1`. No per-IP configuration on
+the iOS side.
+
+### 2. Start a local backend
+
+The repo's prod-shaped `backend/start.sh` does not publish the backend port
+to the host (it expects nginx-proxy-manager to proxy in over a docker
+network). For local dev, you need the port reachable from your iPhone.
+
+Easiest path: add a `docker-compose.override.yml` next to
+`backend/docker-compose.yml`:
+
+```yaml
+services:
+  backend:
+    ports:
+      - "40000:40000"
+    networks:
+      - tigerduck-db
+      # drop proxy-net — there is no NPM locally
+```
+
+Then fill `backend/.env` (see `backend/.env.example`). Key values for dev:
+
+- `TIGERDUCK_ENV=development`
+- `TIGERDUCK_APNS_ENV=development` ← the critical one
+- `TIGERDUCK_API_SHARED_SECRET=…` ← copy this into `DebugAPIToken` below
+- `POSTGRES_PASSWORD=…` ← only used by your local stack
+
+APNs `.p8` key file: same key works for both `development` and
+`production` envs (Apple's auth keys are env-agnostic). Drop it at
+`backend/server/secrets/AuthKey_<KEY_ID>.p8`.
+
+Bring it up:
+
+```sh
+cd backend
+./start.sh   # docker compose up -d --build && tails the log
+```
+
+The backend should now respond on `http://<your-mac-LAN-IP>:40000/v2`.
+
+### 3. Fill `Secrets.plist` on the iOS side
+
+`swift/TigerDuck/Secrets.plist` is gitignored. Copy the template:
+
+```sh
+cp swift/TigerDuck/Secrets.example.plist swift/TigerDuck/Secrets.plist
+```
+
+Edit three keys:
+
+```xml
+<key>APIToken</key>
+<string>…production shared secret…</string>      <!-- from prod backend ops -->
+
+<key>DebugAPIToken</key>
+<string>…dev backend shared secret…</string>     <!-- = your TIGERDUCK_API_SHARED_SECRET -->
+
+<key>DebugServerURL</key>
+<string>http://192.168.X.X:40000/v2</string>     <!-- your Mac's LAN IP -->
+```
+
+If you only develop against the Simulator, you can omit `DebugServerURL`
+— the Debug fallback `http://localhost:40000/v2` resolves to your Mac
+because the Simulator shares network namespace with the host.
+
+If you leave `DebugAPIToken` blank, `resolveSharedSecret()` falls back to
+`APIToken`, matching the prior single-token workflow. Less hygienic, fine
+for solo iteration.
+
+## Running the app
+
+- **Simulator**: `⌘R` in Xcode (Debug config). The app talks to your local
+  backend automatically.
+- **Physical device**: `⌘R` in Xcode with the device selected. Device must
+  be on the same LAN as your Mac, and your Mac's firewall must allow
+  inbound 40000 (System Settings → Network → Firewall → Options).
+
+The Debug startup assert will fire if anything is misaligned: check the
+console for "Push env mismatch:" and follow the diagnostic.
+
+## Sanity checks before reporting "push doesn't work"
+
+1. **Build configuration**: `defaults read org.ntust.app.TigerDuck` and look
+   for `pushServerURLOverride`. If set to a prod URL while building Debug,
+   the override wins — clear it (`defaults delete org.ntust.app.TigerDuck
+   pushServerURLOverride`) or stop the override.
+2. **APNs env on device side**: open the app, go to push diagnostics. The
+   reported APNs env should be `development` for Debug, `production` for
+   TestFlight / App Store.
+3. **APNs env on backend side**: `docker compose exec backend env | grep
+   APNS_ENV` should report `development` on your local stack. If it says
+   `production`, you forgot to flip `.env`.
+4. **Token round-trip**: enable push in the app once, then `docker compose
+   exec backend psql ... -c "select apns_env, created_at from devices order
+   by created_at desc limit 3;"`. The newest row should be `development`.
+
+Mismatches across these four are the entire population of "why didn't my
+push arrive" failures we have seen.
+
+## What lives where
+
+| Concern | iOS-side | Backend-side |
+|---|---|---|
+| URL resolution | `PushCoordinator.resolveServerURL` | n/a |
+| Shared secret read | `PushCoordinator.resolveSharedSecret` | `TIGERDUCK_API_SHARED_SECRET` |
+| APNs env constant | `PushAPNsEnv.resolvedForBuild` | `TIGERDUCK_APNS_ENV` |
+| ATS exception | `swift/TigerDuck/Info.plist` (`NSAllowsLocalNetworking`) | n/a |
+| Production endpoint | `AppConstants.productionPushServerURL` | nginx-proxy-manager → tigerduck-internal:40000 |
+| Per-dev override | `Secrets.plist["DebugServerURL"]` | n/a |

--- a/swift/TigerDuck.xcodeproj/project.pbxproj
+++ b/swift/TigerDuck.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				AGENTS.md,
+				Info.plist,
 				LiveActivity/AGENTS.md,
 				Services/AGENTS.md,
 				Services/Migrations/AGENTS.md,
@@ -760,6 +761,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				EXCLUDED_SOURCE_FILE_NAMES = "";
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TigerDuck/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
@@ -812,6 +814,7 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				EXCLUDED_SOURCE_FILE_NAMES = "";
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TigerDuck/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;

--- a/swift/TigerDuck/App/AppConstants.swift
+++ b/swift/TigerDuck/App/AppConstants.swift
@@ -44,11 +44,17 @@ nonisolated enum AppConstants {
         static let pushDeviceId = "push_device_id"
     }
 
-    /// Base URL for the push notification server. Production default points at
-    /// the nginx-proxy-manager + Cloudflare-fronted Mac mini. Override via
-    /// ``UserDefaultsKeys/pushServerURLOverride`` during development to talk
-    /// to a LAN instance.
-    static let defaultPushServerURL = URL.knownGood("https://api.tigerduck.app/v2")
+    /// Production push/bulletin backend. Release builds always resolve here.
+    /// Debug builds resolve through ``PushCoordinator/resolveServerURL()``,
+    /// which reads per-developer `Secrets.plist["DebugServerURL"]` (gitignored)
+    /// or falls back to ``fallbackDebugPushServerURL`` for Simulator setups.
+    static let productionPushServerURL = URL.knownGood("https://api.tigerduck.app/v2")
+
+    /// Default Debug-build endpoint when `Secrets.plist` has no `DebugServerURL`.
+    /// Works on Simulator (localhost = host Mac); on a physical device this
+    /// resolves to the device itself and will fail to connect — physical-device
+    /// contributors must set `DebugServerURL` to their Mac's LAN IP.
+    static let fallbackDebugPushServerURL = URL.knownGood("http://localhost:40000/v2")
 
     /// How many semesters back the relabel sweep walks when display-toggle
     /// settings change. NTUST keeps ~2 active semesters in flight; 4 covers

--- a/swift/TigerDuck/Info.plist
+++ b/swift/TigerDuck/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+    Partial Info.plist that merges with the keys synthesized from
+    INFOPLIST_KEY_* build settings (GENERATE_INFOPLIST_FILE = YES).
+
+    Lives here because nested dictionary keys (NSAppTransportSecurity)
+    cannot be expressed as flat INFOPLIST_KEY_* settings.
+
+    NSAllowsLocalNetworking only relaxes ATS for loopback, .local, and
+    RFC1918 private IPs. Public hosts still must speak HTTPS — Release
+    builds hit api.tigerduck.app over HTTPS and are unaffected.
+-->
+<plist version="1.0">
+<dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/swift/TigerDuck/Secrets.example.plist
+++ b/swift/TigerDuck/Secrets.example.plist
@@ -2,20 +2,30 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
     Template for Secrets.plist. Copy this file to Secrets.plist (which is
-    gitignored) and replace the placeholder with the real token.
+    gitignored) and replace the placeholders.
 
-    PushCoordinator.resolveSharedSecret() reads APIToken at runtime via
-    Bundle.main.url(forResource: "Secrets", withExtension: "plist").
+    Release builds (TestFlight / App Store) read APIToken and hit
+    https://api.tigerduck.app/v2 — both values must match the production
+    backend's TIGERDUCK_API_SHARED_SECRET or every write request 401s.
 
-    Must match the server's TIGERDUCK_API_SHARED_SECRET (backend/.env) or
-    every write request from this build will 401.
+    Debug builds (Xcode Run) read DebugAPIToken and DebugServerURL — each
+    contributor points these at their own Mac's local dev backend. If
+    DebugServerURL is missing, Debug builds fall back to
+    http://localhost:40000/v2 (works on Simulator, not on a physical device).
+    If DebugAPIToken is missing, Debug builds fall back to APIToken.
 
-    Generate a fresh one with:
+    Generate fresh tokens with:
         python3 -c "import secrets; print(secrets.token_urlsafe(32))"
 -->
 <plist version="1.0">
 <dict>
     <key>APIToken</key>
-    <string>REPLACE_ME_WITH_THE_SAME_SECRET_AS_THE_SERVER</string>
+    <string>REPLACE_ME_WITH_PRODUCTION_SHARED_SECRET</string>
+
+    <key>DebugAPIToken</key>
+    <string>REPLACE_ME_WITH_LOCAL_DEV_BACKEND_SHARED_SECRET</string>
+
+    <key>DebugServerURL</key>
+    <string>http://192.168.X.X:40000/v2</string>
 </dict>
 </plist>

--- a/swift/TigerDuck/Services/API/Bulletin/BulletinAPIClient.swift
+++ b/swift/TigerDuck/Services/API/Bulletin/BulletinAPIClient.swift
@@ -14,7 +14,7 @@ final class BulletinAPIClient: Sendable {
     private let logger = Logger(subsystem: "org.ntust.app.TigerDuck", category: "Bulletin.API")
 
     init(
-        baseURL: URL = AppConstants.defaultPushServerURL,
+        baseURL: URL = PushCoordinator.resolveServerURL(),
         session: URLSession? = nil,
         sharedSecret: String? = nil
     ) {

--- a/swift/TigerDuck/Services/Push/PushAPIClient.swift
+++ b/swift/TigerDuck/Services/Push/PushAPIClient.swift
@@ -14,7 +14,7 @@ final class PushAPIClient: Sendable {
     private let logger = Logger(subsystem: "org.ntust.app.TigerDuck", category: "Push.API")
 
     init(
-        baseURL: URL = AppConstants.defaultPushServerURL,
+        baseURL: URL = PushCoordinator.resolveServerURL(),
         session: URLSession? = nil,
         sharedSecret: String? = nil
     ) {

--- a/swift/TigerDuck/Services/Push/PushCoordinator.swift
+++ b/swift/TigerDuck/Services/Push/PushCoordinator.swift
@@ -235,12 +235,19 @@ final class PushCoordinator {
     }
 
     #if DEBUG
+    /// Reads `Secrets.plist["DebugServerURL"]` and runs it through the same
+    /// gate as the UserDefaults override path. Mis-filled or template values
+    /// (e.g. the literal `http://192.168.X.X:40000/v2` from
+    /// `Secrets.example.plist`) return nil so the resolver falls back to
+    /// `localhost:40000` instead of returning an unreachable URL that would
+    /// either trip `assertEnvConsistency()` at launch or, with assertions
+    /// disabled, silently let the app talk to an arbitrary host.
     nonisolated private static func readDebugServerURL() -> URL? {
         guard let dict = secretsPlistDict(),
               let raw = dict["DebugServerURL"] as? String,
               !raw.isEmpty,
               let url = URL(string: raw),
-              url.host != nil
+              isOverrideAllowed(url)
         else { return nil }
         return url
     }

--- a/swift/TigerDuck/Services/Push/PushCoordinator.swift
+++ b/swift/TigerDuck/Services/Push/PushCoordinator.swift
@@ -284,4 +284,35 @@ final class PushCoordinator {
         }
         return NSDictionary(contentsOf: url)
     }
+
+    /// Crashes Debug builds at launch when the resolved server URL does not
+    /// match the APNs environment baked into the binary (or each other).
+    /// Compiles down to a no-op in Release builds — `assert` is stripped
+    /// under `-O`, so end users never see this.
+    ///
+    /// Guards against the regression where someone flips `PushAPNsEnv` or
+    /// `AppConstants.productionPushServerURL` without flipping the other,
+    /// or seeds a stale UserDefaults override pointing the wrong way.
+    nonisolated static func assertEnvConsistency() {
+        let resolved = resolveServerURL()
+        let host = resolved.host ?? ""
+        #if DEBUG
+        let expectedEnv = "development"
+        let hostOK = host == "localhost"
+            || host == "127.0.0.1"
+            || isPrivateIPv4(host)
+            || host == "staging.api.tigerduck.app"
+        #else
+        let expectedEnv = "production"
+        let hostOK = host == "api.tigerduck.app"
+        #endif
+        assert(
+            hostOK,
+            "Push env mismatch: \(expectedEnv) build resolved to \(resolved)"
+        )
+        assert(
+            PushAPNsEnv.resolvedForBuild == expectedEnv,
+            "Push env mismatch: build is \(expectedEnv) but PushAPNsEnv = \(PushAPNsEnv.resolvedForBuild)"
+        )
+    }
 }

--- a/swift/TigerDuck/Services/Push/PushCoordinator.swift
+++ b/swift/TigerDuck/Services/Push/PushCoordinator.swift
@@ -162,31 +162,90 @@ final class PushCoordinator {
 
     // MARK: - Helpers
 
-    /// Hosts that the push-server URL override is allowed to target. The
-    /// default production endpoint plus a small set of dev/staging hosts.
-    /// An attacker-supplied override (via UserDefaults seeding from a
-    /// compromised backup, MDM, or a future dev panel) cannot point the
-    /// app at an arbitrary server outside this list.
-    private static let pushServerHostAllowlist: Set<String> = [
+    /// Public hosts the override path is allowed to target. Production +
+    /// staging only; anything else must resolve to loopback or an RFC1918
+    /// private IPv4 (see ``isOverrideAllowed(_:)``). An attacker-supplied
+    /// override (via UserDefaults seeding from a compromised backup, MDM,
+    /// or a future dev panel) cannot point the app at an arbitrary public
+    /// server outside this list.
+    private static let publicHostAllowlist: Set<String> = [
         "api.tigerduck.app",
         "staging.api.tigerduck.app",
-        "localhost",
-        "127.0.0.1",
     ]
 
-    static func resolveServerURL() -> URL {
+    /// Resolves the backend URL for this build.
+    ///
+    /// Release builds always return ``AppConstants/productionPushServerURL``.
+    ///
+    /// Debug builds resolve in priority order:
+    ///   1. `Defaults[.pushServerURLOverride]` (UserDefaults escape hatch,
+    ///      gated by ``isOverrideAllowed(_:)``)
+    ///   2. `Secrets.plist["DebugServerURL"]` (per-developer LAN backend;
+    ///      file is gitignored so each contributor sets their own Mac's IP)
+    ///   3. ``AppConstants/fallbackDebugPushServerURL`` (Simulator-friendly
+    ///      `http://localhost:40000/v2`)
+    nonisolated static func resolveServerURL() -> URL {
         #if DEBUG
         if let override = Defaults[.pushServerURLOverride],
            !override.isEmpty,
            let url = URL(string: override),
-           url.scheme == "https" || url.host == "localhost" || url.host == "127.0.0.1",
-           let host = url.host,
-           pushServerHostAllowlist.contains(host) {
+           isOverrideAllowed(url) {
             return url
         }
+        if let url = readDebugServerURL() {
+            return url
+        }
+        return AppConstants.fallbackDebugPushServerURL
+        #else
+        return AppConstants.productionPushServerURL
         #endif
-        return AppConstants.defaultPushServerURL
     }
+
+    /// Whether `url` may be used as a runtime override.
+    ///
+    /// Public hosts are exact-matched against ``publicHostAllowlist``;
+    /// everything else must be loopback or an RFC1918 private IPv4 literal.
+    /// `http://` is allowed only for private/loopback targets — public hosts
+    /// must speak HTTPS.
+    nonisolated static func isOverrideAllowed(_ url: URL) -> Bool {
+        guard let host = url.host else { return false }
+        if publicHostAllowlist.contains(host) {
+            return url.scheme == "https"
+        }
+        if host == "localhost" || host == "127.0.0.1" || isPrivateIPv4(host) {
+            return url.scheme == "http" || url.scheme == "https"
+        }
+        return false
+    }
+
+    /// True if `host` parses as an RFC1918 private IPv4 literal
+    /// (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16). Hostnames, IPv6
+    /// literals, and malformed input return false.
+    nonisolated static func isPrivateIPv4(_ host: String) -> Bool {
+        let parts = host.split(separator: ".")
+        guard parts.count == 4 else { return false }
+        let octets = parts.compactMap { Int($0) }
+        guard octets.count == 4, octets.allSatisfy({ (0...255).contains($0) }) else { return false }
+        switch (octets[0], octets[1]) {
+        case (10, _): return true
+        case (172, 16...31): return true
+        case (192, 168): return true
+        default: return false
+        }
+    }
+
+    #if DEBUG
+    nonisolated private static func readDebugServerURL() -> URL? {
+        guard let plist = Bundle.main.url(forResource: "Secrets", withExtension: "plist"),
+              let dict = NSDictionary(contentsOf: plist),
+              let raw = dict["DebugServerURL"] as? String,
+              !raw.isEmpty,
+              let url = URL(string: raw),
+              url.host != nil
+        else { return nil }
+        return url
+    }
+    #endif
 
     /// Read the shared secret from `Secrets.plist` (gitignored) bundled
     /// with the app. The `APIToken` key must match the server's

--- a/swift/TigerDuck/Services/Push/PushCoordinator.swift
+++ b/swift/TigerDuck/Services/Push/PushCoordinator.swift
@@ -162,14 +162,20 @@ final class PushCoordinator {
 
     // MARK: - Helpers
 
-    /// Public hosts the override path is allowed to target. Production +
-    /// staging only; anything else must resolve to loopback or an RFC1918
-    /// private IPv4 (see ``isOverrideAllowed(_:)``). An attacker-supplied
-    /// override (via UserDefaults seeding from a compromised backup, MDM,
-    /// or a future dev panel) cannot point the app at an arbitrary public
-    /// server outside this list.
+    /// Public hosts a Debug override is allowed to target. Staging only —
+    /// production is intentionally absent: a Debug binary has
+    /// `PushAPNsEnv.resolvedForBuild = "development"` baked in at compile
+    /// time, so pointing it at the prod backend creates an apns_env
+    /// mismatch the production APNs server would reject anyway. Allowing
+    /// it here would let `isOverrideAllowed` pass a URL that
+    /// `assertEnvConsistency()` then crashes on every launch.
+    ///
+    /// Everything else must resolve to loopback or an RFC1918 private
+    /// IPv4 (see ``isOverrideAllowed(_:)``). An attacker-supplied override
+    /// (via UserDefaults seeding from a compromised backup, MDM, or a
+    /// future dev panel) cannot point the app at an arbitrary public
+    /// server outside this list. Release builds bypass this gate entirely.
     private static let publicHostAllowlist: Set<String> = [
-        "api.tigerduck.app",
         "staging.api.tigerduck.app",
     ]
 

--- a/swift/TigerDuck/Services/Push/PushCoordinator.swift
+++ b/swift/TigerDuck/Services/Push/PushCoordinator.swift
@@ -236,8 +236,7 @@ final class PushCoordinator {
 
     #if DEBUG
     nonisolated private static func readDebugServerURL() -> URL? {
-        guard let plist = Bundle.main.url(forResource: "Secrets", withExtension: "plist"),
-              let dict = NSDictionary(contentsOf: plist),
+        guard let dict = secretsPlistDict(),
               let raw = dict["DebugServerURL"] as? String,
               !raw.isEmpty,
               let url = URL(string: raw),
@@ -248,23 +247,41 @@ final class PushCoordinator {
     #endif
 
     /// Read the shared secret from `Secrets.plist` (gitignored) bundled
-    /// with the app. The `APIToken` key must match the server's
-    /// `TIGERDUCK_API_SHARED_SECRET`. A missing file or empty value returns
-    /// nil, which preserves the dev-friendly no-auth path.
+    /// with the app. Must match the corresponding backend's
+    /// `TIGERDUCK_API_SHARED_SECRET` or every write request 401s.
     ///
-    /// Falls back to the legacy Info.plist key so older builds keep
-    /// working if an unrelated CI pipeline still injects there.
+    /// Resolution order:
+    ///   1. Debug builds: `DebugAPIToken` — paired with `DebugServerURL`,
+    ///      so each contributor's local backend can have its own secret
+    ///      without leaking the production one through dev Macs.
+    ///   2. `APIToken` — production secret; also the Debug fallback when
+    ///      a contributor leaves `DebugAPIToken` blank (matches the old
+    ///      "single shared token" workflow).
+    ///   3. Legacy Info.plist `TigerDuckAPIToken` — kept so any CI
+    ///      pipeline that still injects there continues to work.
+    ///   4. nil — preserves the dev-friendly no-auth path.
     static func resolveSharedSecret() -> String? {
-        if let url = Bundle.main.url(forResource: "Secrets", withExtension: "plist"),
-           let dict = NSDictionary(contentsOf: url),
-           let value = dict["APIToken"] as? String,
-           !value.isEmpty {
-            return value
+        if let dict = secretsPlistDict() {
+            #if DEBUG
+            if let value = dict["DebugAPIToken"] as? String, !value.isEmpty {
+                return value
+            }
+            #endif
+            if let value = dict["APIToken"] as? String, !value.isEmpty {
+                return value
+            }
         }
         if let value = Bundle.main.object(forInfoDictionaryKey: "TigerDuckAPIToken") as? String,
            !value.isEmpty {
             return value
         }
         return nil
+    }
+
+    nonisolated private static func secretsPlistDict() -> NSDictionary? {
+        guard let url = Bundle.main.url(forResource: "Secrets", withExtension: "plist") else {
+            return nil
+        }
+        return NSDictionary(contentsOf: url)
     }
 }

--- a/swift/TigerDuck/TigerDuckApp.swift
+++ b/swift/TigerDuck/TigerDuckApp.swift
@@ -14,6 +14,7 @@ struct TigerDuckApp: App {
 
     init() {
         AppLogger.start()
+        PushCoordinator.assertEnvConsistency()
         watchSyncCoordinator.activate()
     }
 


### PR DESCRIPTION
This pull request introduces a comprehensive overhaul of the iOS app's push notification backend configuration, focusing on making local development safer and more convenient for contributors. It adds robust support for running a local TigerDuck backend, clarifies environment separation between development and production, and improves security and flexibility in how the app resolves backend endpoints and shared secrets. The changes also ensure that the app's networking permissions and Info.plist configuration are correctly set up for local development. Below are the most important changes grouped by theme:

**Local Development Support & Documentation**

* Added a detailed `docs/local-dev-backend.md` guide explaining how to set up and use a local TigerDuck backend for iOS development, including environment separation, endpoint selection logic, and troubleshooting steps.
* Updated `Secrets.example.plist` to include `DebugAPIToken` and `DebugServerURL` for per-developer local backend configuration, with clear documentation for both Debug and Release build behaviors.

**Backend Endpoint Resolution & Security**

* Refactored endpoint resolution in `PushCoordinator`:
  - Added `resolveServerURL()` to prioritize UserDefaults override, per-developer `Secrets.plist`, and a Simulator-friendly localhost fallback for Debug builds; Release builds always use the production endpoint.
  - Introduced strict allowlisting for override URLs, allowing only specific public hosts or private/loopback addresses over HTTP/HTTPS as appropriate.
  - Added a runtime assert (`assertEnvConsistency()`) to catch configuration mismatches between build environment and backend endpoint, preventing silent push failures during development. [[1]](diffhunk://#diff-7ef43ccdadfe46a95a246c8c31ee894236b1f9b467a119cd9fa9aa2f1de8f9c7L165-R317) [[2]](diffhunk://#diff-5223df4f9c8bfee3c01a614aaafea7fb1e221444e7bd2bc027050d88e42164b5R17)

* Updated `BulletinAPIClient` and `PushAPIClient` to use the new `PushCoordinator.resolveServerURL()` for determining the backend URL, ensuring consistent endpoint selection across the app. [[1]](diffhunk://#diff-5913588677f69d057d444e129ef9e4235306d9d88566287d3feca2b7a17ad3b4L17-R17) [[2]](diffhunk://#diff-301f66572edca2c0ab4e3bff64f3246ce9e789f1ddbdd088e8d74d8811d057bfL17-R17)

**App Constants & Info.plist Configuration**

* Renamed and clarified push backend constants in `AppConstants`, distinguishing between production and debug endpoints, and documenting their intended use.
* Added a partial `Info.plist` file to explicitly allow local networking (ATS exception) for loopback and RFC1918 private IPs, required for local development. Updated the Xcode project to use this file. [[1]](diffhunk://#diff-df5e0e6abd0b2c802c568c6842b24bfd7e4210cb86219f0d17e0d6200c1b3d86R1-R22) [[2]](diffhunk://#diff-f858c9336351da5b3bb143881b153990b8485ce1d13f76a762c49e62a9cb5178R87) [[3]](diffhunk://#diff-f858c9336351da5b3bb143881b153990b8485ce1d13f76a762c49e62a9cb5178R764) [[4]](diffhunk://#diff-f858c9336351da5b3bb143881b153990b8485ce1d13f76a762c49e62a9cb5178R817)

These changes collectively make it much easier and safer for contributors to develop against a local backend without risking production data or push notification failures, while maintaining strong security boundaries and clear configuration separation.