### PR TITLE
feat(tz): pin app/watch/widget to Asia/Taipei + foreground alert when device TZ differs

### DIFF
--- a/swift/Shared/TaipeiCalendar.swift
+++ b/swift/Shared/TaipeiCalendar.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Single source of truth for the Taiwan-pinned time math shared between
+/// the iOS app and the watch app. NTUST's class table, ICS feed, and
+/// Moodle deadlines are all authored in Taipei wall time, so every
+/// "what day is it / is class now?" decision must read against this
+/// calendar — not `Calendar.current`, which follows the device locale
+/// and would shift weekday math by up to a full day when the student is
+/// traveling.
+///
+/// The phone-app surface re-exports these constants as
+/// `AppConstants.taipeiTimeZone` / `AppConstants.taipeiCalendar`. The
+/// widget extension keeps its own local copy (`WidgetTaipei`) because
+/// `Shared/` is not in its target membership.
+public enum SharedTaipei {
+    public static let timeZone: TimeZone = TimeZone(identifier: "Asia/Taipei") ?? .current
+
+    public static let calendar: Calendar = {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = timeZone
+        return c
+    }()
+}

--- a/swift/Shared/Watch/NextClassResolver.swift
+++ b/swift/Shared/Watch/NextClassResolver.swift
@@ -11,8 +11,13 @@ public enum NextClassResolver {
     /// the class currently in progress (if any) and the next class to start
     /// today (if any). Other weekdays are ignored.
     public static func resolve(courses: [WatchCourse], now: Date) -> Result {
-        let cal = Calendar(identifier: .iso8601)
-        // ISO weekday: Calendar gives 1=Sun..7=Sat; convert to 1=Mon..7=Sun.
+        // Pinned to Taipei: NTUST's class times are authored in Taiwan
+        // wall time, so the watch must answer "what's happening now" in
+        // that frame regardless of where the wearer is physically. Without
+        // the pin a student abroad would see no classes during what is
+        // morning in Taipei.
+        let cal = SharedTaipei.calendar
+        // Gregorian weekday: 1=Sun..7=Sat; convert to 1=Mon..7=Sun.
         let raw = cal.component(.weekday, from: now)
         let isoWeekday = ((raw + 5) % 7) + 1
 

--- a/swift/TigerDuck/App/AppConstants.swift
+++ b/swift/TigerDuck/App/AppConstants.swift
@@ -21,6 +21,21 @@ extension URL {
 nonisolated enum AppConstants {
     static let appName = "TigerDuck"
 
+    /// All "what day/time is it?" logic must read this, not the device
+    /// timezone — NTUST's class table, ICS feed, and Moodle deadlines are
+    /// all authored in Taipei wall time, so a student abroad must still
+    /// see "Monday 08:10" when the schedule says Monday 08:10.
+    static let taipeiTimeZone: TimeZone = TimeZone(identifier: "Asia/Taipei") ?? .current
+
+    /// Gregorian + Asia/Taipei. Use everywhere `Calendar.current` would
+    /// otherwise drift the displayed weekday/day on a device set to a
+    /// non-Taiwan timezone or a non-gregorian calendar (ROC, Buddhist).
+    static let taipeiCalendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = taipeiTimeZone
+        return cal
+    }()
+
     static let dataDidUpdate = Notification.Name("TigerDuck.dataDidUpdate")
     static let liveActivityPreferencesDidChange = Notification.Name("TigerDuck.liveActivityPreferencesDidChange")
     static let languageDidChange = Notification.Name("TigerDuck.languageDidChange")

--- a/swift/TigerDuck/Clock/TimezoneObserver.swift
+++ b/swift/TigerDuck/Clock/TimezoneObserver.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Observation
+
+/// Observable signal for "is the device's wall clock currently offset from
+/// Taipei?". Read `TimezoneObserver.shared.isNonTaipei` somewhere in a view's
+/// dependency graph and SwiftUI re-evaluates when:
+///   - The system posts `NSSystemTimeZoneDidChange` (traveler crosses a
+///     timezone boundary, or settings toggles automatic time).
+///   - The debug clock flips — DST status changes across the year, so the
+///     same device can be in/out of Taipei offset depending on "now".
+///
+/// Compares the offset (not the identifier) at the current instant: a device
+/// set to `Asia/Hong_Kong` shares Taipei's offset year-round and should not
+/// trip the banner; a device set to `Europe/London` switches between BST and
+/// GMT, so DST flips matter.
+@MainActor
+@Observable
+final class TimezoneObserver {
+    static let shared = TimezoneObserver()
+
+    private(set) var isNonTaipei: Bool
+
+    private var clockToken: AppClock.ObserverToken?
+    private var tzNotificationToken: NSObjectProtocol?
+
+    private init() {
+        isNonTaipei = Self.computeIsNonTaipei()
+
+        // Hop to MainActor; the observer fires on whoever's thread called
+        // `AppClock.setOverride`, which in practice is MainActor but the API
+        // does not promise it.
+        clockToken = AppClock.observe { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.recompute()
+            }
+        }
+
+        tzNotificationToken = NotificationCenter.default.addObserver(
+            forName: .NSSystemTimeZoneDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            // The queue:.main delivery already puts us on MainActor, but the
+            // closure crossing into a @MainActor class still needs the hop
+            // to satisfy Swift 6 strict concurrency.
+            Task { @MainActor [weak self] in
+                NSTimeZone.resetSystemTimeZone()
+                self?.recompute()
+            }
+        }
+    }
+
+    private func recompute() {
+        let next = Self.computeIsNonTaipei()
+        if next != isNonTaipei {
+            isNonTaipei = next
+        }
+    }
+
+    private static func computeIsNonTaipei() -> Bool {
+        let now = AppClock.now()
+        let deviceOffset = TimeZone.current.secondsFromGMT(for: now)
+        let taipeiOffset = AppConstants.taipeiTimeZone.secondsFromGMT(for: now)
+        return deviceOffset != taipeiOffset
+    }
+}

--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -74,6 +74,17 @@ struct MainTabView: View {
                 evaluateTimezoneAlert()
             }
         }
+        // Mid-foreground transitions matter too: if the user is in the
+        // app when the device crosses a timezone boundary (or the debug
+        // clock flips to a non-Taipei offset), the observer recomputes
+        // immediately and we want to surface the hint right then. Reading
+        // the observable here registers the tracking dependency that
+        // body evaluation alone otherwise misses.
+        .onChange(of: TimezoneObserver.shared.isNonTaipei) { _, isNonTaipei in
+            if isNonTaipei {
+                showTimezoneAlert = true
+            }
+        }
     }
 
     private func evaluateTimezoneAlert() {

--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -17,7 +17,9 @@ struct ContentView: View {
 
 struct MainTabView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.scenePhase) private var scenePhase
     @State private var selectedTab: AppFeature = .home
+    @State private var showTimezoneAlert: Bool = false
 
     /// Configured tabs filtered to hide library features when disabled
     private var visibleTabs: [AppFeature] {
@@ -30,11 +32,6 @@ struct MainTabView: View {
     }
 
     var body: some View {
-        // Wire `TimezoneObserver.shared.isNonTaipei` into MainTabView's
-        // dependency graph so SwiftUI re-evaluates the banner when the
-        // system posts NSSystemTimeZoneDidChange or the debug clock flips.
-        let isNonTaipei = TimezoneObserver.shared.isNonTaipei
-
         TabView(selection: $selectedTab) {
             ForEach(visibleTabs) { feature in
                 Tab(feature.tabBarDisplayName, systemImage: feature.iconName, value: feature) {
@@ -46,19 +43,42 @@ struct MainTabView: View {
                 MoreView()
             }
         }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            if isNonTaipei {
-                NonTaipeiTimezoneBanner()
-            }
+        .alert(
+            String(localized: "app_non_taipei_timezone_hint"),
+            isPresented: $showTimezoneAlert
+        ) {
+            Button(String(localized: "action_got_it"), role: .cancel) { }
         }
         .onChange(of: visibleTabs) { _, newTabs in
             if selectedTab != .more, !newTabs.contains(selectedTab), let first = newTabs.first {
                 selectedTab = first
             }
         }
-        .onAppear { drainPendingWidgetDestination() }
+        .onAppear {
+            drainPendingWidgetDestination()
+            // Fresh launch path. `.onChange(of: scenePhase)` won't fire
+            // for the initial `.active` value, so the first prompt has
+            // to come from here. Subsequent foreground returns go
+            // through the scene-phase observer below.
+            evaluateTimezoneAlert()
+        }
         .onChange(of: appState.pendingWidgetDestination) { _, _ in
             drainPendingWidgetDestination()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            // Multitask-switch path: every time the app re-enters the
+            // foreground, re-evaluate. The observer keeps `isNonTaipei`
+            // current against NSSystemTimeZoneDidChange while we were
+            // backgrounded, so this read sees the latest decision.
+            if newPhase == .active {
+                evaluateTimezoneAlert()
+            }
+        }
+    }
+
+    private func evaluateTimezoneAlert() {
+        if TimezoneObserver.shared.isNonTaipei {
+            showTimezoneAlert = true
         }
     }
 
@@ -101,22 +121,6 @@ struct MainTabView: View {
         case .englishVocab: PlaceholderFeatureView(feature: feature)
         default: PlaceholderFeatureView(feature: feature)
         }
-    }
-}
-
-/// Yellow hint shown above the tab bar while the device is not in Taipei
-/// time. Mirrors the Android implementation's bottom-bar Column injection
-/// and uses the same `app_non_taipei_timezone_hint` string.
-struct NonTaipeiTimezoneBanner: View {
-    var body: some View {
-        Text(String(localized: "app_non_taipei_timezone_hint"))
-            .font(.footnote)
-            .multilineTextAlignment(.center)
-            .foregroundStyle(Color(red: 0x5C / 255.0, green: 0x4A / 255.0, blue: 0x00 / 255.0))
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(Color(red: 1.0, green: 0xF3 / 255.0, blue: 0xB0 / 255.0))
     }
 }
 

--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -30,6 +30,11 @@ struct MainTabView: View {
     }
 
     var body: some View {
+        // Wire `TimezoneObserver.shared.isNonTaipei` into MainTabView's
+        // dependency graph so SwiftUI re-evaluates the banner when the
+        // system posts NSSystemTimeZoneDidChange or the debug clock flips.
+        let isNonTaipei = TimezoneObserver.shared.isNonTaipei
+
         TabView(selection: $selectedTab) {
             ForEach(visibleTabs) { feature in
                 Tab(feature.tabBarDisplayName, systemImage: feature.iconName, value: feature) {
@@ -39,6 +44,11 @@ struct MainTabView: View {
 
             Tab(AppFeature.more.tabBarDisplayName, systemImage: AppFeature.more.iconName, value: .more) {
                 MoreView()
+            }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            if isNonTaipei {
+                NonTaipeiTimezoneBanner()
             }
         }
         .onChange(of: visibleTabs) { _, newTabs in
@@ -91,6 +101,22 @@ struct MainTabView: View {
         case .englishVocab: PlaceholderFeatureView(feature: feature)
         default: PlaceholderFeatureView(feature: feature)
         }
+    }
+}
+
+/// Yellow hint shown above the tab bar while the device is not in Taipei
+/// time. Mirrors the Android implementation's bottom-bar Column injection
+/// and uses the same `app_non_taipei_timezone_hint` string.
+struct NonTaipeiTimezoneBanner: View {
+    var body: some View {
+        Text(String(localized: "app_non_taipei_timezone_hint"))
+            .font(.footnote)
+            .multilineTextAlignment(.center)
+            .foregroundStyle(Color(red: 0x5C / 255.0, green: 0x4A / 255.0, blue: 0x00 / 255.0))
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color(red: 1.0, green: 0xF3 / 255.0, blue: 0xB0 / 255.0))
     }
 }
 

--- a/swift/TigerDuck/Extensions/Date+Formatting.swift
+++ b/swift/TigerDuck/Extensions/Date+Formatting.swift
@@ -6,14 +6,14 @@ extension Date {
     /// feeds are gregorian — using `Calendar.current` would shift
     /// month/day arithmetic on a device set to ROC or Buddhist calendar
     /// (already proven by `SDCourse.isoFormatter` pinning the same way).
-    static let scheduleCalendar: Calendar = {
-        var cal = Calendar(identifier: .gregorian)
-        cal.timeZone = TimeZone(identifier: "Asia/Taipei") ?? .current
-        return cal
-    }()
+    /// Aliased onto `AppConstants.taipeiCalendar` so app code has one
+    /// canonical handle to the Taiwan-pinned calendar.
+    static let scheduleCalendar: Calendar = AppConstants.taipeiCalendar
 
     var shortDateString: String {
-        formatted(.dateTime.month(.defaultDigits).day())
+        var style = Date.FormatStyle.dateTime.month(.defaultDigits).day()
+        style.timeZone = AppConstants.taipeiTimeZone
+        return formatted(style)
     }
 
     /// Full numeric date — "2026/04/23". Used for article mastheads where
@@ -27,13 +27,17 @@ extension Date {
         f.dateFormat = "yyyy/MM/dd"
         // Pin to gregorian + en_US_POSIX so a device set to ROC /
         // Buddhist calendar doesn't render `2026-04-23` as `0115/04/23`.
+        // Pin time zone too so a traveler sees Taipei's calendar day.
         f.locale = Locale(identifier: "en_US_POSIX")
         f.calendar = Calendar(identifier: .gregorian)
+        f.timeZone = AppConstants.taipeiTimeZone
         return f
     }()
 
     var timeString: String {
-        formatted(.dateTime.hour(.twoDigits(amPM: .omitted)).minute(.twoDigits))
+        var style = Date.FormatStyle.dateTime.hour(.twoDigits(amPM: .omitted)).minute(.twoDigits)
+        style.timeZone = AppConstants.taipeiTimeZone
+        return formatted(style)
     }
 
     var weekdayIndex: Int {
@@ -85,6 +89,7 @@ extension Date {
         f.dateFormat = "M/d HH:mm:ss"
         f.locale = Locale(identifier: "en_US_POSIX")
         f.calendar = Calendar(identifier: .gregorian)
+        f.timeZone = AppConstants.taipeiTimeZone
         return f
     }()
 
@@ -93,6 +98,7 @@ extension Date {
         f.dateFormat = "M/d HH:mm"
         f.locale = Locale(identifier: "en_US_POSIX")
         f.calendar = Calendar(identifier: .gregorian)
+        f.timeZone = AppConstants.taipeiTimeZone
         return f
     }()
 

--- a/swift/TigerDuck/Features/Calendar/CalendarViewModel.swift
+++ b/swift/TigerDuck/Features/Calendar/CalendarViewModel.swift
@@ -35,16 +35,16 @@ final class CalendarViewModel {
     }
 
     func eventsOnDate(_ date: Date) -> [SDCalendarEvent] {
-        let key = Calendar.current.dateComponents([.year, .month, .day], from: date)
+        let key = AppConstants.taipeiCalendar.dateComponents([.year, .month, .day], from: date)
         return eventsByDay[key] ?? []
     }
 
     func previousMonth() {
-        displayedMonth = Calendar.current.date(byAdding: .month, value: -1, to: displayedMonth)!
+        displayedMonth = AppConstants.taipeiCalendar.date(byAdding: .month, value: -1, to: displayedMonth)!
     }
 
     func nextMonth() {
-        displayedMonth = Calendar.current.date(byAdding: .month, value: 1, to: displayedMonth)!
+        displayedMonth = AppConstants.taipeiCalendar.date(byAdding: .month, value: 1, to: displayedMonth)!
     }
 
     func goToToday() {
@@ -151,7 +151,7 @@ final class CalendarViewModel {
 
     @MainActor
     private func loadSystemCalendarEvents() {
-        let cal = Calendar.current
+        let cal = AppConstants.taipeiCalendar
         guard let startDate = cal.date(byAdding: .month, value: -1, to: displayedMonth.startOfMonth),
               let endDate = cal.date(byAdding: .month, value: 2, to: displayedMonth.startOfMonth) else { return }
 
@@ -177,7 +177,7 @@ final class CalendarViewModel {
     }
 
     private static func buildCalendarDays(for month: Date) -> [Date?] {
-        let cal = Calendar.current
+        let cal = AppConstants.taipeiCalendar
         let start = month.startOfMonth
         let daysInMonth = month.daysInMonth
         let firstWeekday = month.firstWeekdayOfMonth // 1=Sunday
@@ -194,7 +194,7 @@ final class CalendarViewModel {
 
     private func setEvents(_ newEvents: [SDCalendarEvent]) {
         events = newEvents
-        let cal = Calendar.current
+        let cal = AppConstants.taipeiCalendar
         eventsByDay = Dictionary(grouping: newEvents) { event in
             cal.dateComponents([.year, .month, .day], from: event.date)
         }

--- a/swift/TigerDuck/Features/Calendar/Components/DayEventListView.swift
+++ b/swift/TigerDuck/Features/Calendar/Components/DayEventListView.swift
@@ -26,6 +26,7 @@ struct DayEventListView: View {
     private static let dateFormatter: DateFormatter = {
         let f = DateFormatter()
         f.setLocalizedDateFormatFromTemplate("MMMd")
+        f.timeZone = AppConstants.taipeiTimeZone
         return f
     }()
 

--- a/swift/TigerDuck/Features/Calendar/Components/MonthCalendarView.swift
+++ b/swift/TigerDuck/Features/Calendar/Components/MonthCalendarView.swift
@@ -15,7 +15,9 @@ struct MonthCalendarView: View {
     private let columns = Array(repeating: GridItem(.flexible()), count: 7)
 
     private var monthTitle: String {
-        viewModel.displayedMonth.formatted(.dateTime.year().month(.wide))
+        var style = Date.FormatStyle.dateTime.year().month(.wide)
+        style.timeZone = AppConstants.taipeiTimeZone
+        return viewModel.displayedMonth.formatted(style)
     }
 
     private var calendarDays: [Date?] { viewModel.calendarDays }
@@ -83,7 +85,7 @@ private struct DayCellView: View {
     var body: some View {
         Button(action: onTap) {
             VStack(spacing: 2) {
-                Text("\(Calendar.current.component(.day, from: date))")
+                Text("\(AppConstants.taipeiCalendar.component(.day, from: date))")
                     .font(TigerDuckTheme.Typography.body)
                     .foregroundStyle(isSelected ? .white : (isToday ? .accentPrimary : .textPrimary))
                     .frame(width: 32, height: 32)

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
@@ -35,7 +35,7 @@ struct CourseTimeCard: View {
     private func cardContent(slot: CourseTimeSlot, opacity: Double) -> some View {
         let course = slot.course
         let weekday = slot.date.scheduleWeekday
-        let isToday = Calendar.current.isDateInToday(slot.date)
+        let isToday = AppConstants.taipeiCalendar.isDateInToday(slot.date)
 
         HStack(alignment: .top, spacing: 10) {
             // Accent stripe — shows the course color as a small accent in
@@ -119,6 +119,7 @@ struct CourseTimeCard: View {
     private static let dateLabelFormatter: DateFormatter = {
         let f = DateFormatter()
         f.calendar = Calendar(identifier: .gregorian)
+        f.timeZone = AppConstants.taipeiTimeZone
         f.dateFormat = "M/d (EEEEE)"
         return f
     }()
@@ -127,6 +128,7 @@ struct CourseTimeCard: View {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
         f.calendar = Calendar(identifier: .gregorian)
+        f.timeZone = AppConstants.taipeiTimeZone
         f.dateFormat = "M/d"
         return f
     }()

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeSlot.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeSlot.swift
@@ -14,7 +14,7 @@ struct CourseTimeSlot: Identifiable, Equatable {
 
     /// Build slots for a single day.
     static func buildSlots(from courses: [SDCourse], weekday: Int, on date: Date = AppClock.now()) -> [CourseTimeSlot] {
-        let calendar = Calendar.current
+        let calendar = AppConstants.taipeiCalendar
         var slots: [CourseTimeSlot] = []
 
         for course in courses {
@@ -47,7 +47,7 @@ struct CourseTimeSlot: Identifiable, Equatable {
         centerDate: Date,
         dayRadius: Int = TimeSliderMetrics.timelineDayRadius
     ) -> [CourseTimeSlot] {
-        let calendar = Calendar.current
+        let calendar = AppConstants.taipeiCalendar
         var allSlots: [CourseTimeSlot] = []
 
         for offset in -dayRadius...dayRadius {
@@ -60,7 +60,7 @@ struct CourseTimeSlot: Identifiable, Equatable {
         return allSlots.sorted { $0.start < $1.start }
     }
 
-    static func dateFromTimeString(_ time: String, on date: Date, calendar: Calendar = .current) -> Date? {
+    static func dateFromTimeString(_ time: String, on date: Date, calendar: Calendar = AppConstants.taipeiCalendar) -> Date? {
         let parts = time.split(separator: ":").compactMap { Int($0) }
         guard parts.count == 2 else { return nil }
         var dc = calendar.dateComponents([.year, .month, .day], from: date)
@@ -74,6 +74,7 @@ struct CourseTimeSlot: Identifiable, Equatable {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
         f.calendar = Calendar(identifier: .gregorian)
+        f.timeZone = AppConstants.taipeiTimeZone
         f.dateFormat = "yyyyMMdd"
         return f
     }()

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/TimeSliderSection.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/TimeSliderSection.swift
@@ -122,7 +122,7 @@ struct TimeSliderSection: View {
     }
 
     private var timeLabelString: String {
-        let isToday = Calendar.current.isDateInToday(viewModel.selectedTime)
+        let isToday = AppConstants.taipeiCalendar.isDateInToday(viewModel.selectedTime)
         if isToday {
             return Self.timeFormatter.string(from: viewModel.selectedTime)
         } else {
@@ -146,6 +146,7 @@ struct TimeSliderSection: View {
     private static let timeFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "HH:mm"
+        f.timeZone = AppConstants.taipeiTimeZone
         return f
     }()
 
@@ -153,6 +154,7 @@ struct TimeSliderSection: View {
         let f = DateFormatter()
         f.locale = .autoupdatingCurrent
         f.dateFormat = "M/d (EEEEE) HH:mm"
+        f.timeZone = AppConstants.taipeiTimeZone
         return f
     }()
 }

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/TimeSliderViewModel.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/TimeSliderViewModel.swift
@@ -86,7 +86,7 @@ final class TimeSliderViewModel {
                 let next = timeSlots[i + 1]
                 let gapMin = next.start.timeIntervalSince(slot.end) / 60
 
-                let calendar = Calendar.current
+                let calendar = AppConstants.taipeiCalendar
                 let crossesDay = !calendar.isDate(slot.date, inSameDayAs: next.date)
 
                 if crossesDay {
@@ -132,7 +132,7 @@ final class TimeSliderViewModel {
     }
 
     private func checkTimelineRebuildNeeded() {
-        let calendar = Calendar.current
+        let calendar = AppConstants.taipeiCalendar
         let daysSinceCenter = abs(calendar.dateComponents(
             [.day], from: timelineCenterDate, to: selectedTime
         ).day ?? 0)

--- a/swift/TigerDuck/Features/Home/Components/TodayCourseCarousel.swift
+++ b/swift/TigerDuck/Features/Home/Components/TodayCourseCarousel.swift
@@ -9,6 +9,7 @@ struct TodayCourseCarousel: View {
     private static let periodTimeFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "HH:mm"
+        f.timeZone = AppConstants.taipeiTimeZone
         return f
     }()
 
@@ -83,7 +84,7 @@ struct TodayCourseCarousel: View {
     private func courseProgress(_ course: SDCourse) -> Double? {
         guard let periods = course.schedule[today]?.sortedByPeriodOrder() else { return nil }
         let now = AppClock.now()
-        let cal = Calendar.current
+        let cal = AppConstants.taipeiCalendar
         let formatter = Self.periodTimeFormatter
 
         guard let firstPeriod = periods.first,

--- a/swift/TigerDuck/Models/SwiftData/SDCourse.swift
+++ b/swift/TigerDuck/Models/SwiftData/SDCourse.swift
@@ -223,7 +223,11 @@ extension SDCourse {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
         f.calendar = Calendar(identifier: .gregorian)
-        f.timeZone = .current
+        // Pin to Taipei so a traveler marking "today" as skipped still
+        // hits the same calendar day the widget/timeline derivation
+        // computes — both sides must agree on what `yyyy-MM-dd` resolves
+        // to or the skip silently misses.
+        f.timeZone = AppConstants.taipeiTimeZone
         f.dateFormat = "yyyy-MM-dd"
         return f
     }()

--- a/swift/TigerDuckWatch Watch App/UI/TodayView.swift
+++ b/swift/TigerDuckWatch Watch App/UI/TodayView.swift
@@ -5,7 +5,10 @@ struct TodayView: View {
 
     private var todaysCourses: [WatchCourse] {
         guard let snapshot = store.snapshot else { return [] }
-        let cal = Calendar(identifier: .iso8601)
+        // Pinned to Taipei so the watch shows Taiwan's "today" even when
+        // the wearer is in a different timezone — class schedules are
+        // authored in Taipei wall time.
+        let cal = SharedTaipei.calendar
         let raw = cal.component(.weekday, from: AppClock.now())
         let iso = ((raw + 5) % 7) + 1
         return snapshot.courses

--- a/swift/TigerDuckWatchWidget/NextClassProvider.swift
+++ b/swift/TigerDuckWatchWidget/NextClassProvider.swift
@@ -36,7 +36,13 @@ struct NextClassProvider: TimelineProvider {
 
         var entries: [NextClassEntry] = []
         let now = Date()
-        let cal = Calendar(identifier: .iso8601)
+        // Pin to Taipei so timeline boundaries (class start/end and the
+        // 04:00 reload) land on Taiwan wall time, matching the resolver
+        // and the iOS app. A device-TZ calendar would slide today/
+        // tomorrow's anchors and the reload trigger for a traveling
+        // wearer, leaving the face stale across class transitions and
+        // midnight.
+        let cal = SharedTaipei.calendar
 
         // Build boundary timestamps for today + tomorrow so the post-midnight
         // window doesn't strand the watch face on "no upcoming classes" until
@@ -94,7 +100,12 @@ struct NextClassProvider: TimelineProvider {
     }
 
     private func combine(hhmm: String, with anchor: Date) -> Date? {
-        let cal = Calendar(identifier: .iso8601)
+        // Must match the calendar used in `getTimeline(...)` so the
+        // year/month/day extracted from `anchor` and the hh:mm stitched
+        // back on are interpreted in the same frame — otherwise a
+        // device in a non-Taipei TZ produces start/end instants offset
+        // from what the resolver expects.
+        let cal = SharedTaipei.calendar
         let parts = hhmm.split(separator: ":")
         guard parts.count == 2, let h = Int(parts[0]), let m = Int(parts[1]) else { return nil }
         var dc = cal.dateComponents([.year, .month, .day], from: anchor)

--- a/swift/TigerDuckWidgets/Logic/WidgetTaipei.swift
+++ b/swift/TigerDuckWidgets/Logic/WidgetTaipei.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Widget-extension-local mirror of `SharedTaipei`. The `Shared/` folder
+/// is not part of the widget extension's target membership, so this
+/// duplicates the two constants the widget needs to keep "what day is
+/// it / is class now?" math aligned with the iOS app (which pins to
+/// Taipei via `AppConstants.taipeiCalendar`).
+///
+/// Keep in sync with `SharedTaipei`.
+enum WidgetTaipei {
+    static let timeZone: TimeZone = TimeZone(identifier: "Asia/Taipei") ?? .current
+
+    static let calendar: Calendar = {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = timeZone
+        return c
+    }()
+}

--- a/swift/TigerDuckWidgets/Logic/WidgetTimelineDerivation.swift
+++ b/swift/TigerDuckWidgets/Logic/WidgetTimelineDerivation.swift
@@ -84,7 +84,7 @@ enum WidgetTimelineDerivation {
         }
 
         // 3. Tomorrow first: scan ahead up to 7 weekdays
-        let calendar = Calendar(identifier: .gregorian)
+        let calendar = WidgetTaipei.calendar
         for offset in 1...7 {
             let target = ((weekday - 1 + offset) % 7) + 1
             let targetDate = calendar.date(byAdding: .day, value: offset, to: date) ?? date
@@ -112,8 +112,11 @@ enum WidgetTimelineDerivation {
         return .noMoreClasses
     }
 
-    /// `yyyy-MM-dd` in the device's time zone — must mirror `SDCourse.isoFormatter`
-    /// so a `Set<String>` lookup against `SnapshotCourse.skippedDates` matches.
+    /// `yyyy-MM-dd` in Asia/Taipei — must mirror `SDCourse.isoFormatter`
+    /// so a `Set<String>` lookup against `SnapshotCourse.skippedDates`
+    /// matches. Both sides pin to Taipei so a student traveling abroad
+    /// still sees their skipped-class state apply on the correct
+    /// Taiwan calendar day.
     static func dateKey(for date: Date) -> String {
         return Self.dateKeyFormatter.string(from: date)
     }
@@ -122,23 +125,25 @@ enum WidgetTimelineDerivation {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
         f.calendar = Calendar(identifier: .gregorian)
-        f.timeZone = .current
+        f.timeZone = WidgetTaipei.timeZone
         f.dateFormat = "yyyy-MM-dd"
         return f
     }()
 
     // MARK: - Helpers
 
-    /// Returns 1=Mon … 7=Sun. Pinned to the gregorian calendar so device
-    /// locale calendars (e.g. ROC, Buddhist) don't shift weekday math
-    /// against NTUST's gregorian-based schedule.
+    /// Returns 1=Mon … 7=Sun. Pinned to gregorian + Asia/Taipei so neither
+    /// device locale calendars (ROC, Buddhist) nor the device timezone
+    /// shift weekday math against NTUST's gregorian-Taipei schedule. A
+    /// traveler in London at 22:00 Saturday is on Sunday 06:00 in Taipei,
+    /// and the widget must agree.
     static func weekdayFor(_ date: Date) -> Int {
-        let raw = Calendar(identifier: .gregorian).component(.weekday, from: date)
+        let raw = WidgetTaipei.calendar.component(.weekday, from: date)
         return raw == 1 ? 7 : raw - 1
     }
 
     static func minuteOfDayFor(_ date: Date) -> Int {
-        let cal = Calendar(identifier: .gregorian)
+        let cal = WidgetTaipei.calendar
         let h = cal.component(.hour, from: date)
         let m = cal.component(.minute, from: date)
         return h * 60 + m
@@ -208,7 +213,7 @@ extension WidgetTimelineDerivation {
     static func entryDates(
         snapshot: WidgetSnapshot,
         after now: Date,
-        calendar: Calendar = Calendar(identifier: .gregorian)
+        calendar: Calendar = WidgetTaipei.calendar
     ) -> [Date] {
         var result: Set<Date> = [now]
         let weekday = weekdayFor(now)

--- a/swift/TigerDuckWidgets/Widgets/LibraryShortcutWidget.swift
+++ b/swift/TigerDuckWidgets/Widgets/LibraryShortcutWidget.swift
@@ -25,7 +25,10 @@ struct LibraryShortcutProvider: TimelineProvider {
         // scheduling metadata and a fake-future stamp would defer rendering.
         let snapshot = store.readSnapshot()
         let entry = LibraryShortcutEntry(date: Date(), snapshot: snapshot)
-        let appMidnight = Calendar(identifier: .gregorian).startOfDay(for: AppClock.now().addingTimeInterval(86_400))
+        // Pin to Taipei — even with no time-of-day content here, day
+        // rollover is computed in the same frame the rest of the widget
+        // surface uses, so the refresh cadence stays consistent.
+        let appMidnight = WidgetTaipei.calendar.startOfDay(for: AppClock.now().addingTimeInterval(86_400))
         // WidgetKit interprets `.after(...)` against real wall-clock time,
         // so translate the fake-clock midnight to the real instant it maps
         // to. Identity when no debug override is active.

--- a/swift/TigerDuckWidgets/Widgets/WeekWidget.swift
+++ b/swift/TigerDuckWidgets/Widgets/WeekWidget.swift
@@ -33,7 +33,9 @@ struct WeekProvider: TimelineProvider {
         // independent, so a single entry + .after(midnight) policy
         // is enough.
         let snap = store.readSnapshot() ?? Self.emptySnapshot
-        let appMidnight = Calendar(identifier: .gregorian).startOfDay(for: AppClock.now().addingTimeInterval(86_400))
+        // Pin to Taipei so the refresh fires at Taiwan's midnight — that's
+        // when the "today" underline rolls over in the rendered grid.
+        let appMidnight = WidgetTaipei.calendar.startOfDay(for: AppClock.now().addingTimeInterval(86_400))
         // WidgetKit interprets `.after(...)` against real wall-clock time,
         // so translate the fake-clock midnight to the real instant it maps
         // to. Identity when no debug override is active.


### PR DESCRIPTION
## Summary
- Pin every "what day is it / is class now?" decision to Asia/Taipei across the iOS app, the Watch app, and the Widget extension — NTUST's class table, ICS feed, and Moodle deadlines are all authored in Taipei wall time, so a student abroad would otherwise see the wrong weekday's courses and a wrong "ongoing" state.
- Repoint `DateFormatter`s that previously inherited the device TZ (including `SDCourse.isoFormatter` and the widget's `dateKey`, which must agree on `yyyy-MM-dd` for skip-state lookups to match).
- Add a `TimezoneObserver` (reactive to `NSSystemTimeZoneDidChange` + debug-clock flips); the iOS app shows the `app_non_taipei_timezone_hint` as a one-shot `.alert` whenever the app re-enters the foreground (fresh launch via `.onAppear`, multitask return via `scenePhase → .active`). Mirrors the Android implementation's copy but uses a popup instead of a persistent banner.
- Watch and widget pin silently — no banner/alert on either surface.

## Architecture
- `swift/Shared/TaipeiCalendar.swift` — `SharedTaipei.{timeZone, calendar}` used by main app + watch (Shared/ is in both targets).
- `swift/TigerDuck/App/AppConstants.swift` — re-exports as `AppConstants.taipeiTimeZone` / `taipeiCalendar`.
- `swift/TigerDuckWidgets/Logic/WidgetTaipei.swift` — local duplicate inside the widget extension target (Shared/ isn't included there).

## Test plan
- [ ] iPhone Simulator set to a non-Taiwan TZ: fresh launch shows the alert with "Got it"; dismiss → background → foreground → alert re-appears. Simulator set to Asia/Taipei: no alert on fresh launch or foreground.
- [ ] Time slider + Today carousel render the correct weekday's courses while the device TZ is non-Taiwan (e.g. America/New_York, Europe/London).
- [ ] Mark a course as skipped on a date; verify the widget's skipped pill matches the in-app skip on a non-Taiwan device.
- [ ] Watch app "Now" / "Today" tabs show the right Taipei weekday + ongoing state when paired iPhone is in a non-Taiwan TZ.
- [ ] All four schemes build clean: `TigerDuck`, `TigerDuckWidgetsExtension`, `TigerDuckLiveActivityExtension`, `TigerDuckWatch Watch App` (verified locally during development).