### PR TITLE
Misc UX polish: onboarding rewrite, macOS classtable parity, widget fixes

### DIFF
--- a/swift/TigerDuck.xcodeproj/project.pbxproj
+++ b/swift/TigerDuck.xcodeproj/project.pbxproj
@@ -1113,6 +1113,7 @@
 					CourseDetailSheet.swift,
 					ClassTableLayout.swift,
 					"View+PlatformCompat.swift",
+					LoadingButtonLabel.swift,
 				);
 				INFOPLIST_FILE = TigerDuck/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -1278,6 +1279,7 @@
 					CourseDetailSheet.swift,
 					ClassTableLayout.swift,
 					"View+PlatformCompat.swift",
+					LoadingButtonLabel.swift,
 				);
 				INFOPLIST_FILE = TigerDuck/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;

--- a/swift/TigerDuck.xcodeproj/project.pbxproj
+++ b/swift/TigerDuck.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 			membershipExceptions = (
 				Clock/AppClock.swift,
 				Clock/ClockOverride.swift,
+				Shared/ClassTableLayout.swift,
 				Widgets/WidgetSnapshot.swift,
 			);
 			target = B244D74E2FB87B580040D6FA /* TigerDuckWidgetsExtension */;
@@ -1108,6 +1109,10 @@
 					WidgetSnapshotWriter.swift,
 					WidgetReloadCoordinator.swift,
 					CanonicalCourseProvider.swift,
+					AddCourseSheet.swift,
+					CourseDetailSheet.swift,
+					ClassTableLayout.swift,
+					"View+PlatformCompat.swift",
 				);
 				INFOPLIST_FILE = TigerDuck/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -1269,6 +1274,10 @@
 					WidgetSnapshotWriter.swift,
 					WidgetReloadCoordinator.swift,
 					CanonicalCourseProvider.swift,
+					AddCourseSheet.swift,
+					CourseDetailSheet.swift,
+					ClassTableLayout.swift,
+					"View+PlatformCompat.swift",
 				);
 				INFOPLIST_FILE = TigerDuck/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;

--- a/swift/TigerDuck/Debug/DebugSettingsView.swift
+++ b/swift/TigerDuck/Debug/DebugSettingsView.swift
@@ -1,5 +1,7 @@
 #if DEBUG
+import Observation
 import SwiftUI
+import UserNotifications
 
 /// Developer-only screen for the debug time override. Reached from the
 /// bottom of Settings; the entry point itself is also `#if DEBUG` so
@@ -41,7 +43,17 @@ struct DebugSettingsView: View {
                 Text(viewModel.effectiveNow.formatted(date: .complete, time: .standard))
                     .font(.system(.body, design: .monospaced))
             }
+        }
+        .navigationTitle("Time override")
+        .task { await viewModel.observeEffectiveNow() }
+    }
+}
 
+struct DebugNotificationsView: View {
+    @State private var viewModel = DebugNotificationsViewModel()
+
+    var body: some View {
+        Form {
             Section {
                 Button("Send fake local notification") {
                     Task { await viewModel.sendSimulatedPushNow() }
@@ -51,14 +63,60 @@ struct DebugSettingsView: View {
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
-            } header: {
-                Text("Notifications")
             } footer: {
                 Text("Fires a local lock-screen / banner notification ~3 s from now. This is NOT a Live Activity — the Dynamic Island appears automatically when the fake clock enters a class window above. Backend APNs pushes use the real wall clock and cannot honor the fake-time override.")
             }
         }
-        .navigationTitle("Time override")
-        .task { await viewModel.observeEffectiveNow() }
+        .navigationTitle("Notifications")
+    }
+}
+
+@MainActor
+@Observable
+final class DebugNotificationsViewModel {
+    private(set) var lastSimulatedPushStatus: String?
+
+    /// Fires a local notification ~3 s from real-now to simulate what a
+    /// backend APNs push would look like. Backend pushes can't honor the
+    /// debug clock (the server has no idea time is faked), so this exists
+    /// purely so QA can visually confirm a "push arrived" while the LA /
+    /// widget pipeline is running under a fake-clock override.
+    func sendSimulatedPushNow() async {
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .notDetermined:
+            let granted = (try? await center.requestAuthorization(options: [.alert, .sound])) ?? false
+            guard granted else {
+                lastSimulatedPushStatus = "Authorization denied"
+                return
+            }
+        case .denied:
+            lastSimulatedPushStatus = "Authorization denied — enable in Settings"
+            return
+        case .authorized, .provisional, .ephemeral:
+            break
+        @unknown default:
+            break
+        }
+
+        let content = UNMutableNotificationContent()
+        content.title = "Simulated push"
+        content.body = "Fake push fired at \(AppClock.now().formatted(date: .omitted, time: .standard)) (app clock)"
+        content.sound = .default
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 3, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: "debug-simulated-push-\(UUID().uuidString)",
+            content: content,
+            trigger: trigger
+        )
+        do {
+            try await center.add(request)
+            lastSimulatedPushStatus = "Scheduled — arrives in ~3 s (real time)"
+        } catch {
+            lastSimulatedPushStatus = "Failed: \(error.localizedDescription)"
+        }
     }
 }
 #endif

--- a/swift/TigerDuck/Debug/DebugSettingsViewModel.swift
+++ b/swift/TigerDuck/Debug/DebugSettingsViewModel.swift
@@ -1,7 +1,6 @@
 #if DEBUG
 import Foundation
 import Observation
-import UserNotifications
 
 @MainActor
 @Observable
@@ -10,7 +9,6 @@ final class DebugSettingsViewModel {
     var draftInstant: Date
     var frozen: Bool
     private(set) var effectiveNow: Date
-    private(set) var lastSimulatedPushStatus: String?
 
     init() {
         let current = DebugClockController.shared.currentOverride()
@@ -62,47 +60,5 @@ final class DebugSettingsViewModel {
         DebugClockController.shared.setOverride(override)
     }
 
-    /// Fires a local notification ~3 s from real-now to simulate what a
-    /// backend APNs push would look like. Backend pushes can't honor the
-    /// debug clock (the server has no idea time is faked), so this exists
-    /// purely so QA can visually confirm a "push arrived" while the LA /
-    /// widget pipeline is running under a fake-clock override.
-    func sendSimulatedPushNow() async {
-        let center = UNUserNotificationCenter.current()
-        let settings = await center.notificationSettings()
-        switch settings.authorizationStatus {
-        case .notDetermined:
-            let granted = (try? await center.requestAuthorization(options: [.alert, .sound])) ?? false
-            guard granted else {
-                lastSimulatedPushStatus = "Authorization denied"
-                return
-            }
-        case .denied:
-            lastSimulatedPushStatus = "Authorization denied — enable in Settings"
-            return
-        case .authorized, .provisional, .ephemeral:
-            break
-        @unknown default:
-            break
-        }
-
-        let content = UNMutableNotificationContent()
-        content.title = "Simulated push"
-        content.body = "Fake push fired at \(AppClock.now().formatted(date: .omitted, time: .standard)) (app clock)"
-        content.sound = .default
-
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 3, repeats: false)
-        let request = UNNotificationRequest(
-            identifier: "debug-simulated-push-\(UUID().uuidString)",
-            content: content,
-            trigger: trigger
-        )
-        do {
-            try await center.add(request)
-            lastSimulatedPushStatus = "Scheduled — arrives in ~3 s (real time)"
-        } catch {
-            lastSimulatedPushStatus = "Failed: \(error.localizedDescription)"
-        }
-    }
 }
 #endif

--- a/swift/TigerDuck/Extensions/SDAssignment+DisplayName.swift
+++ b/swift/TigerDuck/Extensions/SDAssignment+DisplayName.swift
@@ -33,4 +33,19 @@ extension SDAssignment {
     /// `Assignment 1 &amp; 2`; rendering the raw string would expose the
     /// encoded entity to the user.
     var displayTitle: String { title.decodingHTMLEntities() }
+
+    /// "課名 • 課程ID" line shown beneath each assignment title. Prefers the
+    /// in-memory `SDCourse` so user renames and the canonical NTUST code are
+    /// reflected; otherwise the cached `courseName` keeps the row useful while
+    /// the roster is still loading. The code is dropped when it's empty or
+    /// already equal to the name (unknown courses whose name falls back to
+    /// the courseNo).
+    func courseLineLabel(matching course: SDCourse?) -> String {
+        let name = displayCourseName(matching: course)
+        let code = course?.courseNo ?? courseNo
+        if code.isEmpty || name.isEmpty || name == code {
+            return name
+        }
+        return "\(name) • \(code)"
+    }
 }

--- a/swift/TigerDuck/Extensions/UIApplication+Keyboard.swift
+++ b/swift/TigerDuck/Extensions/UIApplication+Keyboard.swift
@@ -1,0 +1,14 @@
+#if canImport(UIKit)
+import UIKit
+
+extension UIApplication {
+    /// Forces the current first responder to resign, dismissing any visible
+    /// keyboard regardless of which control owns it. Use when programmatic
+    /// `@FocusState = nil` is silently ignored — notably with our wrapped
+    /// `UITextField`-backed `PasswordField`, which intentionally does not
+    /// resign on transient focus-state writes.
+    static func dismissKeyboard() {
+        shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}
+#endif

--- a/swift/TigerDuck/Extensions/View+PlatformCompat.swift
+++ b/swift/TigerDuck/Extensions/View+PlatformCompat.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Cross-platform shims for view modifiers that only exist on iOS, so the
+/// same SwiftUI source compiles for both iPhone and macOS without
+/// per-call-site `#if os(iOS)` ladders.
+extension View {
+    /// `navigationBarTitleDisplayMode(.inline)` on iOS, no-op on macOS.
+    @ViewBuilder
+    func inlineNavigationTitle() -> some View {
+        #if os(iOS)
+        self.navigationBarTitleDisplayMode(.inline)
+        #else
+        self
+        #endif
+    }
+
+    /// `textInputAutocapitalization(.never)` on iOS, no-op on macOS.
+    @ViewBuilder
+    func textFieldNeverCapitalized() -> some View {
+        #if os(iOS)
+        self.textInputAutocapitalization(.never)
+        #else
+        self
+        #endif
+    }
+}

--- a/swift/TigerDuck/Features/Bulletins/BulletinNotificationSettingsView.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinNotificationSettingsView.swift
@@ -144,12 +144,7 @@ struct BulletinNotificationSettingsView: View {
                 Button {
                     Task { await enablePush() }
                 } label: {
-                    if isAskingPermission {
-                        HStack(spacing: TigerDuckTheme.Spacing.xs) {
-                            ProgressView()
-                            Text(String(localized: "bulletin_push_requesting"))
-                        }
-                    } else {
+                    LoadingButtonLabel(isLoading: isAskingPermission) {
                         Label(String(localized: "bulletin_push_enable_action"), systemImage: "bell.badge")
                     }
                 }

--- a/swift/TigerDuck/Features/ClassTable/Components/AddCourseSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/AddCourseSheet.swift
@@ -39,7 +39,7 @@ struct AddCourseSheet: View {
                 Section {
                     TextField(String(localized: "add_course_placeholder"), text: $searchText)
                         .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
+                        .textFieldNeverCapitalized()
                         .focused($searchFocused)
                         .submitLabel(.search)
                         .onSubmit { submitTrigger &+= 1 }
@@ -74,12 +74,15 @@ struct AddCourseSheet: View {
             }
             .background(Color.backgroundPrimary)
             .navigationTitle(String(localized: "add_course_title"))
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(String(localized: "action_close")) { dismiss() }
                 }
             }
+            #if os(macOS)
+            .frame(minWidth: 520, minHeight: 480)
+            #endif
             .onAppear { searchFocused = true }
             // Live, debounced search. `.task(id:)` deterministically re-fires
             // whenever the id changes and auto-cancels the in-flight task —
@@ -174,9 +177,18 @@ struct AddCourseSheet: View {
         secondaryNamesByNo = [:]
 
         let isCourseCode = Self.looksLikeCourseCode(query)
-        let uiLanguage = LanguageManager.resolvedCourseApiLanguage(
-            appLanguage: Defaults[.appLanguage]
-        )
+        // Primary language follows what the user is typing, not the UI:
+        // a CJK query shows "中文 (English)", a Latin query shows "English (中文)".
+        // Course-code queries are language-neutral — fall back to UI language
+        // so the row's primary name is still in the reader's language.
+        let primaryLanguage: String
+        if isCourseCode {
+            primaryLanguage = LanguageManager.resolvedCourseApiLanguage(
+                appLanguage: Defaults[.appLanguage]
+            )
+        } else {
+            primaryLanguage = Self.queryLanguage(of: query)
+        }
         // Send the traditional form to the zh API so simplified queries
         // ("隐私") still match traditional course names ("隱私與資訊安全").
         let zhQuery = Self.toTraditional(query)
@@ -194,8 +206,8 @@ struct AddCourseSheet: View {
             let enResults = try await enTask
             try Task.checkCancellation()
 
-            let primaryResultsRaw = uiLanguage == "en" ? enResults : zhResults
-            let secondaryResultsRaw = uiLanguage == "en" ? zhResults : enResults
+            let primaryResultsRaw = primaryLanguage == "en" ? enResults : zhResults
+            let secondaryResultsRaw = primaryLanguage == "en" ? zhResults : enResults
 
             // Fast path: the primary-language API returned matches. Show them
             // immediately with whatever parentheticals the secondary call
@@ -221,8 +233,8 @@ struct AddCourseSheet: View {
             )
             try Task.checkCancellation()
 
-            let primary = uiLanguage == "en" ? enFilled : zhFilled
-            let secondary = uiLanguage == "en" ? zhFilled : enFilled
+            let primary = primaryLanguage == "en" ? enFilled : zhFilled
+            let secondary = primaryLanguage == "en" ? zhFilled : enFilled
             let secondaryByNo = Dictionary(
                 secondary.map { ($0.CourseNo, $0.CourseName) },
                 uniquingKeysWith: { first, _ in first }
@@ -343,6 +355,27 @@ struct AddCourseSheet: View {
 
     private static func toTraditional(_ text: String) -> String {
         text.applyingTransform(hansHantTransform, reverse: false) ?? text
+    }
+
+    /// Returns "zh" if the query contains any CJK Unified Ideograph
+    /// (traditional, simplified, or extension blocks); otherwise "en".
+    /// The result drives which language's result list is shown as primary,
+    /// independent of the UI language — so an English-typing user gets
+    /// "Calculus (微積分)" and a Mandarin-typing user gets "微積分 (Calculus)".
+    static func queryLanguage(of query: String) -> String {
+        for scalar in query.unicodeScalars {
+            switch scalar.value {
+            case 0x3400...0x4DBF,    // CJK Unified Ideographs Extension A
+                 0x4E00...0x9FFF,    // CJK Unified Ideographs
+                 0x20000...0x2A6DF,  // Extension B
+                 0x2A700...0x2EBEF,  // Extensions C, D, E, F
+                 0x30000...0x3134F:  // Extension G
+                return "zh"
+            default:
+                continue
+            }
+        }
+        return "en"
     }
 
     // MARK: - Group & Add

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
@@ -11,6 +11,7 @@ import SwiftUI
 /// instead of being buried in the same flat list as the metadata rows.
 struct CourseDetailSheet: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.openURL) private var openURL
 
     let course: SDCourse
     let assignments: [SDAssignment]
@@ -30,8 +31,13 @@ struct CourseDetailSheet: View {
                 .padding(.bottom, TigerDuckTheme.Spacing.lg)
             }
             .background(Color.backgroundPrimary)
+            #if os(iOS)
             .toolbar(.hidden, for: .navigationBar)
+            #endif
         }
+        #if os(macOS)
+        .frame(minWidth: 460, minHeight: 360)
+        #endif
     }
 
     // MARK: - Header
@@ -140,7 +146,7 @@ struct CourseDetailSheet: View {
             ForEach(Array(assignments.enumerated()), id: \.element.assignmentId) { _, assignment in
                 Button {
                     if let url = assignment.moodleDeepLink {
-                        UIApplication.shared.open(url)
+                        openURL(url)
                     }
                 } label: {
                     HStack {
@@ -172,10 +178,11 @@ struct CourseDetailSheet: View {
 
     /// Always route through the `moodlemobile://` deep link — matches the
     /// assignment-row convention above and keeps the user inside the Moodle
-    /// app instead of bouncing out to Safari.
+    /// app instead of bouncing out to Safari. `openURL` falls back to the
+    /// system browser on macOS when no Moodle app is installed.
     private func openMoodleCourse() {
         guard let deepLink = course.moodleDeepLink else { return }
-        UIApplication.shared.open(deepLink)
+        openURL(deepLink)
     }
 }
 

--- a/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
+++ b/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
@@ -179,21 +179,8 @@ struct UpcomingAssignmentsView: View {
         }
     }
 
-    /// "課名 • 課程ID" — the line that sits beneath the (possibly wrapped)
-    /// title. Prefers the in-memory `SDCourse` so the label reflects the
-    /// user's custom rename and the canonical NTUST course code; otherwise
-    /// falls back to whatever the assignment was cached with so the line
-    /// still renders something useful when the course roster hasn't loaded
-    /// yet. The code is omitted when it's empty or already echoes the name
-    /// (an unknown course where the name fallback is just the courseNo).
     private func courseLineLabel(for assignment: SDAssignment) -> String {
-        let match = courseByNo[assignment.courseNo]
-        let name = assignment.displayCourseName(matching: match)
-        let code = match?.courseNo ?? assignment.courseNo
-        if code.isEmpty || name.isEmpty || name == code {
-            return name
-        }
-        return "\(name) • \(code)"
+        assignment.courseLineLabel(matching: courseByNo[assignment.courseNo])
     }
 
     @ViewBuilder
@@ -248,16 +235,11 @@ struct UpcomingAssignmentsView: View {
         }
     }
 
-    /// Resolves the right-side time text. The 全部 tab uses time-based
-    /// branching (past rows always show the absolute deadline as the
-    /// second line); other tabs keep the legacy "relative unless toggled,
-    /// override to absolute for completed-and-past" rule.
+    /// Past rows always render the absolute deadline so an overdue row reads
+    /// `已逾期 / 4/1 23:50` instead of duplicating the "Overdue" badge with
+    /// `relativeTimeString`'s own "Overdue" return. Matches macOS.
     private func timeLabel(for assignment: SDAssignment, now: Date) -> String {
-        let isPast = assignment.dueDate < now
-        if filter == .all && isPast {
-            return assignment.dueDate.absoluteTimeString
-        }
-        if showAbsoluteTime || (assignment.isCompleted && isPast) {
+        if showAbsoluteTime || assignment.dueDate < now {
             return assignment.dueDate.absoluteTimeString
         }
         return assignment.dueDate.relativeTimeString(from: now)

--- a/swift/TigerDuck/Features/More/Components/FeatureCardView.swift
+++ b/swift/TigerDuck/Features/More/Components/FeatureCardView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct FeatureCardView: View {
     let feature: AppFeature
-    var isPinned: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.sm) {
@@ -12,11 +11,6 @@ struct FeatureCardView: View {
                     .foregroundStyle(Color.accentPrimary)
                     .frame(width: 28, height: 28)
                 Spacer()
-                if isPinned {
-                    Image(systemName: "pin.fill")
-                        .font(.caption2)
-                        .foregroundStyle(Color.textSecondary)
-                }
             }
             Text(feature.displayName)
                 .font(TigerDuckTheme.Typography.headline)

--- a/swift/TigerDuck/Features/More/Components/FeatureCategorySection.swift
+++ b/swift/TigerDuck/Features/More/Components/FeatureCategorySection.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct FeatureCategorySection: View {
     let category: FeatureCategory
     let features: [AppFeature]
-    var isPinned: (AppFeature) -> Bool = { _ in false }
     var onFeatureTap: ((AppFeature) -> Void)? = nil
 
     private let columns = [
@@ -20,7 +19,7 @@ struct FeatureCategorySection: View {
                     Button {
                         onFeatureTap?(feature)
                     } label: {
-                        FeatureCardView(feature: feature, isPinned: isPinned(feature))
+                        FeatureCardView(feature: feature)
                     }
                     .buttonStyle(.plain)
                 }

--- a/swift/TigerDuck/Features/More/MoreView.swift
+++ b/swift/TigerDuck/Features/More/MoreView.swift
@@ -11,7 +11,7 @@ struct MoreView: View {
         return NavigationStack(path: $navigationPath) {
             ScrollView {
                 VStack(spacing: TigerDuckTheme.Spacing.lg) {
-                    HStack {
+                    HStack(alignment: .top) {
                         Text(String(localized: "feature_more"))
                             .font(TigerDuckTheme.Typography.title)
                             .foregroundStyle(Color.textPrimary)
@@ -21,9 +21,9 @@ struct MoreView: View {
                                 SettingsView()
                             } label: {
                                 Image(systemName: "gearshape.fill")
-                                    .font(.body)
+                                    .font(.title2)
                                     .foregroundStyle(.primary)
-                                    .frame(width: 34, height: 34)
+                                    .frame(width: 44, height: 44)
                                     .glassEffect(.regular.interactive(), in: .circle)
                             }
                             .buttonStyle(.plain)
@@ -32,9 +32,9 @@ struct MoreView: View {
                                 SettingsView()
                             } label: {
                                 Image(systemName: "gearshape.fill")
-                                    .font(.body)
+                                    .font(.title2)
                                     .foregroundStyle(Color.textPrimary)
-                                    .frame(width: 34, height: 34)
+                                    .frame(width: 44, height: 44)
                                     .background(.ultraThinMaterial, in: Circle())
                             }
                             .buttonStyle(.plain)
@@ -49,7 +49,6 @@ struct MoreView: View {
                         FeatureCategorySection(
                             category: group.category,
                             features: group.features,
-                            isPinned: { viewModel.isPinned($0, in: appState) },
                             onFeatureTap: { feature in
                                 if feature.isImplemented {
                                     navigationPath.append(feature)

--- a/swift/TigerDuck/Features/More/MoreViewModel.swift
+++ b/swift/TigerDuck/Features/More/MoreViewModel.swift
@@ -10,12 +10,4 @@ final class MoreViewModel {
             return features.isEmpty ? nil : (category, features)
         }
     }()
-
-    /// `pinnedTabs` previously held a never-written `Set<AppFeature>`,
-    /// so the pin badge was always false. Read from `AppState`'s
-    /// `configuredTabs` instead — the actual source of truth for which
-    /// features are pinned to the bottom tab bar.
-    func isPinned(_ feature: AppFeature, in appState: AppState) -> Bool {
-        appState.configuredTabs.contains(feature)
-    }
 }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -76,7 +76,7 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
                     .font(.system(size: 32, weight: .semibold))
                     .foregroundStyle(.white)
                     .symbolEffect(.pulse, options: .repeating.speed(0.35))
-                    .offset(y: 4)
+                    .offset(y: -4)
             }
         }
     }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -40,8 +40,11 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
                 .padding(.top, TigerDuckTheme.Spacing.xxl)
                 .padding(.bottom, TigerDuckTheme.Spacing.xxl * 2)
                 .frame(maxWidth: .infinity, minHeight: proxy.size.height)
+                .contentShape(Rectangle())
+                .onTapGesture { UIApplication.dismissKeyboard() }
             }
             .scrollIndicators(.never)
+            .scrollDismissesKeyboard(.interactively)
         }
     }
 }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -18,40 +18,42 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
     @ViewBuilder let actions: () -> Actions
 
     var body: some View {
-        GeometryReader { proxy in
-            ScrollView {
-                VStack(spacing: TigerDuckTheme.Spacing.lg) {
-                    iconView
+        VStack(spacing: TigerDuckTheme.Spacing.lg) {
+            iconView
 
-                    Text(title)
-                        .font(TigerDuckTheme.Typography.title)
-                        .foregroundStyle(Color.textPrimary)
-                        .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
+            Text(title)
+                .font(TigerDuckTheme.Typography.title)
+                .foregroundStyle(Color.textPrimary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
 
-                    Text(subtitle)
-                        .font(TigerDuckTheme.Typography.body)
-                        .foregroundStyle(Color.textSecondary)
-                        .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-
-                    content()
-
-                    Spacer(minLength: TigerDuckTheme.Spacing.lg)
-
-                    actions()
-                }
+            Text(subtitle)
+                .font(TigerDuckTheme.Typography.body)
+                .foregroundStyle(Color.textSecondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-                .padding(.top, TigerDuckTheme.Spacing.xxl)
-                .padding(.bottom, TigerDuckTheme.Spacing.xxl * 2)
-                .frame(maxWidth: .infinity, minHeight: proxy.size.height)
-                .contentShape(Rectangle())
-                .onTapGesture { UIApplication.dismissKeyboard() }
+
+            GeometryReader { scrollProxy in
+                ScrollView {
+                    VStack(spacing: TigerDuckTheme.Spacing.lg) {
+                        content()
+                        Spacer(minLength: TigerDuckTheme.Spacing.lg)
+                        actions()
+                    }
+                    .frame(maxWidth: .infinity, minHeight: scrollProxy.size.height)
+                }
+                .scrollIndicators(.never)
+                .scrollBounceBehavior(.basedOnSize)
+                .scrollDismissesKeyboard(.interactively)
             }
-            .scrollIndicators(.never)
-            .scrollDismissesKeyboard(.interactively)
         }
+        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+        .padding(.top, TigerDuckTheme.Spacing.xxl)
+        .padding(.bottom, TigerDuckTheme.Spacing.xxl * 2)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .contentShape(Rectangle())
+        .onTapGesture { UIApplication.dismissKeyboard() }
     }
 
     @ViewBuilder
@@ -71,10 +73,10 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
                     .font(.system(size: 64))
                     .foregroundStyle(accentColor)
                 Image(systemName: "lock.fill")
-                    .font(.system(size: 22, weight: .semibold))
+                    .font(.system(size: 32, weight: .semibold))
                     .foregroundStyle(.white)
                     .symbolEffect(.pulse, options: .repeating.speed(0.35))
-                    .offset(y: 3)
+                    .offset(y: 4)
             }
         }
     }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -8,32 +8,35 @@ struct OnboardingPageView<Actions: View>: View {
     @ViewBuilder let actions: () -> Actions
 
     var body: some View {
-        VStack(spacing: TigerDuckTheme.Spacing.xxl) {
-            Spacer()
+        ScrollView {
+            VStack(spacing: TigerDuckTheme.Spacing.lg) {
+                Image(systemName: icon)
+                    .font(.system(size: 64))
+                    .foregroundStyle(accentColor)
+                    .symbolEffect(.pulse)
 
-            Image(systemName: icon)
-                .font(.system(size: 72))
-                .foregroundStyle(accentColor)
-                .symbolEffect(.pulse)
-
-            VStack(spacing: TigerDuckTheme.Spacing.md) {
                 Text(title)
-                    .font(TigerDuckTheme.Typography.largeTitle)
+                    .font(TigerDuckTheme.Typography.title)
                     .foregroundStyle(Color.textPrimary)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Text(subtitle)
                     .font(TigerDuckTheme.Typography.body)
                     .foregroundStyle(Color.textSecondary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, TigerDuckTheme.Spacing.xxl)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+
+                Spacer().frame(height: TigerDuckTheme.Spacing.sm)
+
+                actions()
             }
-
-            Spacer()
-
-            actions()
-                .padding(.bottom, TigerDuckTheme.Spacing.xxl)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+            .padding(.top, TigerDuckTheme.Spacing.xxl)
+            .padding(.bottom, TigerDuckTheme.Spacing.xxl * 2)
         }
-        .padding()
+        .scrollIndicators(.never)
     }
 }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 
-struct OnboardingPageView<Actions: View>: View {
+struct OnboardingPageView<Content: View, Actions: View>: View {
     let icon: String
     let title: String
     let subtitle: String
     var accentColor: Color = .accentPrimary
+    @ViewBuilder let content: () -> Content
     @ViewBuilder let actions: () -> Actions
 
     var body: some View {
@@ -29,6 +30,8 @@ struct OnboardingPageView<Actions: View>: View {
                         .fixedSize(horizontal: false, vertical: true)
                         .padding(.horizontal, TigerDuckTheme.Spacing.lg)
 
+                    content()
+
                     Spacer(minLength: TigerDuckTheme.Spacing.lg)
 
                     actions()
@@ -40,5 +43,24 @@ struct OnboardingPageView<Actions: View>: View {
             }
             .scrollIndicators(.never)
         }
+    }
+}
+
+extension OnboardingPageView where Content == EmptyView {
+    init(
+        icon: String,
+        title: String,
+        subtitle: String,
+        accentColor: Color = .accentPrimary,
+        @ViewBuilder actions: @escaping () -> Actions
+    ) {
+        self.init(
+            icon: icon,
+            title: title,
+            subtitle: subtitle,
+            accentColor: accentColor,
+            content: { EmptyView() },
+            actions: actions
+        )
     }
 }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -1,10 +1,19 @@
 import SwiftUI
 
 struct OnboardingPageView<Content: View, Actions: View>: View {
+    enum IconAnimation {
+        /// Default — the whole symbol pulses once on appear.
+        case pulse
+        /// Cycles per-layer color: on multi-layer symbols (e.g.
+        /// `lock.shield.fill`), the inner layer reads as flashing.
+        case layerFlash
+    }
+
     let icon: String
     let title: String
     let subtitle: String
     var accentColor: Color = .accentPrimary
+    var iconAnimation: IconAnimation = .pulse
     @ViewBuilder let content: () -> Content
     @ViewBuilder let actions: () -> Actions
 
@@ -12,10 +21,7 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
         GeometryReader { proxy in
             ScrollView {
                 VStack(spacing: TigerDuckTheme.Spacing.lg) {
-                    Image(systemName: icon)
-                        .font(.system(size: 64))
-                        .foregroundStyle(accentColor)
-                        .symbolEffect(.pulse)
+                    iconView
 
                     Text(title)
                         .font(TigerDuckTheme.Typography.title)
@@ -47,6 +53,22 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
             .scrollDismissesKeyboard(.interactively)
         }
     }
+
+    @ViewBuilder
+    private var iconView: some View {
+        let image = Image(systemName: icon)
+            .font(.system(size: 64))
+            .foregroundStyle(accentColor)
+
+        switch iconAnimation {
+        case .pulse:
+            image.symbolEffect(.pulse)
+        case .layerFlash:
+            image
+                .symbolRenderingMode(.hierarchical)
+                .symbolEffect(.variableColor.iterative.reversing, options: .repeating)
+        }
+    }
 }
 
 extension OnboardingPageView where Content == EmptyView {
@@ -55,6 +77,7 @@ extension OnboardingPageView where Content == EmptyView {
         title: String,
         subtitle: String,
         accentColor: Color = .accentPrimary,
+        iconAnimation: IconAnimation = .pulse,
         @ViewBuilder actions: @escaping () -> Actions
     ) {
         self.init(
@@ -62,6 +85,7 @@ extension OnboardingPageView where Content == EmptyView {
             title: title,
             subtitle: subtitle,
             accentColor: accentColor,
+            iconAnimation: iconAnimation,
             content: { EmptyView() },
             actions: actions
         )

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -8,35 +8,37 @@ struct OnboardingPageView<Actions: View>: View {
     @ViewBuilder let actions: () -> Actions
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: TigerDuckTheme.Spacing.lg) {
-                Image(systemName: icon)
-                    .font(.system(size: 64))
-                    .foregroundStyle(accentColor)
-                    .symbolEffect(.pulse)
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(spacing: TigerDuckTheme.Spacing.lg) {
+                    Image(systemName: icon)
+                        .font(.system(size: 64))
+                        .foregroundStyle(accentColor)
+                        .symbolEffect(.pulse)
 
-                Text(title)
-                    .font(TigerDuckTheme.Typography.title)
-                    .foregroundStyle(Color.textPrimary)
-                    .multilineTextAlignment(.center)
-                    .fixedSize(horizontal: false, vertical: true)
+                    Text(title)
+                        .font(TigerDuckTheme.Typography.title)
+                        .foregroundStyle(Color.textPrimary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
 
-                Text(subtitle)
-                    .font(TigerDuckTheme.Typography.body)
-                    .foregroundStyle(Color.textSecondary)
-                    .multilineTextAlignment(.center)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+                    Text(subtitle)
+                        .font(TigerDuckTheme.Typography.body)
+                        .foregroundStyle(Color.textSecondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
 
-                Spacer().frame(height: TigerDuckTheme.Spacing.sm)
+                    Spacer(minLength: TigerDuckTheme.Spacing.lg)
 
-                actions()
+                    actions()
+                }
+                .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+                .padding(.top, TigerDuckTheme.Spacing.xxl)
+                .padding(.bottom, TigerDuckTheme.Spacing.xxl * 2)
+                .frame(maxWidth: .infinity, minHeight: proxy.size.height)
             }
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-            .padding(.top, TigerDuckTheme.Spacing.xxl)
-            .padding(.bottom, TigerDuckTheme.Spacing.xxl * 2)
+            .scrollIndicators(.never)
         }
-        .scrollIndicators(.never)
     }
 }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -56,17 +56,26 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
 
     @ViewBuilder
     private var iconView: some View {
-        let image = Image(systemName: icon)
-            .font(.system(size: 64))
-            .foregroundStyle(accentColor)
-
         switch iconAnimation {
         case .pulse:
-            image.symbolEffect(.pulse)
+            Image(systemName: icon)
+                .font(.system(size: 64))
+                .foregroundStyle(accentColor)
+                .symbolEffect(.pulse)
         case .layerFlash:
-            image
-                .symbolRenderingMode(.hierarchical)
-                .symbolEffect(.variableColor.iterative.reversing, options: .repeating)
+            // Compose the shield and lock as separate images so only the
+            // lock animates (the built-in lock.shield.fill effect would
+            // pulse both layers).
+            ZStack {
+                Image(systemName: "shield.fill")
+                    .font(.system(size: 64))
+                    .foregroundStyle(accentColor)
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .symbolEffect(.pulse, options: .repeating.speed(0.35))
+                    .offset(y: 3)
+            }
         }
     }
 }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -34,19 +34,18 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, TigerDuckTheme.Spacing.lg)
 
-            GeometryReader { scrollProxy in
-                ScrollView {
-                    VStack(spacing: TigerDuckTheme.Spacing.lg) {
-                        content()
-                        Spacer(minLength: TigerDuckTheme.Spacing.lg)
-                        actions()
-                    }
-                    .frame(maxWidth: .infinity, minHeight: scrollProxy.size.height)
+            ScrollView {
+                VStack(spacing: TigerDuckTheme.Spacing.lg) {
+                    content()
                 }
-                .scrollIndicators(.never)
-                .scrollBounceBehavior(.basedOnSize)
-                .scrollDismissesKeyboard(.interactively)
+                .frame(maxWidth: .infinity)
             }
+            .scrollIndicators(.never)
+            .scrollBounceBehavior(.basedOnSize)
+            .scrollDismissesKeyboard(.interactively)
+
+            actions()
+                .frame(maxWidth: .infinity)
         }
         .padding(.horizontal, TigerDuckTheme.Spacing.lg)
         .padding(.top, TigerDuckTheme.Spacing.xxl)

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -80,41 +80,39 @@ struct OnboardingView: View {
             icon: "lock.shield.fill",
             title: String(localized: "onboarding_privacy_title"),
             subtitle: String(localized: "onboarding_privacy_subtitle"),
-            accentColor: .blue
-        ) {
-            VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.md) {
-                privacyCheckbox(
-                    isOn: $agreedPrivacy,
-                    label: String(localized: "onboarding_privacy_policy_label"),
-                    destination: AppURLs.privacyPolicy
-                )
-                privacyCheckbox(
-                    isOn: $agreedDeletion,
-                    label: String(localized: "onboarding_privacy_delete_account_label"),
-                    destination: AppURLs.deleteAccount
-                )
-
-                if !(agreedPrivacy && agreedDeletion) {
+            accentColor: .blue,
+            content: {
+                VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.md) {
+                    privacyCheckbox(
+                        isOn: $agreedPrivacy,
+                        label: String(localized: "onboarding_privacy_policy_label"),
+                        destination: AppURLs.privacyPolicy
+                    )
+                    privacyCheckbox(
+                        isOn: $agreedDeletion,
+                        label: String(localized: "onboarding_privacy_delete_account_label"),
+                        destination: AppURLs.deleteAccount
+                    )
+                }
+                .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+            },
+            actions: {
+                VStack(spacing: TigerDuckTheme.Spacing.sm) {
                     Text(String(localized: "onboarding_privacy_continue_hint"))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.top, TigerDuckTheme.Spacing.sm)
-                }
+                        .opacity(agreedPrivacy && agreedDeletion ? 0 : 1)
 
-                HStack {
-                    Spacer()
                     Button(String(localized: "action_next")) {
                         withAnimation { currentPage = Page.watchOS.rawValue }
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
                     .disabled(!(agreedPrivacy && agreedDeletion))
-                    Spacer()
                 }
             }
-            .padding(.horizontal, TigerDuckTheme.Spacing.xl)
-        }
+        )
     }
 
     private func privacyCheckbox(

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -51,23 +51,23 @@ struct OnboardingView: View {
         ) {
             VStack(spacing: TigerDuckTheme.Spacing.md) {
                 Text(String(localized: "onboarding_welcome_description"))
-                    .font(.callout)
+                    .font(.footnote)
                     .foregroundStyle(Color.textSecondary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, TigerDuckTheme.Spacing.xl)
                     .fixedSize(horizontal: false, vertical: true)
 
                 VStack(spacing: TigerDuckTheme.Spacing.sm) {
                     Link(String(localized: "onboarding_welcome_website_label"), destination: AppURLs.website)
                     Link(String(localized: "onboarding_welcome_github_label"), destination: AppURLs.github)
                 }
-                .font(.callout.weight(.semibold))
+                .font(.footnote.weight(.semibold))
 
                 Button(String(localized: "action_next")) {
                     withAnimation { currentPage = Page.privacy.rawValue }
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
+                .padding(.top, TigerDuckTheme.Spacing.sm)
             }
         }
     }
@@ -254,7 +254,7 @@ struct OnboardingView: View {
             subtitle: String(localized: "onboarding_permissions_subtitle"),
             accentColor: .orange
         ) {
-            VStack(spacing: TigerDuckTheme.Spacing.lg) {
+            VStack(spacing: TigerDuckTheme.Spacing.md) {
                 notificationStatusRow
 
                 if notificationStatus == .denied {
@@ -267,18 +267,18 @@ struct OnboardingView: View {
                     .controlSize(.large)
                 }
 
-                HStack(spacing: TigerDuckTheme.Spacing.lg) {
-                    Button(String(localized: "onboarding_skip_for_now")) {
-                        withAnimation { currentPage = Page.ready.rawValue }
-                    }
-                    .foregroundStyle(Color.textSecondary)
+                Spacer().frame(height: TigerDuckTheme.Spacing.xl)
 
-                    Button(String(localized: "action_next")) {
-                        withAnimation { currentPage = Page.ready.rawValue }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
+                Button(String(localized: "onboarding_skip_for_now")) {
+                    withAnimation { currentPage = Page.ready.rawValue }
                 }
+                .foregroundStyle(Color.textSecondary)
+
+                Button(String(localized: "action_next")) {
+                    withAnimation { currentPage = Page.ready.rawValue }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
             }
         }
     }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -21,8 +21,6 @@ struct OnboardingView: View {
         case welcome, privacy, watchOS, login, notifications, ready
     }
 
-    private let lastPageIndex = Page.allCases.count - 1
-
     var body: some View {
         TabView(selection: $currentPage) {
             welcomePage.tag(Page.welcome.rawValue)

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -81,6 +81,7 @@ struct OnboardingView: View {
             title: String(localized: "onboarding_privacy_title"),
             subtitle: String(localized: "onboarding_privacy_subtitle"),
             accentColor: .blue,
+            iconAnimation: .layerFlash,
             content: {
                 VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.md) {
                     privacyCheckbox(
@@ -154,80 +155,99 @@ struct OnboardingView: View {
     // MARK: - Page 3: Login
 
     private var loginPage: some View {
-        OnboardingPageView(
+        let isSignedIn = appState.authService.hasStoredCredentials
+
+        return OnboardingPageView(
             icon: "person.badge.key.fill",
             title: String(localized: "onboarding_login_title"),
             subtitle: String(localized: "onboarding_login_subtitle"),
             accentColor: .green,
             content: {
-                VStack(spacing: TigerDuckTheme.Spacing.md) {
-                    VStack(spacing: 1) {
-                        HStack(spacing: TigerDuckTheme.Spacing.md) {
-                            Image(systemName: "person.fill")
-                                .foregroundStyle(.secondary)
-                                .frame(width: 20)
-                            TextField(String(localized: "login_student_id"), text: $studentId)
-                                .keyboardType(.asciiCapable)
-                                .focused($focusedField, equals: .studentId)
-                                .textContentType(.username)
-                                .autocorrectionDisabled()
-                                .textInputAutocapitalization(.characters)
-                                .submitLabel(.next)
-                                .onSubmit { focusedField = .password }
-                        }
-                        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-                        .padding(.vertical, TigerDuckTheme.Spacing.md)
-                        .background(.fill.quaternary, in: .rect(topLeadingRadius: TigerDuckTheme.CornerRadius.md, topTrailingRadius: TigerDuckTheme.CornerRadius.md))
-
-                        Divider()
+                if isSignedIn {
+                    Label(
+                        String(localized: "action_done"),
+                        systemImage: "checkmark.circle.fill"
+                    )
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(.green)
+                } else {
+                    VStack(spacing: TigerDuckTheme.Spacing.md) {
+                        VStack(spacing: 1) {
+                            HStack(spacing: TigerDuckTheme.Spacing.md) {
+                                Image(systemName: "person.fill")
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 20)
+                                TextField(String(localized: "login_student_id"), text: $studentId)
+                                    .keyboardType(.asciiCapable)
+                                    .focused($focusedField, equals: .studentId)
+                                    .textContentType(.username)
+                                    .autocorrectionDisabled()
+                                    .textInputAutocapitalization(.characters)
+                                    .submitLabel(.next)
+                                    .onSubmit { focusedField = .password }
+                            }
                             .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+                            .padding(.vertical, TigerDuckTheme.Spacing.md)
+                            .background(.fill.quaternary, in: .rect(topLeadingRadius: TigerDuckTheme.CornerRadius.md, topTrailingRadius: TigerDuckTheme.CornerRadius.md))
 
-                        HStack(spacing: TigerDuckTheme.Spacing.md) {
-                            Image(systemName: "lock.fill")
-                                .foregroundStyle(.secondary)
-                                .frame(width: 20)
-                            PasswordField(
-                                placeholder: String(localized: "login_password"),
-                                text: $password,
-                                focusBinding: $focusedField,
-                                focusValue: .password,
-                                onSubmit: { submitLogin() }
-                            )
+                            Divider()
+                                .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+
+                            HStack(spacing: TigerDuckTheme.Spacing.md) {
+                                Image(systemName: "lock.fill")
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 20)
+                                PasswordField(
+                                    placeholder: String(localized: "login_password"),
+                                    text: $password,
+                                    focusBinding: $focusedField,
+                                    focusValue: .password,
+                                    onSubmit: { submitLogin() }
+                                )
+                            }
+                            .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+                            .padding(.vertical, TigerDuckTheme.Spacing.md)
+                            .background(.fill.quaternary, in: .rect(bottomLeadingRadius: TigerDuckTheme.CornerRadius.md, bottomTrailingRadius: TigerDuckTheme.CornerRadius.md))
                         }
-                        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-                        .padding(.vertical, TigerDuckTheme.Spacing.md)
-                        .background(.fill.quaternary, in: .rect(bottomLeadingRadius: TigerDuckTheme.CornerRadius.md, bottomTrailingRadius: TigerDuckTheme.CornerRadius.md))
-                    }
-                    .frame(maxWidth: 320)
+                        .frame(maxWidth: 320)
 
-                    if let error = appState.authService.loginError {
-                        Text(error)
-                            .font(.caption)
-                            .foregroundStyle(.red)
+                        if let error = appState.authService.loginError {
+                            Text(error)
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                        }
                     }
                 }
             },
             actions: {
-                VStack(spacing: TigerDuckTheme.Spacing.md) {
-                    Button(String(localized: "onboarding_skip_for_now")) {
+                if isSignedIn {
+                    Button(String(localized: "action_next")) {
                         withAnimation { currentPage = Page.notifications.rawValue }
-                    }
-                    .foregroundStyle(Color.textSecondary)
-
-                    Button {
-                        submitLogin()
-                    } label: {
-                        LoadingButtonLabel(
-                            isLoading: appState.authService.isLoggingIn,
-                            tint: .white
-                        ) {
-                            Text(String(localized: "onboarding_login_button"))
-                                .font(.callout.weight(.semibold))
-                        }
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
-                    .disabled(studentId.isEmpty || password.isEmpty || appState.authService.isLoggingIn)
+                } else {
+                    VStack(spacing: TigerDuckTheme.Spacing.md) {
+                        Button(String(localized: "onboarding_skip_for_now")) {
+                            withAnimation { currentPage = Page.notifications.rawValue }
+                        }
+                        .foregroundStyle(Color.textSecondary)
+
+                        Button {
+                            submitLogin()
+                        } label: {
+                            LoadingButtonLabel(
+                                isLoading: appState.authService.isLoggingIn,
+                                tint: .white
+                            ) {
+                                Text(String(localized: "onboarding_login_button"))
+                                    .font(.callout.weight(.semibold))
+                            }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.large)
+                        .disabled(studentId.isEmpty || password.isEmpty || appState.authService.isLoggingIn)
+                    }
                 }
             }
         )

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -51,25 +51,28 @@ struct OnboardingView: View {
             content: {
                 VStack(spacing: TigerDuckTheme.Spacing.md) {
                     Text(String(localized: "onboarding_welcome_description"))
-                        .font(.footnote)
+                        .font(.callout)
                         .foregroundStyle(Color.textSecondary)
                         .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
+                        .lineLimit(12)
+                        .minimumScaleFactor(0.6)
 
                     VStack(spacing: TigerDuckTheme.Spacing.md) {
                         Link(String(localized: "onboarding_welcome_website_label"), destination: AppURLs.website)
                         Link(String(localized: "onboarding_welcome_github_label"), destination: AppURLs.github)
                     }
-                    .font(.footnote.weight(.semibold))
+                    .font(.callout.weight(.semibold))
                     .padding(.top, TigerDuckTheme.Spacing.sm)
                 }
             },
             actions: {
-                Button(String(localized: "action_next")) {
-                    withAnimation { currentPage = Page.privacy.rawValue }
+                VStack(spacing: TigerDuckTheme.Spacing.md) {
+                    Button(String(localized: "action_next")) {
+                        withAnimation { currentPage = Page.privacy.rawValue }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
             }
         )
     }
@@ -84,18 +87,19 @@ struct OnboardingView: View {
             accentColor: .blue,
             iconAnimation: .layerFlash,
             content: {
-                VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.md) {
-                    privacyCheckbox(
+                Grid(alignment: .leading, horizontalSpacing: TigerDuckTheme.Spacing.md, verticalSpacing: TigerDuckTheme.Spacing.md) {
+                    privacyCheckboxRow(
                         isOn: $agreedPrivacy,
                         label: String(localized: "onboarding_privacy_policy_label"),
                         destination: AppURLs.privacyPolicy
                     )
-                    privacyCheckbox(
+                    privacyCheckboxRow(
                         isOn: $agreedDeletion,
                         label: String(localized: "onboarding_privacy_delete_account_label"),
                         destination: AppURLs.deleteAccount
                     )
                 }
+                .frame(maxWidth: .infinity)
                 .padding(.horizontal, TigerDuckTheme.Spacing.lg)
             },
             actions: {
@@ -117,24 +121,25 @@ struct OnboardingView: View {
         )
     }
 
-    private func privacyCheckbox(
+    private func privacyCheckboxRow(
         isOn: Binding<Bool>, label: String, destination: URL
     ) -> some View {
-        HStack(spacing: TigerDuckTheme.Spacing.md) {
+        GridRow {
             Button {
                 isOn.wrappedValue.toggle()
             } label: {
-                Image(systemName: isOn.wrappedValue ? "checkmark.square.fill" : "square")
-                    .font(.title3)
+                Image(systemName: isOn.wrappedValue ? "checkmark.circle.fill" : "circle")
+                    .font(.title2)
+                    .symbolRenderingMode(.hierarchical)
                     .foregroundStyle(isOn.wrappedValue ? Color.accentPrimary : Color.textSecondary)
+                    .contentTransition(.symbolEffect(.replace))
             }
             .buttonStyle(.plain)
+            .sensoryFeedback(.selection, trigger: isOn.wrappedValue)
 
             Link(label, destination: destination)
                 .font(.callout)
-            Spacer()
         }
-        .sensoryFeedback(.selection, trigger: isOn.wrappedValue)
     }
 
     // MARK: - Page 2: Apple Watch support

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -133,6 +133,7 @@ struct OnboardingView: View {
                 .font(.callout)
             Spacer()
         }
+        .sensoryFeedback(.selection, trigger: isOn.wrappedValue)
     }
 
     // MARK: - Page 2: Apple Watch support

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -47,29 +47,30 @@ struct OnboardingView: View {
             icon: "graduationcap.fill",
             title: String(localized: "onboarding_welcome_title"),
             subtitle: String(localized: "onboarding_welcome_subtitle"),
-            accentColor: .accentPrimary
-        ) {
-            VStack(spacing: TigerDuckTheme.Spacing.md) {
-                Text(String(localized: "onboarding_welcome_description"))
-                    .font(.footnote)
-                    .foregroundStyle(Color.textSecondary)
-                    .multilineTextAlignment(.center)
-                    .fixedSize(horizontal: false, vertical: true)
+            accentColor: .accentPrimary,
+            content: {
+                VStack(spacing: TigerDuckTheme.Spacing.md) {
+                    Text(String(localized: "onboarding_welcome_description"))
+                        .font(.footnote)
+                        .foregroundStyle(Color.textSecondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
 
-                VStack(spacing: TigerDuckTheme.Spacing.sm) {
-                    Link(String(localized: "onboarding_welcome_website_label"), destination: AppURLs.website)
-                    Link(String(localized: "onboarding_welcome_github_label"), destination: AppURLs.github)
+                    VStack(spacing: TigerDuckTheme.Spacing.sm) {
+                        Link(String(localized: "onboarding_welcome_website_label"), destination: AppURLs.website)
+                        Link(String(localized: "onboarding_welcome_github_label"), destination: AppURLs.github)
+                    }
+                    .font(.footnote.weight(.semibold))
                 }
-                .font(.footnote.weight(.semibold))
-
+            },
+            actions: {
                 Button(String(localized: "action_next")) {
                     withAnimation { currentPage = Page.privacy.rawValue }
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
-                .padding(.top, TigerDuckTheme.Spacing.sm)
             }
-        }
+        )
     }
 
     // MARK: - Page 1: Privacy & terms
@@ -159,78 +160,80 @@ struct OnboardingView: View {
             icon: "person.badge.key.fill",
             title: String(localized: "onboarding_login_title"),
             subtitle: String(localized: "onboarding_login_subtitle"),
-            accentColor: .green
-        ) {
-            VStack(spacing: TigerDuckTheme.Spacing.lg) {
-                VStack(spacing: 1) {
-                    HStack(spacing: TigerDuckTheme.Spacing.md) {
-                        Image(systemName: "person.fill")
-                            .foregroundStyle(.secondary)
-                            .frame(width: 20)
-                        TextField(String(localized: "login_student_id"), text: $studentId)
-                            .keyboardType(.asciiCapable)
-                            .focused($focusedField, equals: .studentId)
-                            .textContentType(.username)
-                            .autocorrectionDisabled()
-                            .textInputAutocapitalization(.characters)
-                            .submitLabel(.next)
-                            .onSubmit { focusedField = .password }
-                    }
-                    .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-                    .padding(.vertical, TigerDuckTheme.Spacing.md)
-                    .background(.fill.quaternary, in: .rect(topLeadingRadius: TigerDuckTheme.CornerRadius.md, topTrailingRadius: TigerDuckTheme.CornerRadius.md))
-
-                    Divider()
+            accentColor: .green,
+            content: {
+                VStack(spacing: TigerDuckTheme.Spacing.md) {
+                    VStack(spacing: 1) {
+                        HStack(spacing: TigerDuckTheme.Spacing.md) {
+                            Image(systemName: "person.fill")
+                                .foregroundStyle(.secondary)
+                                .frame(width: 20)
+                            TextField(String(localized: "login_student_id"), text: $studentId)
+                                .keyboardType(.asciiCapable)
+                                .focused($focusedField, equals: .studentId)
+                                .textContentType(.username)
+                                .autocorrectionDisabled()
+                                .textInputAutocapitalization(.characters)
+                                .submitLabel(.next)
+                                .onSubmit { focusedField = .password }
+                        }
                         .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+                        .padding(.vertical, TigerDuckTheme.Spacing.md)
+                        .background(.fill.quaternary, in: .rect(topLeadingRadius: TigerDuckTheme.CornerRadius.md, topTrailingRadius: TigerDuckTheme.CornerRadius.md))
 
-                    HStack(spacing: TigerDuckTheme.Spacing.md) {
-                        Image(systemName: "lock.fill")
-                            .foregroundStyle(.secondary)
-                            .frame(width: 20)
-                        PasswordField(
-                            placeholder: String(localized: "login_password"),
-                            text: $password,
-                            focusBinding: $focusedField,
-                            focusValue: .password,
-                            onSubmit: { submitLogin() }
-                        )
+                        Divider()
+                            .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+
+                        HStack(spacing: TigerDuckTheme.Spacing.md) {
+                            Image(systemName: "lock.fill")
+                                .foregroundStyle(.secondary)
+                                .frame(width: 20)
+                            PasswordField(
+                                placeholder: String(localized: "login_password"),
+                                text: $password,
+                                focusBinding: $focusedField,
+                                focusValue: .password,
+                                onSubmit: { submitLogin() }
+                            )
+                        }
+                        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+                        .padding(.vertical, TigerDuckTheme.Spacing.md)
+                        .background(.fill.quaternary, in: .rect(bottomLeadingRadius: TigerDuckTheme.CornerRadius.md, bottomTrailingRadius: TigerDuckTheme.CornerRadius.md))
                     }
-                    .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-                    .padding(.vertical, TigerDuckTheme.Spacing.md)
-                    .background(.fill.quaternary, in: .rect(bottomLeadingRadius: TigerDuckTheme.CornerRadius.md, bottomTrailingRadius: TigerDuckTheme.CornerRadius.md))
-                }
-                .frame(maxWidth: 320)
+                    .frame(maxWidth: 320)
 
-                Spacer().frame(height: TigerDuckTheme.Spacing.lg)
-
-                if let error = appState.authService.loginError {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                }
-
-                Button(String(localized: "onboarding_skip_for_now")) {
-                    withAnimation { currentPage = Page.notifications.rawValue }
-                }
-                .foregroundStyle(Color.textSecondary)
-
-                Button {
-                    submitLogin()
-                } label: {
-                    if appState.authService.isLoggingIn {
-                        ProgressView()
-                            .tint(.white)
-                            .controlSize(.small)
-                    } else {
-                        Text(String(localized: "onboarding_login_button"))
-                            .font(.callout.weight(.semibold))
+                    if let error = appState.authService.loginError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
                     }
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .disabled(studentId.isEmpty || password.isEmpty || appState.authService.isLoggingIn)
+            },
+            actions: {
+                VStack(spacing: TigerDuckTheme.Spacing.md) {
+                    Button(String(localized: "onboarding_skip_for_now")) {
+                        withAnimation { currentPage = Page.notifications.rawValue }
+                    }
+                    .foregroundStyle(Color.textSecondary)
+
+                    Button {
+                        submitLogin()
+                    } label: {
+                        if appState.authService.isLoggingIn {
+                            ProgressView()
+                                .tint(.white)
+                                .controlSize(.small)
+                        } else {
+                            Text(String(localized: "onboarding_login_button"))
+                                .font(.callout.weight(.semibold))
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .disabled(studentId.isEmpty || password.isEmpty || appState.authService.isLoggingIn)
+                }
             }
-        }
+        )
     }
 
     private func submitLogin() {

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -356,8 +356,15 @@ struct OnboardingView: View {
         notificationRequestInFlight = true
         defer { notificationRequestInFlight = false }
         let center = UNUserNotificationCenter.current()
-        _ = (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+        let granted = (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
         await refreshNotificationStatus()
+        // Onboarding is the user's first opt-in to notifications; flip the
+        // `pushServerEnabled` flag so PushCoordinator registers for remote
+        // notifications and the server sync runs. Without this the user
+        // would have to find Settings → Notifications later to actually
+        // start receiving server-backed pushes.
+        guard granted else { return }
+        appState.enablePushServer()
     }
 
     private func refreshNotificationStatus() async {

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -267,35 +267,37 @@ struct OnboardingView: View {
             icon: "bell.badge.fill",
             title: String(localized: "onboarding_permissions_title"),
             subtitle: String(localized: "onboarding_permissions_subtitle"),
-            accentColor: .orange
-        ) {
-            VStack(spacing: TigerDuckTheme.Spacing.md) {
-                notificationStatusRow
+            accentColor: .orange,
+            content: {
+                VStack(spacing: TigerDuckTheme.Spacing.md) {
+                    notificationStatusRow
 
-                if notificationStatus == .denied {
-                    Button(String(localized: "action_go_to_settings")) {
-                        if let url = URL(string: UIApplication.openSettingsURLString) {
-                            UIApplication.shared.open(url)
+                    if notificationStatus == .denied {
+                        Button(String(localized: "action_go_to_settings")) {
+                            if let url = URL(string: UIApplication.openSettingsURLString) {
+                                UIApplication.shared.open(url)
+                            }
                         }
+                        .buttonStyle(.bordered)
+                        .controlSize(.large)
                     }
-                    .buttonStyle(.bordered)
+                }
+            },
+            actions: {
+                VStack(spacing: TigerDuckTheme.Spacing.md) {
+                    Button(String(localized: "onboarding_skip_for_now")) {
+                        withAnimation { currentPage = Page.ready.rawValue }
+                    }
+                    .foregroundStyle(Color.textSecondary)
+
+                    Button(String(localized: "action_next")) {
+                        withAnimation { currentPage = Page.ready.rawValue }
+                    }
+                    .buttonStyle(.borderedProminent)
                     .controlSize(.large)
                 }
-
-                Spacer().frame(height: TigerDuckTheme.Spacing.xl)
-
-                Button(String(localized: "onboarding_skip_for_now")) {
-                    withAnimation { currentPage = Page.ready.rawValue }
-                }
-                .foregroundStyle(Color.textSecondary)
-
-                Button(String(localized: "action_next")) {
-                    withAnimation { currentPage = Page.ready.rawValue }
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
             }
-        }
+        )
     }
 
     @ViewBuilder

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -10,6 +10,7 @@ struct OnboardingView: View {
     @State private var agreedDeletion = false
     @State private var notificationStatus: UNAuthorizationStatus = .notDetermined
     @State private var notificationRequestInFlight = false
+    @Environment(\.scenePhase) private var scenePhase
     @FocusState private var focusedField: Field?
 
     private enum Field { case studentId, password }
@@ -36,6 +37,14 @@ struct OnboardingView: View {
         .onTapGesture { focusedField = nil }
         .onChange(of: currentPage) { _, _ in focusedField = nil }
         .task { await refreshNotificationStatus() }
+        .onChange(of: scenePhase) { _, newPhase in
+            // Catch a System Settings round-trip — if the user enabled
+            // notifications externally, reflect that the moment they
+            // return so the denied row + settings button stop showing.
+            if newPhase == .active {
+                Task { await refreshNotificationStatus() }
+            }
+        }
     }
 
     // MARK: - Page 0: Welcome
@@ -294,11 +303,19 @@ struct OnboardingView: View {
                     }
                     .foregroundStyle(Color.textSecondary)
 
-                    Button(String(localized: "action_next")) {
-                        withAnimation { currentPage = Page.ready.rawValue }
+                    // While the user hasn't answered the system prompt yet,
+                    // the affirmative action lives in `notificationStatusRow`
+                    // (Allow). Don't surface a second prominent Next here —
+                    // it would let the user finish onboarding without ever
+                    // triggering `requestAuthorization`, stranding the app
+                    // in `.notDetermined` with no registration path.
+                    if notificationStatus != .notDetermined {
+                        Button(String(localized: "action_next")) {
+                            withAnimation { currentPage = Page.ready.rawValue }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.large)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
                 }
             }
         )

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -1,170 +1,346 @@
 import SwiftUI
+import UserNotifications
 
 struct OnboardingView: View {
     @Environment(AppState.self) private var appState
     @State private var currentPage = 0
     @State private var studentId = ""
     @State private var password = ""
+    @State private var agreedPrivacy = false
+    @State private var agreedDeletion = false
+    @State private var notificationStatus: UNAuthorizationStatus = .notDetermined
+    @State private var notificationRequestInFlight = false
     @FocusState private var focusedField: Field?
 
     private enum Field { case studentId, password }
 
+    /// Page order matches the Android flow at
+    /// `OnboardingScreen.kt:85-87`: Welcome → Privacy → Apple Watch →
+    /// Login → Notifications → Ready.
+    private enum Page: Int, CaseIterable {
+        case welcome, privacy, watchOS, login, notifications, ready
+    }
+
+    private let lastPageIndex = Page.allCases.count - 1
+
     var body: some View {
         TabView(selection: $currentPage) {
-            // Page 1: Welcome
-            OnboardingPageView(
-                icon: "graduationcap.fill",
-                title: String(localized: "onboarding_welcome_title"),
-                subtitle: String(localized: "onboarding_welcome_subtitle"),
-                accentColor: .accentPrimary
-            ) {
-                Button(String(localized: "action_next")) {
-                    withAnimation { currentPage = 1 }
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-            }
-            .tag(0)
-
-            // Page 2: Login
-            OnboardingPageView(
-                icon: "person.badge.key.fill",
-                title: String(localized: "onboarding_login_title"),
-                subtitle: String(localized: "onboarding_login_subtitle"),
-                accentColor: .green
-            ) {
-                VStack(spacing: TigerDuckTheme.Spacing.lg) {
-                    VStack(spacing: 1) {
-                        HStack(spacing: TigerDuckTheme.Spacing.md) {
-                            Image(systemName: "person.fill")
-                                .foregroundStyle(.secondary)
-                                .frame(width: 20)
-                            TextField(String(localized: "login_student_id"), text: $studentId)
-                                .keyboardType(.asciiCapable)
-                                .focused($focusedField, equals: .studentId)
-                                .textContentType(.username)
-                                .autocorrectionDisabled()
-                                .textInputAutocapitalization(.characters)
-                                .submitLabel(.next)
-                                .onSubmit { focusedField = .password }
-                        }
-                        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-                        .padding(.vertical, TigerDuckTheme.Spacing.md)
-                        .background(.fill.quaternary, in: .rect(topLeadingRadius: TigerDuckTheme.CornerRadius.md, topTrailingRadius: TigerDuckTheme.CornerRadius.md))
-
-                        Divider()
-                            .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-
-                        HStack(spacing: TigerDuckTheme.Spacing.md) {
-                            Image(systemName: "lock.fill")
-                                .foregroundStyle(.secondary)
-                                .frame(width: 20)
-                            PasswordField(
-                                placeholder: String(localized: "login_password"),
-                                text: $password,
-                                focusBinding: $focusedField,
-                                focusValue: .password,
-                                onSubmit: {
-                                    let trimmedId = studentId.trimmingCharacters(in: .whitespaces)
-                                    let trimmedPwd = password.trimmingCharacters(in: .whitespaces)
-                                    guard !trimmedId.isEmpty, !trimmedPwd.isEmpty, !appState.authService.isLoggingIn else { return }
-                                    Task {
-                                        let success = await appState.authService.login(studentId: trimmedId, password: trimmedPwd)
-                                        if success { withAnimation { currentPage = 2 } }
-                                    }
-                                }
-                            )
-                        }
-                        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-                        .padding(.vertical, TigerDuckTheme.Spacing.md)
-                        .background(.fill.quaternary, in: .rect(bottomLeadingRadius: TigerDuckTheme.CornerRadius.md, bottomTrailingRadius: TigerDuckTheme.CornerRadius.md))
-                    }
-                    .frame(maxWidth: 320)
-
-                    Spacer()
-                        .frame(height: TigerDuckTheme.Spacing.lg)
-
-                    if let error = appState.authService.loginError {
-                        Text(error)
-                            .font(.caption)
-                            .foregroundStyle(.red)
-                    }
-
-                    Button(String(localized: "onboarding_skip_for_now")) {
-                        withAnimation { currentPage = 2 }
-                    }
-                    .foregroundStyle(Color.textSecondary)
-
-                    Button {
-                        focusedField = nil
-                        let trimmedId = studentId.trimmingCharacters(in: .whitespaces)
-                        let trimmedPwd = password.trimmingCharacters(in: .whitespaces)
-                        Task {
-                            let success = await appState.authService.login(
-                                studentId: trimmedId,
-                                password: trimmedPwd
-                            )
-                            if success {
-                                withAnimation { currentPage = 2 }
-                            }
-                        }
-                    } label: {
-                        if appState.authService.isLoggingIn {
-                            ProgressView()
-                                .tint(.white)
-                        } else {
-                            Text(String(localized: "onboarding_login_button"))
-                                .font(.callout.weight(.semibold))
-                        }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
-                    .disabled(studentId.isEmpty || password.isEmpty || appState.authService.isLoggingIn)
-                }
-            }
-            .tag(1)
-
-            // Page 3: Feature selection
-            OnboardingPageView(
-                icon: "slider.horizontal.3",
-                title: String(localized: "onboarding_choose_features_title"),
-                subtitle: String(localized: "onboarding_choose_features_subtitle"),
-                accentColor: .orange
-            ) {
-                Button(String(localized: "action_next")) {
-                    withAnimation { currentPage = 3 }
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-            }
-            .tag(2)
-
-            // Page 4: Done
-            OnboardingPageView(
-                icon: "checkmark.circle.fill",
-                title: String(localized: "onboarding_ready_title"),
-                subtitle: String(localized: "onboarding_ready_subtitle"),
-                accentColor: .accentPrimary
-            ) {
-                Button(String(localized: "onboarding_start_button")) {
-                    appState.completeOnboarding()
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                // Block "Start" while a login is still in flight on the
-                // previous page. Otherwise a user who advances mid-login
-                // (or while backgrounded) lands on the home screen
-                // logged-out, with onboarding already marked done — and
-                // has to discover the Settings → re-login path manually.
-                .disabled(appState.authService.isLoggingIn)
-            }
-            .tag(3)
+            welcomePage.tag(Page.welcome.rawValue)
+            privacyPage.tag(Page.privacy.rawValue)
+            watchOSPage.tag(Page.watchOS.rawValue)
+            loginPage.tag(Page.login.rawValue)
+            notificationsPage.tag(Page.notifications.rawValue)
+            readyPage.tag(Page.ready.rawValue)
         }
         .tabViewStyle(.page(indexDisplayMode: .always))
         .background(Color.backgroundPrimary)
         .contentShape(Rectangle())
         .onTapGesture { focusedField = nil }
         .onChange(of: currentPage) { _, _ in focusedField = nil }
+        .task { await refreshNotificationStatus() }
+    }
+
+    // MARK: - Page 0: Welcome
+
+    private var welcomePage: some View {
+        OnboardingPageView(
+            icon: "graduationcap.fill",
+            title: String(localized: "onboarding_welcome_title"),
+            subtitle: String(localized: "onboarding_welcome_subtitle"),
+            accentColor: .accentPrimary
+        ) {
+            VStack(spacing: TigerDuckTheme.Spacing.md) {
+                Text(String(localized: "onboarding_welcome_description"))
+                    .font(.callout)
+                    .foregroundStyle(Color.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, TigerDuckTheme.Spacing.xl)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                VStack(spacing: TigerDuckTheme.Spacing.sm) {
+                    Link(String(localized: "onboarding_welcome_website_label"), destination: AppURLs.website)
+                    Link(String(localized: "onboarding_welcome_github_label"), destination: AppURLs.github)
+                }
+                .font(.callout.weight(.semibold))
+
+                Button(String(localized: "action_next")) {
+                    withAnimation { currentPage = Page.privacy.rawValue }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+            }
+        }
+    }
+
+    // MARK: - Page 1: Privacy & terms
+
+    private var privacyPage: some View {
+        OnboardingPageView(
+            icon: "lock.shield.fill",
+            title: String(localized: "onboarding_privacy_title"),
+            subtitle: String(localized: "onboarding_privacy_subtitle"),
+            accentColor: .blue
+        ) {
+            VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.md) {
+                privacyCheckbox(
+                    isOn: $agreedPrivacy,
+                    label: String(localized: "onboarding_privacy_policy_label"),
+                    destination: AppURLs.privacyPolicy
+                )
+                privacyCheckbox(
+                    isOn: $agreedDeletion,
+                    label: String(localized: "onboarding_privacy_delete_account_label"),
+                    destination: AppURLs.deleteAccount
+                )
+
+                if !(agreedPrivacy && agreedDeletion) {
+                    Text(String(localized: "onboarding_privacy_continue_hint"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.top, TigerDuckTheme.Spacing.sm)
+                }
+
+                HStack {
+                    Spacer()
+                    Button(String(localized: "action_next")) {
+                        withAnimation { currentPage = Page.watchOS.rawValue }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .disabled(!(agreedPrivacy && agreedDeletion))
+                    Spacer()
+                }
+            }
+            .padding(.horizontal, TigerDuckTheme.Spacing.xl)
+        }
+    }
+
+    private func privacyCheckbox(
+        isOn: Binding<Bool>, label: String, destination: URL
+    ) -> some View {
+        HStack(spacing: TigerDuckTheme.Spacing.md) {
+            Button {
+                isOn.wrappedValue.toggle()
+            } label: {
+                Image(systemName: isOn.wrappedValue ? "checkmark.square.fill" : "square")
+                    .font(.title3)
+                    .foregroundStyle(isOn.wrappedValue ? Color.accentPrimary : Color.textSecondary)
+            }
+            .buttonStyle(.plain)
+
+            Link(label, destination: destination)
+                .font(.callout)
+            Spacer()
+        }
+    }
+
+    // MARK: - Page 2: Apple Watch support
+
+    private var watchOSPage: some View {
+        OnboardingPageView(
+            icon: "applewatch",
+            title: String(localized: "onboarding_watchos_title"),
+            subtitle: String(localized: "onboarding_watchos_description"),
+            accentColor: .red
+        ) {
+            Button(String(localized: "action_next")) {
+                withAnimation { currentPage = Page.login.rawValue }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+        }
+    }
+
+    // MARK: - Page 3: Login
+
+    private var loginPage: some View {
+        OnboardingPageView(
+            icon: "person.badge.key.fill",
+            title: String(localized: "onboarding_login_title"),
+            subtitle: String(localized: "onboarding_login_subtitle"),
+            accentColor: .green
+        ) {
+            VStack(spacing: TigerDuckTheme.Spacing.lg) {
+                VStack(spacing: 1) {
+                    HStack(spacing: TigerDuckTheme.Spacing.md) {
+                        Image(systemName: "person.fill")
+                            .foregroundStyle(.secondary)
+                            .frame(width: 20)
+                        TextField(String(localized: "login_student_id"), text: $studentId)
+                            .keyboardType(.asciiCapable)
+                            .focused($focusedField, equals: .studentId)
+                            .textContentType(.username)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.characters)
+                            .submitLabel(.next)
+                            .onSubmit { focusedField = .password }
+                    }
+                    .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+                    .padding(.vertical, TigerDuckTheme.Spacing.md)
+                    .background(.fill.quaternary, in: .rect(topLeadingRadius: TigerDuckTheme.CornerRadius.md, topTrailingRadius: TigerDuckTheme.CornerRadius.md))
+
+                    Divider()
+                        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+
+                    HStack(spacing: TigerDuckTheme.Spacing.md) {
+                        Image(systemName: "lock.fill")
+                            .foregroundStyle(.secondary)
+                            .frame(width: 20)
+                        PasswordField(
+                            placeholder: String(localized: "login_password"),
+                            text: $password,
+                            focusBinding: $focusedField,
+                            focusValue: .password,
+                            onSubmit: { submitLogin() }
+                        )
+                    }
+                    .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+                    .padding(.vertical, TigerDuckTheme.Spacing.md)
+                    .background(.fill.quaternary, in: .rect(bottomLeadingRadius: TigerDuckTheme.CornerRadius.md, bottomTrailingRadius: TigerDuckTheme.CornerRadius.md))
+                }
+                .frame(maxWidth: 320)
+
+                Spacer().frame(height: TigerDuckTheme.Spacing.lg)
+
+                if let error = appState.authService.loginError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+
+                Button(String(localized: "onboarding_skip_for_now")) {
+                    withAnimation { currentPage = Page.notifications.rawValue }
+                }
+                .foregroundStyle(Color.textSecondary)
+
+                Button {
+                    submitLogin()
+                } label: {
+                    if appState.authService.isLoggingIn {
+                        ProgressView().tint(.white)
+                    } else {
+                        Text(String(localized: "onboarding_login_button"))
+                            .font(.callout.weight(.semibold))
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(studentId.isEmpty || password.isEmpty || appState.authService.isLoggingIn)
+            }
+        }
+    }
+
+    private func submitLogin() {
+        UIApplication.dismissKeyboard()
+        focusedField = nil
+        let trimmedId = studentId.trimmingCharacters(in: .whitespaces)
+        let trimmedPwd = password.trimmingCharacters(in: .whitespaces)
+        guard !trimmedId.isEmpty, !trimmedPwd.isEmpty, !appState.authService.isLoggingIn else { return }
+        Task {
+            let success = await appState.authService.login(
+                studentId: trimmedId, password: trimmedPwd
+            )
+            if success { withAnimation { currentPage = Page.notifications.rawValue } }
+        }
+    }
+
+    // MARK: - Page 4: Notifications
+
+    private var notificationsPage: some View {
+        OnboardingPageView(
+            icon: "bell.badge.fill",
+            title: String(localized: "onboarding_permissions_title"),
+            subtitle: String(localized: "onboarding_permissions_subtitle"),
+            accentColor: .orange
+        ) {
+            VStack(spacing: TigerDuckTheme.Spacing.lg) {
+                notificationStatusRow
+
+                if notificationStatus == .denied {
+                    Button(String(localized: "action_go_to_settings")) {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+                }
+
+                HStack(spacing: TigerDuckTheme.Spacing.lg) {
+                    Button(String(localized: "onboarding_skip_for_now")) {
+                        withAnimation { currentPage = Page.ready.rawValue }
+                    }
+                    .foregroundStyle(Color.textSecondary)
+
+                    Button(String(localized: "action_next")) {
+                        withAnimation { currentPage = Page.ready.rawValue }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var notificationStatusRow: some View {
+        switch notificationStatus {
+        case .authorized, .provisional, .ephemeral:
+            Label(String(localized: "bulletin_push_status_registration_done"), systemImage: "checkmark.circle.fill")
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.green)
+        case .denied:
+            Label(String(localized: "bulletin_push_status_denied"), systemImage: "xmark.octagon.fill")
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.red)
+        case .notDetermined:
+            Button {
+                Task { await requestNotifications() }
+            } label: {
+                if notificationRequestInFlight {
+                    ProgressView()
+                } else {
+                    Label(String(localized: "action_allow"), systemImage: "bell.fill")
+                        .font(.callout.weight(.semibold))
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled(notificationRequestInFlight)
+        @unknown default:
+            EmptyView()
+        }
+    }
+
+    private func requestNotifications() async {
+        notificationRequestInFlight = true
+        defer { notificationRequestInFlight = false }
+        let center = UNUserNotificationCenter.current()
+        _ = (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+        await refreshNotificationStatus()
+    }
+
+    private func refreshNotificationStatus() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        await MainActor.run { notificationStatus = settings.authorizationStatus }
+    }
+
+    // MARK: - Page 5: Done
+
+    private var readyPage: some View {
+        OnboardingPageView(
+            icon: "checkmark.circle.fill",
+            title: String(localized: "onboarding_ready_title"),
+            subtitle: String(localized: "onboarding_ready_subtitle"),
+            accentColor: .accentPrimary
+        ) {
+            Button(String(localized: "onboarding_start_button")) {
+                appState.completeOnboarding()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled(appState.authService.isLoggingIn)
+        }
     }
 }
-

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -218,7 +218,9 @@ struct OnboardingView: View {
                     submitLogin()
                 } label: {
                     if appState.authService.isLoggingIn {
-                        ProgressView().tint(.white)
+                        ProgressView()
+                            .tint(.white)
+                            .controlSize(.small)
                     } else {
                         Text(String(localized: "onboarding_login_button"))
                             .font(.callout.weight(.semibold))

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -217,11 +217,10 @@ struct OnboardingView: View {
                     Button {
                         submitLogin()
                     } label: {
-                        if appState.authService.isLoggingIn {
-                            ProgressView()
-                                .tint(.white)
-                                .controlSize(.small)
-                        } else {
+                        LoadingButtonLabel(
+                            isLoading: appState.authService.isLoggingIn,
+                            tint: .white
+                        ) {
                             Text(String(localized: "onboarding_login_button"))
                                 .font(.callout.weight(.semibold))
                         }
@@ -301,9 +300,10 @@ struct OnboardingView: View {
             Button {
                 Task { await requestNotifications() }
             } label: {
-                if notificationRequestInFlight {
-                    ProgressView()
-                } else {
+                LoadingButtonLabel(
+                    isLoading: notificationRequestInFlight,
+                    tint: .white
+                ) {
                     Label(String(localized: "action_allow"), systemImage: "bell.fill")
                         .font(.callout.weight(.semibold))
                 }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -56,11 +56,12 @@ struct OnboardingView: View {
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
 
-                    VStack(spacing: TigerDuckTheme.Spacing.sm) {
+                    VStack(spacing: TigerDuckTheme.Spacing.md) {
                         Link(String(localized: "onboarding_welcome_website_label"), destination: AppURLs.website)
                         Link(String(localized: "onboarding_welcome_github_label"), destination: AppURLs.github)
                     }
                     .font(.footnote.weight(.semibold))
+                    .padding(.top, TigerDuckTheme.Spacing.sm)
                 }
             },
             actions: {

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -163,91 +163,83 @@ struct OnboardingView: View {
             subtitle: String(localized: "onboarding_login_subtitle"),
             accentColor: .green,
             content: {
-                if isSignedIn {
-                    Label(
-                        String(localized: "action_done"),
-                        systemImage: "checkmark.circle.fill"
-                    )
-                    .font(.callout.weight(.semibold))
-                    .foregroundStyle(.green)
-                } else {
-                    VStack(spacing: TigerDuckTheme.Spacing.md) {
-                        VStack(spacing: 1) {
-                            HStack(spacing: TigerDuckTheme.Spacing.md) {
-                                Image(systemName: "person.fill")
-                                    .foregroundStyle(.secondary)
-                                    .frame(width: 20)
-                                TextField(String(localized: "login_student_id"), text: $studentId)
-                                    .keyboardType(.asciiCapable)
-                                    .focused($focusedField, equals: .studentId)
-                                    .textContentType(.username)
-                                    .autocorrectionDisabled()
-                                    .textInputAutocapitalization(.characters)
-                                    .submitLabel(.next)
-                                    .onSubmit { focusedField = .password }
-                            }
-                            .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-                            .padding(.vertical, TigerDuckTheme.Spacing.md)
-                            .background(.fill.quaternary, in: .rect(topLeadingRadius: TigerDuckTheme.CornerRadius.md, topTrailingRadius: TigerDuckTheme.CornerRadius.md))
-
-                            Divider()
-                                .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-
-                            HStack(spacing: TigerDuckTheme.Spacing.md) {
-                                Image(systemName: "lock.fill")
-                                    .foregroundStyle(.secondary)
-                                    .frame(width: 20)
-                                PasswordField(
-                                    placeholder: String(localized: "login_password"),
-                                    text: $password,
-                                    focusBinding: $focusedField,
-                                    focusValue: .password,
-                                    onSubmit: { submitLogin() }
-                                )
-                            }
-                            .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-                            .padding(.vertical, TigerDuckTheme.Spacing.md)
-                            .background(.fill.quaternary, in: .rect(bottomLeadingRadius: TigerDuckTheme.CornerRadius.md, bottomTrailingRadius: TigerDuckTheme.CornerRadius.md))
+                VStack(spacing: TigerDuckTheme.Spacing.md) {
+                    VStack(spacing: 1) {
+                        HStack(spacing: TigerDuckTheme.Spacing.md) {
+                            Image(systemName: "person.fill")
+                                .foregroundStyle(.secondary)
+                                .frame(width: 20)
+                            TextField(String(localized: "login_student_id"), text: $studentId)
+                                .keyboardType(.asciiCapable)
+                                .focused($focusedField, equals: .studentId)
+                                .textContentType(.username)
+                                .autocorrectionDisabled()
+                                .textInputAutocapitalization(.characters)
+                                .submitLabel(.next)
+                                .onSubmit { focusedField = .password }
                         }
-                        .frame(maxWidth: 320)
+                        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+                        .padding(.vertical, TigerDuckTheme.Spacing.md)
+                        .background(.fill.quaternary, in: .rect(topLeadingRadius: TigerDuckTheme.CornerRadius.md, topTrailingRadius: TigerDuckTheme.CornerRadius.md))
 
-                        if let error = appState.authService.loginError {
-                            Text(error)
-                                .font(.caption)
-                                .foregroundStyle(.red)
+                        Divider()
+                            .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+
+                        HStack(spacing: TigerDuckTheme.Spacing.md) {
+                            Image(systemName: "lock.fill")
+                                .foregroundStyle(.secondary)
+                                .frame(width: 20)
+                            PasswordField(
+                                placeholder: String(localized: "login_password"),
+                                text: $password,
+                                focusBinding: $focusedField,
+                                focusValue: .password,
+                                onSubmit: { submitLogin() }
+                            )
                         }
+                        .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+                        .padding(.vertical, TigerDuckTheme.Spacing.md)
+                        .background(.fill.quaternary, in: .rect(bottomLeadingRadius: TigerDuckTheme.CornerRadius.md, bottomTrailingRadius: TigerDuckTheme.CornerRadius.md))
+                    }
+                    .frame(maxWidth: 320)
+
+                    if let error = appState.authService.loginError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+
+                    if isSignedIn {
+                        Label(
+                            String(localized: "action_done"),
+                            systemImage: "checkmark.circle.fill"
+                        )
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(.green)
                     }
                 }
             },
             actions: {
-                if isSignedIn {
-                    Button(String(localized: "action_next")) {
+                VStack(spacing: TigerDuckTheme.Spacing.md) {
+                    Button(String(localized: "onboarding_skip_for_now")) {
                         withAnimation { currentPage = Page.notifications.rawValue }
+                    }
+                    .foregroundStyle(Color.textSecondary)
+
+                    Button {
+                        submitLogin()
+                    } label: {
+                        LoadingButtonLabel(
+                            isLoading: appState.authService.isLoggingIn,
+                            tint: .white
+                        ) {
+                            Text(String(localized: "onboarding_login_button"))
+                                .font(.callout.weight(.semibold))
+                        }
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
-                } else {
-                    VStack(spacing: TigerDuckTheme.Spacing.md) {
-                        Button(String(localized: "onboarding_skip_for_now")) {
-                            withAnimation { currentPage = Page.notifications.rawValue }
-                        }
-                        .foregroundStyle(Color.textSecondary)
-
-                        Button {
-                            submitLogin()
-                        } label: {
-                            LoadingButtonLabel(
-                                isLoading: appState.authService.isLoggingIn,
-                                tint: .white
-                            ) {
-                                Text(String(localized: "onboarding_login_button"))
-                                    .font(.callout.weight(.semibold))
-                            }
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.large)
-                        .disabled(studentId.isEmpty || password.isEmpty || appState.authService.isLoggingIn)
-                    }
+                    .disabled(studentId.isEmpty || password.isEmpty || appState.authService.isLoggingIn)
                 }
             }
         )

--- a/swift/TigerDuck/Features/Settings/Components/LoginSheet.swift
+++ b/swift/TigerDuck/Features/Settings/Components/LoginSheet.swift
@@ -109,6 +109,7 @@ struct LoginSheet: View {
 
     private func submitIfReady() {
         guard !username.isEmpty, !password.isEmpty, !isLoggingIn else { return }
+        UIApplication.dismissKeyboard()
         focusedField = nil
         onLogin(username, password)
     }

--- a/swift/TigerDuck/Features/Settings/Components/LoginSheet.swift
+++ b/swift/TigerDuck/Features/Settings/Components/LoginSheet.swift
@@ -77,16 +77,13 @@ struct LoginSheet: View {
                     Button {
                         submitIfReady()
                     } label: {
-                        HStack {
-                            Spacer()
-                            if isLoggingIn {
-                                ProgressView()
-                                    .controlSize(.small)
-                                    .padding(.trailing, 6)
+                        LoadingButtonLabel(isLoading: isLoggingIn) {
+                            HStack {
+                                Spacer()
+                                Text(String(localized: "action_login"))
+                                    .fontWeight(.semibold)
+                                Spacer()
                             }
-                            Text(String(localized: "action_login"))
-                                .fontWeight(.semibold)
-                            Spacer()
                         }
                     }
                     .disabled(username.isEmpty || password.isEmpty || isLoggingIn)

--- a/swift/TigerDuck/Features/Settings/SettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/SettingsView.swift
@@ -213,6 +213,9 @@ struct SettingsView: View {
                 NavigationLink("Time override") {
                     DebugSettingsView()
                 }
+                NavigationLink("Notifications") {
+                    DebugNotificationsView()
+                }
             }
             #endif
         }

--- a/swift/TigerDuck/Features/Settings/SettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/SettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import CoreHaptics
+import UserNotifications
 
 struct SettingsView: View {
     @Environment(AppState.self) private var appState
@@ -20,10 +21,13 @@ struct SettingsView: View {
     @State private var libraryWarningTask: Task<Void, Never>?
     @State private var hapticEngine: CHHapticEngine?
     @State private var hapticPlayer: CHHapticPatternPlayer?
+    @State private var notificationsAuthorized: Bool = true
+    @Environment(\.scenePhase) private var scenePhase
 
-    private static let feedbackURL = URL(string: "https://github.com/tigerduck-app/tigerduck-app/issues")!
-    private static let privacyURL = URL(string: "https://app.ntust.org/tigerduck/privacy")!
-    private static let licenseURL = URL(string: "https://github.com/tigerduck-app/tigerduck-app/blob/main/LICENSE")!
+    private static let feedbackURL = AppURLs.issues
+    private static let privacyURL = AppURLs.privacyPolicy
+    private static let licenseURL = AppURLs.license
+    private static let deleteAccountURL = AppURLs.deleteAccount
 
     private var appVersion: String {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
@@ -124,6 +128,19 @@ struct SettingsView: View {
 
             // MARK: - Notifications & Live Activity
             Section(String(localized: "settings_section_notifications")) {
+                if !notificationsAuthorized {
+                    Button {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    } label: {
+                        Label(
+                            String(localized: "settings_notifications_disabled_warning"),
+                            systemImage: "exclamationmark.triangle.fill"
+                        )
+                        .foregroundStyle(.orange)
+                    }
+                }
                 NavigationLink(String(localized: "live_activity_settings_nav_title")) {
                     LiveActivitySettingsView(store: appState.liveActivityPreferences)
                 }
@@ -174,6 +191,11 @@ struct SettingsView: View {
                 } label: {
                     Text(String(localized: "settings_privacy_policy"))
                 }
+                Button {
+                    UIApplication.shared.open(Self.deleteAccountURL)
+                } label: {
+                    Text(String(localized: "settings_delete_account"))
+                }
                 Button(String(localized: "settings_open_source_licenses")) {
                     if appState.browserPreference == .inApp {
                         showLicense = true
@@ -195,6 +217,15 @@ struct SettingsView: View {
             #endif
         }
         .navigationTitle(String(localized: "feature_settings"))
+        .task { await refreshNotificationsAuthorization() }
+        .onChange(of: scenePhase) { _, newPhase in
+            // Reflect a System Settings round-trip the moment the user
+            // comes back so the warning row updates without the user
+            // having to leave and re-enter Settings.
+            if newPhase == .active {
+                Task { await refreshNotificationsAuthorization() }
+            }
+        }
         .sheet(isPresented: $showingTabEditor) {
             TabEditorView()
         }
@@ -399,6 +430,18 @@ struct SettingsView: View {
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
         }
+    }
+
+    /// Read the current system-level notification authorization so the
+    /// warning row appears whenever the user has revoked permission
+    /// (.denied) or has yet to grant it (.notDetermined). Re-runs on
+    /// every `scenePhase == .active` so a System Settings round-trip
+    /// updates the row without the user leaving Settings.
+    private func refreshNotificationsAuthorization() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        let status = settings.authorizationStatus
+        let authorized = (status == .authorized || status == .provisional || status == .ephemeral)
+        await MainActor.run { notificationsAuthorized = authorized }
     }
 }
 

--- a/swift/TigerDuck/Platform/Mac/MacAssignmentsList.swift
+++ b/swift/TigerDuck/Platform/Mac/MacAssignmentsList.swift
@@ -11,7 +11,17 @@ import AppKit
 /// segmented filter (Incomplete / All / Ignored) on top mirrors the
 /// iPhone picker so muscle memory carries across.
 struct MacAssignmentsList: View {
+    /// In-memory course roster so the secondary line on each row reflects
+    /// the user's rename and the canonical NTUST course code (same contract
+    /// as the iPhone `UpcomingAssignmentsView`). Without this, the row falls
+    /// back to the cached `assignment.courseName`.
+    var courses: [SDCourse] = []
+
     @Environment(AppState.self) private var appState
+
+    private var courseByNo: [String: SDCourse] {
+        Dictionary(courses.map { ($0.courseNo, $0) }, uniquingKeysWith: { first, _ in first })
+    }
 
     var body: some View {
         // TimelineView so "due in 2h" labels and the past/present
@@ -66,7 +76,7 @@ struct MacAssignmentsList: View {
                         .foregroundStyle(.primary)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
-                    Text(assignment.courseName)
+                    Text(assignment.courseLineLabel(matching: courseByNo[assignment.courseNo]))
                         .font(.callout)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)

--- a/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
@@ -84,10 +84,21 @@ struct MacClassTableView: View {
 
     private var courses: [SDCourse] {
         _ = cacheRevision
+        // Route through the canonical merge so the deletedCourseNos
+        // tombstone filter and customNames overlay apply here too. The Mac
+        // picker can target a past semester, so we can't call
+        // `CanonicalCourseProvider.currentCourses()` (which is pinned to
+        // the live `CourseSelectionService` semester) — feed the static
+        // `merge` directly with per-semester inputs instead.
         let cached = DataCache.shared.loadCourses(semester: selectedSemester)
         let userAdded = DataCache.shared.loadUserAddedCourses()
             .filter { $0.semester == selectedSemester || $0.semester.isEmpty }
-        return cached + userAdded
+        return CanonicalCourseProvider.merge(
+            primary: cached,
+            userAdded: userAdded,
+            deletedCourseNos: Set(DataCache.shared.loadDeletedCourseNos()),
+            customNames: DataCache.shared.loadCourseCustomNames()
+        )
     }
 
     private var visiblePeriods: [String] {

--- a/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
@@ -358,18 +358,16 @@ struct MacClassTableView: View {
             courseCell(course)
                 .frame(height: blockHeight(spanCount))
                 .onTapGesture { selectedCourse = course }
-        case let .conflictStart(a, _, _, b, _, _, combinedSpan):
-            // macOS renders 衝堂 as a horizontal split for the full cluster
-            // height. Cleaner than the iPhone L-shape interlock (which needs
-            // offset-aware geometry) but still surfaces both courses and
-            // makes each independently clickable.
+        case let .conflictStart(a, spanA, offsetA, b, spanB, offsetB, combinedSpan):
+            // 衝堂 renders as a horizontal split where each half is a column
+            // sized to that course's actual span and positioned at its
+            // offset within the cluster. Without offset-aware columns,
+            // mismatched spans (e.g. A on periods 1–3 overlapping B only on
+            // period 2) would show B as a full-height column and make it
+            // clickable in rows where the two courses don't actually meet.
             HStack(spacing: rowSpacing) {
-                courseCell(a)
-                    .onTapGesture { selectedCourse = a }
-                    .accessibilityLabel(Text(a.displayName))
-                courseCell(b)
-                    .onTapGesture { selectedCourse = b }
-                    .accessibilityLabel(Text(b.displayName))
+                conflictColumn(course: a, span: spanA, offset: offsetA, combinedSpan: combinedSpan)
+                conflictColumn(course: b, span: spanB, offset: offsetB, combinedSpan: combinedSpan)
             }
             .frame(height: blockHeight(combinedSpan))
         case let .conflictMany(courses, combinedSpan):
@@ -388,6 +386,26 @@ struct MacClassTableView: View {
 
     private func blockHeight(_ span: Int) -> CGFloat {
         CGFloat(span) * cellHeight + CGFloat(max(span - 1, 0)) * rowSpacing
+    }
+
+    /// One column of a 衝堂 cluster. Empty spacers above/below the course
+    /// block reserve the rows the course isn't scheduled in so an overlap
+    /// only meeting in part of the cluster doesn't extend to the rest.
+    @ViewBuilder
+    private func conflictColumn(course: SDCourse, span: Int, offset: Int, combinedSpan: Int) -> some View {
+        let bottom = max(combinedSpan - offset - span, 0)
+        VStack(spacing: rowSpacing) {
+            if offset > 0 {
+                Color.clear.frame(height: blockHeight(offset))
+            }
+            courseCell(course)
+                .frame(height: blockHeight(span))
+                .onTapGesture { selectedCourse = course }
+                .accessibilityLabel(Text(course.displayName))
+            if bottom > 0 {
+                Color.clear.frame(height: blockHeight(bottom))
+            }
+        }
     }
 
     private var emptyCell: some View {

--- a/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
@@ -493,7 +493,16 @@ struct MacClassTableView: View {
     /// Home page's widget cards also re-render.
     private func addUserCourse(_ course: SDCourse) {
         let existing = DataCache.shared.loadUserAddedCourses()
-        guard !existing.contains(where: { $0.courseNo == course.courseNo }),
+        // Dedupe within the selected semester only — the same `courseNo`
+        // legitimately recurs across terms (a recurring elective added
+        // manually in both 1131 and 1132), and `removeUserAddedCourse`
+        // already scopes its undo to `selectedSemester`. `courses`
+        // already reflects the current semester's roster so its
+        // duplicate check stays semester-scoped implicitly.
+        let isInSelectedSemester: (SDCourse) -> Bool = {
+            $0.semester == selectedSemester || $0.semester.isEmpty
+        }
+        guard !existing.contains(where: { $0.courseNo == course.courseNo && isInSelectedSemester($0) }),
               !courses.contains(where: { $0.courseNo == course.courseNo })
         else { return }
 

--- a/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
@@ -24,9 +24,30 @@ struct MacClassTableView: View {
     @State private var cacheRevision: Int = 0
     @State private var hasWarmedCaches = false
     @State private var isLoadingSemester = false
+    @State private var tripleConflictError: TripleConflictError?
 
-    /// Mon–Fri only — Sat/Sun are hidden on iPhone too unless data forces them.
-    private let weekdays: [Int] = [1, 2, 3, 4, 5]
+    /// Identifies a slot the add path tried to push into when it would
+    /// have become a 3-course slot. `existing` is the two courses already
+    /// scheduled there so the alert can name them.
+    private struct TripleConflictError: Identifiable {
+        let id = UUID()
+        let weekday: Int
+        let periodId: String
+        let newCourseName: String
+        let existingA: SDCourse
+        let existingB: SDCourse
+    }
+
+    /// Mon–Fri by default; weekend columns appear only when a loaded
+    /// schedule actually places a course on Sat/Sun, matching the
+    /// iPhone `activeWeekdays` behavior.
+    private var weekdays: [Int] {
+        let occupied = Set(courses.flatMap { $0.schedule.keys })
+        var days = Array(1...5)
+        if occupied.contains(6) { days.append(6) }
+        if occupied.contains(7) { days.append(7) }
+        return days
+    }
 
     private let cellHeight: CGFloat = 56
     private let rowSpacing: CGFloat = 4
@@ -113,6 +134,27 @@ struct MacClassTableView: View {
                 onAdd: { addUserCourse($0) },
                 onRemove: { removeUserAddedCourse(courseNo: $0) }
             )
+        }
+        .alert(
+            String(localized: "class_table_conflict_add_failed_title"),
+            isPresented: Binding(
+                get: { tripleConflictError != nil },
+                set: { if !$0 { tripleConflictError = nil } }
+            ),
+            presenting: tripleConflictError
+        ) { _ in
+            Button(String(localized: "action_confirm"), role: .cancel) {
+                tripleConflictError = nil
+            }
+        } message: { err in
+            Text(String(
+                format: String(localized: "class_table_conflict_add_failed_message"),
+                err.newCourseName,
+                "\(err.weekday)",
+                err.periodId,
+                err.existingA.displayName,
+                err.existingB.displayName
+            ))
         }
         .task {
             await warmCachesIfNeeded()
@@ -239,12 +281,21 @@ struct MacClassTableView: View {
     private var headerRow: some View {
         HStack(spacing: rowSpacing) {
             Color.clear.frame(width: periodLabelWidth, height: 22)
-            ForEach(weekdays.indices, id: \.self) { idx in
-                Text(AppConstants.Periods.weekdays[safe: idx] ?? "?")
+            ForEach(weekdays, id: \.self) { weekday in
+                Text(weekdayLabel(weekday))
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity)
             }
+        }
+    }
+
+    private func weekdayLabel(_ weekday: Int) -> String {
+        switch weekday {
+        case 1...5: return AppConstants.Periods.weekdays[safe: weekday - 1] ?? "?"
+        case 6: return AppConstants.Periods.weekendDays[safe: 0] ?? "?"
+        case 7: return AppConstants.Periods.weekendDays[safe: 1] ?? "?"
+        default: return "?"
         }
     }
 
@@ -321,6 +372,15 @@ struct MacClassTableView: View {
                     .accessibilityLabel(Text(b.displayName))
             }
             .frame(height: blockHeight(combinedSpan))
+        case let .conflictMany(courses, combinedSpan):
+            HStack(spacing: rowSpacing) {
+                ForEach(courses, id: \.courseNo) { course in
+                    courseCell(course)
+                        .onTapGesture { selectedCourse = course }
+                        .accessibilityLabel(Text(course.displayName))
+                }
+            }
+            .frame(height: blockHeight(combinedSpan))
         case .skip:
             EmptyView()
         }
@@ -389,14 +449,23 @@ struct MacClassTableView: View {
     /// Mirrors the parts of `ClassTableViewModel.addCourse(_:)` that are load-
     /// bearing on macOS: tombstone clear, NameAbbr cache seeding so toggles
     /// round-trip without a refetch, and a `dataDidUpdate` broadcast so the
-    /// Home page's widget cards also re-render. Triple-conflict guarding is
-    /// left to a future macOS pass (iPhone's `wouldCauseTripleConflict` lives
-    /// inside `ClassTableViewModel` and isn't reusable yet).
+    /// Home page's widget cards also re-render.
     private func addUserCourse(_ course: SDCourse) {
         let existing = DataCache.shared.loadUserAddedCourses()
         guard !existing.contains(where: { $0.courseNo == course.courseNo }),
               !courses.contains(where: { $0.courseNo == course.courseNo })
         else { return }
+
+        // Refuse if any slot the candidate would occupy already has 2
+        // courses. The shared `ClassTableLayout` can render N-way conflicts,
+        // but persisting 3+ in a slot is still a bug surface (Android caps
+        // at 2 and the iPhone path rejects too). Must run BEFORE tombstone
+        // clear, otherwise a rejected add leaves a tombstone cleared and the
+        // next reload would resurrect the course.
+        if let err = firstTripleConflict(for: course) {
+            tripleConflictError = err
+            return
+        }
 
         var deleted = Set(DataCache.shared.loadDeletedCourseNos())
         if deleted.remove(course.courseNo) != nil {
@@ -415,6 +484,29 @@ struct MacClassTableView: View {
         DataCache.shared.saveUserAddedCourses(existing + [course])
         cacheRevision &+= 1
         NotificationCenter.default.post(name: AppConstants.dataDidUpdate, object: nil)
+    }
+
+    /// Scans every slot `candidate` would occupy and returns the first one
+    /// that already has two courses — adding the candidate there would push
+    /// it to three. Returns nil when the add is safe.
+    private func firstTripleConflict(for candidate: SDCourse) -> TripleConflictError? {
+        for (weekday, periodIds) in candidate.schedule {
+            for pid in periodIds {
+                let occupants = courses.filter {
+                    ($0.schedule[weekday] ?? []).contains(pid)
+                }
+                if occupants.count >= 2 {
+                    return TripleConflictError(
+                        weekday: weekday,
+                        periodId: pid,
+                        newCourseName: candidate.displayName,
+                        existingA: occupants[0],
+                        existingB: occupants[1]
+                    )
+                }
+            }
+        }
+        return nil
     }
 
     /// Undo a not-yet-committed user-added course without tombstoning the

--- a/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
@@ -553,10 +553,16 @@ struct MacClassTableView: View {
     /// Undo a not-yet-committed user-added course without tombstoning the
     /// `courseNo`. Tap-to-toggle in `AddCourseSheet` routes here when the user
     /// adds and immediately removes a course in the same session.
+    /// Scoped to the currently-selected semester so undoing `X` here doesn't
+    /// also delete a manually-added `X` the user saved for a different
+    /// semester (the sheet's onRemove callback only carries the courseNo).
     private func removeUserAddedCourse(courseNo: String) {
         let existing = DataCache.shared.loadUserAddedCourses()
-        guard existing.contains(where: { $0.courseNo == courseNo }) else { return }
-        DataCache.shared.saveUserAddedCourses(existing.filter { $0.courseNo != courseNo })
+        let updated = existing.filter { course in
+            !(course.courseNo == courseNo && (course.semester == selectedSemester || course.semester.isEmpty))
+        }
+        guard updated.count != existing.count else { return }
+        DataCache.shared.saveUserAddedCourses(updated)
         cacheRevision &+= 1
         NotificationCenter.default.post(name: AppConstants.dataDidUpdate, object: nil)
     }

--- a/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
@@ -16,8 +16,18 @@ struct MacClassTableView: View {
     @Environment(AppState.self) private var appState
 
     @State private var selectedSemester: String = Defaults[.classTableSelectedSemester]
-    @State private var selectedCourse: SDCourse?
+    @State private var selectedSlot: SelectedSlot?
     @State private var showAddCourse: Bool = false
+
+    /// Carries the weekday alongside the tapped course so the detail sheet
+    /// can render the concrete slot's classroom + time range. Without the
+    /// weekday context, `CourseDetailSheet` falls back to the aggregate
+    /// classroom and shows `—` for the time card.
+    private struct SelectedSlot: Identifiable {
+        let course: SDCourse
+        let weekday: Int
+        var id: String { "\(course.courseNo)-\(weekday)" }
+    }
     /// Bumps whenever an async fetch lands new cache; the body's
     /// `courses` computed read includes this to trigger re-render
     /// (Observation can't see plain `DataCache` mutations).
@@ -121,10 +131,12 @@ struct MacClassTableView: View {
                 .help(String(localized: "class_table_add_course"))
             }
         }
-        .sheet(item: $selectedCourse) { course in
+        .sheet(item: $selectedSlot) { slot in
             CourseDetailSheet(
-                course: course,
-                assignments: DataCache.shared.loadAssignments().unfinished(for: course.courseNo)
+                course: slot.course,
+                assignments: DataCache.shared.loadAssignments().unfinished(for: slot.course.courseNo),
+                timeRange: slot.course.timeRange(for: slot.weekday),
+                weekday: slot.weekday
             )
         }
         .sheet(isPresented: $showAddCourse) {
@@ -344,20 +356,20 @@ struct MacClassTableView: View {
                     keyOf: { $0.courseNo },
                     scheduleOf: { $0.schedule }
                 )
-                cellView(role: role)
+                cellView(role: role, weekday: weekday)
             }
         }
     }
 
     @ViewBuilder
-    private func cellView(role: ClassTableCellRole<SDCourse>) -> some View {
+    private func cellView(role: ClassTableCellRole<SDCourse>, weekday: Int) -> some View {
         switch role {
         case .empty:
             emptyCell.frame(height: cellHeight)
         case let .solo(course, spanCount):
             courseCell(course)
                 .frame(height: blockHeight(spanCount))
-                .onTapGesture { selectedCourse = course }
+                .onTapGesture { selectedSlot = SelectedSlot(course: course, weekday: weekday) }
         case let .conflictStart(a, spanA, offsetA, b, spanB, offsetB, combinedSpan):
             // 衝堂 renders as a horizontal split where each half is a column
             // sized to that course's actual span and positioned at its
@@ -366,15 +378,15 @@ struct MacClassTableView: View {
             // period 2) would show B as a full-height column and make it
             // clickable in rows where the two courses don't actually meet.
             HStack(spacing: rowSpacing) {
-                conflictColumn(course: a, span: spanA, offset: offsetA, combinedSpan: combinedSpan)
-                conflictColumn(course: b, span: spanB, offset: offsetB, combinedSpan: combinedSpan)
+                conflictColumn(course: a, span: spanA, offset: offsetA, combinedSpan: combinedSpan, weekday: weekday)
+                conflictColumn(course: b, span: spanB, offset: offsetB, combinedSpan: combinedSpan, weekday: weekday)
             }
             .frame(height: blockHeight(combinedSpan))
         case let .conflictMany(courses, combinedSpan):
             HStack(spacing: rowSpacing) {
                 ForEach(courses, id: \.courseNo) { course in
                     courseCell(course)
-                        .onTapGesture { selectedCourse = course }
+                        .onTapGesture { selectedSlot = SelectedSlot(course: course, weekday: weekday) }
                         .accessibilityLabel(Text(course.displayName))
                 }
             }
@@ -392,7 +404,7 @@ struct MacClassTableView: View {
     /// block reserve the rows the course isn't scheduled in so an overlap
     /// only meeting in part of the cluster doesn't extend to the rest.
     @ViewBuilder
-    private func conflictColumn(course: SDCourse, span: Int, offset: Int, combinedSpan: Int) -> some View {
+    private func conflictColumn(course: SDCourse, span: Int, offset: Int, combinedSpan: Int, weekday: Int) -> some View {
         let bottom = max(combinedSpan - offset - span, 0)
         VStack(spacing: rowSpacing) {
             if offset > 0 {
@@ -400,7 +412,7 @@ struct MacClassTableView: View {
             }
             courseCell(course)
                 .frame(height: blockHeight(span))
-                .onTapGesture { selectedCourse = course }
+                .onTapGesture { selectedSlot = SelectedSlot(course: course, weekday: weekday) }
                 .accessibilityLabel(Text(course.displayName))
             if bottom > 0 {
                 Color.clear.frame(height: blockHeight(bottom))

--- a/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
@@ -17,6 +17,7 @@ struct MacClassTableView: View {
 
     @State private var selectedSemester: String = Defaults[.classTableSelectedSemester]
     @State private var selectedCourse: SDCourse?
+    @State private var showAddCourse: Bool = false
     /// Bumps whenever an async fetch lands new cache; the body's
     /// `courses` computed read includes this to trigger re-render
     /// (Observation can't see plain `DataCache` mutations).
@@ -90,9 +91,28 @@ struct MacClassTableView: View {
                 }
                 .pickerStyle(.menu)
             }
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    showAddCourse = true
+                } label: {
+                    Label(String(localized: "class_table_add_course"), systemImage: "plus")
+                }
+                .help(String(localized: "class_table_add_course"))
+            }
         }
         .sheet(item: $selectedCourse) { course in
-            courseDetailSheet(course)
+            CourseDetailSheet(
+                course: course,
+                assignments: DataCache.shared.loadAssignments().unfinished(for: course.courseNo)
+            )
+        }
+        .sheet(isPresented: $showAddCourse) {
+            AddCourseSheet(
+                semester: selectedSemester,
+                existingCourseNos: Set(courses.map(\.courseNo)),
+                onAdd: { addUserCourse($0) },
+                onRemove: { removeUserAddedCourse(courseNo: $0) }
+            )
         }
         .task {
             await warmCachesIfNeeded()
@@ -256,199 +276,100 @@ struct MacClassTableView: View {
         .padding(.trailing, 4)
     }
 
-    /// One vertical stack of cells for `weekday`. Walks `visiblePeriods`
-    /// merging contiguous runs of the same course into a single tall
-    /// block (matching iPhone's `TimetableGridView` semantics). When two
-    /// courses overlap on the same period, the first course's name is
-    /// shown with a "+N" badge — Mac doesn't render the L-shape
-    /// interlock the iOS grid uses, but the conflict is still surfaced.
+    /// One vertical stack of cells for `weekday`. Walks `visiblePeriods` one
+    /// row at a time; `ClassTableLayout.cellRole` tells us when a row is the
+    /// start of a multi-row block (solo or 衝堂 cluster) so contiguous runs
+    /// render as a single tall block — same partitioning the iPhone uses.
     @ViewBuilder
     private func weekdayColumn(_ weekday: Int) -> some View {
-        let segments = segments(for: weekday)
+        let periods = visiblePeriods
         VStack(spacing: rowSpacing) {
-            ForEach(segments.indices, id: \.self) { index in
-                let seg = segments[index]
-                let height = CGFloat(seg.span) * cellHeight + CGFloat(seg.span - 1) * rowSpacing
-                segmentView(seg)
-                    .frame(height: height)
+            ForEach(periods.indices, id: \.self) { index in
+                let role = ClassTableLayout.cellRole(
+                    courses: courses,
+                    periodIds: periods,
+                    weekday: weekday,
+                    periodIndex: index,
+                    keyOf: { $0.courseNo },
+                    scheduleOf: { $0.schedule }
+                )
+                cellView(role: role)
             }
         }
     }
 
     @ViewBuilder
-    private func segmentView(_ segment: CellSegment) -> some View {
-        if let course = segment.course {
-            courseCell(course, conflicts: segment.conflicts)
+    private func cellView(role: ClassTableCellRole<SDCourse>) -> some View {
+        switch role {
+        case .empty:
+            emptyCell.frame(height: cellHeight)
+        case let .solo(course, spanCount):
+            courseCell(course)
+                .frame(height: blockHeight(spanCount))
                 .onTapGesture { selectedCourse = course }
-        } else {
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.primary.opacity(0.04))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(Color.primary.opacity(0.04), lineWidth: 0.5)
-                )
+        case let .conflictStart(a, _, _, b, _, _, combinedSpan):
+            // macOS renders 衝堂 as a horizontal split for the full cluster
+            // height. Cleaner than the iPhone L-shape interlock (which needs
+            // offset-aware geometry) but still surfaces both courses and
+            // makes each independently clickable.
+            HStack(spacing: rowSpacing) {
+                courseCell(a)
+                    .onTapGesture { selectedCourse = a }
+                    .accessibilityLabel(Text(a.displayName))
+                courseCell(b)
+                    .onTapGesture { selectedCourse = b }
+                    .accessibilityLabel(Text(b.displayName))
+            }
+            .frame(height: blockHeight(combinedSpan))
+        case .skip:
+            EmptyView()
         }
     }
 
-    private func courseCell(_ course: SDCourse, conflicts: Int) -> some View {
-        let color = TigerDuckTheme.courseColor(for: course.courseNo)
-        return ZStack(alignment: .topTrailing) {
-            VStack(alignment: .leading, spacing: 3) {
-                Text(course.displayName)
-                    .font(.callout.weight(.semibold))
-                    .foregroundStyle(.primary)
-                    .lineLimit(3)
-                    .multilineTextAlignment(.leading)
-                if !course.instructor.isEmpty {
-                    Text(course.instructor)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-                Spacer(minLength: 0)
-            }
-            .padding(8)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .background(
-                ZStack {
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(.ultraThinMaterial)
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(color.opacity(0.4))
-                }
-            )
+    private func blockHeight(_ span: Int) -> CGFloat {
+        CGFloat(span) * cellHeight + CGFloat(max(span - 1, 0)) * rowSpacing
+    }
+
+    private var emptyCell: some View {
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(Color.primary.opacity(0.04))
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(color.opacity(0.6), lineWidth: 0.5)
+                    .stroke(Color.primary.opacity(0.04), lineWidth: 0.5)
             )
-
-            if conflicts > 0 {
-                Text("+\(conflicts)")
-                    .font(.caption2.bold())
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 2)
-                    .background(
-                        Capsule().fill(Color.black.opacity(0.55))
-                    )
-                    .padding(4)
-            }
-        }
-        .contentShape(Rectangle())
     }
 
-    // MARK: - Cell segmentation
-
-    /// A contiguous block in one weekday column. `course` is nil for an
-    /// empty gap; `conflicts` is the number of additional courses that
-    /// share the first period of this block (0 for a clean run).
-    private struct CellSegment {
-        let course: SDCourse?
-        let span: Int
-        let conflicts: Int
-    }
-
-    /// Merge contiguous same-course runs into single segments. For
-    /// conflicts (multiple courses on one period), the first course
-    /// wins the cell with a `+N` badge and the run length collapses to
-    /// 1 — we don't try to merge "course A spans periods 1-3 AND
-    /// course B spans periods 2-4" because the L-shape rendering for
-    /// that case is non-trivial and rare on the Mac surface.
-    private func segments(for weekday: Int) -> [CellSegment] {
-        let periods = visiblePeriods
-        var result: [CellSegment] = []
-        var i = 0
-        while i < periods.count {
-            let period = periods[i]
-            let matches = courses.filter { ($0.schedule[weekday] ?? []).contains(period) }
-            if matches.isEmpty {
-                result.append(CellSegment(course: nil, span: 1, conflicts: 0))
-                i += 1
-                continue
-            }
-            if matches.count >= 2 {
-                result.append(CellSegment(
-                    course: matches[0],
-                    span: 1,
-                    conflicts: matches.count - 1
-                ))
-                i += 1
-                continue
-            }
-            // Solo course — find consecutive run length.
-            let course = matches[0]
-            var span = 1
-            while i + span < periods.count {
-                let nextPeriod = periods[i + span]
-                let nextMatches = courses.filter { ($0.schedule[weekday] ?? []).contains(nextPeriod) }
-                if nextMatches.count == 1, nextMatches[0].courseNo == course.courseNo {
-                    span += 1
-                } else {
-                    break
-                }
-            }
-            result.append(CellSegment(course: course, span: span, conflicts: 0))
-            i += span
-        }
-        return result
-    }
-
-    // MARK: - Course detail sheet
-
-    private func courseDetailSheet(_ course: SDCourse) -> some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack {
-                Circle()
-                    .fill(TigerDuckTheme.courseColor(for: course.courseNo))
-                    .frame(width: 14, height: 14)
-                Text(course.displayName)
-                    .font(.title2.bold())
-                Spacer()
-                Button {
-                    selectedCourse = nil
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.secondary)
-                        .font(.title3)
-                }
-                .buttonStyle(.borderless)
-                .keyboardShortcut(.cancelAction)
-            }
-
-            Divider()
-
-            detailRow(label: String(localized: "desktop_course_detail_course_no_label"), value: course.courseNo)
+    private func courseCell(_ course: SDCourse) -> some View {
+        let color = TigerDuckTheme.courseColor(for: course.courseNo)
+        return VStack(alignment: .leading, spacing: 3) {
+            Text(course.displayName)
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(3)
+                .multilineTextAlignment(.leading)
             if !course.instructor.isEmpty {
-                detailRow(label: String(localized: "course_detail_instructor_label"), value: course.instructor)
+                Text(course.instructor)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
             }
-            detailRow(label: String(localized: "course_detail_credits_label"), value: "\(course.credits)")
-            ForEach(course.schedule.keys.sorted(), id: \.self) { weekday in
-                let periods = (course.schedule[weekday] ?? []).sortedByPeriodOrder().joined(separator: ", ")
-                let room = course.classroom(for: weekday)
-                let weekdayLabel = AppConstants.Periods.weekdays[safe: weekday - 1] ?? "?"
-                detailRow(
-                    label: weekdayLabel,
-                    value: room.isEmpty ? periods : "\(periods)  ·  \(room)"
-                )
-            }
-
             Spacer(minLength: 0)
         }
-        .padding(24)
-        .frame(width: 440, height: 340)
-    }
-
-    private func detailRow(label: String, value: String) -> some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text(label)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .frame(width: 100, alignment: .leading)
-            Text(value)
-                .font(.callout)
-                .textSelection(.enabled)
-            Spacer()
-        }
+        .padding(8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(
+            ZStack {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(.ultraThinMaterial)
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(color.opacity(0.4))
+            }
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(color.opacity(0.6), lineWidth: 0.5)
+        )
+        .contentShape(Rectangle())
     }
 
     // MARK: - Helpers
@@ -460,6 +381,51 @@ struct MacClassTableView: View {
     private func displayLabel(for code: String) -> String {
         guard code.count >= 2 else { return code }
         return String(code.dropLast()) + "-" + String(code.last!)
+    }
+
+    // MARK: - User-added courses
+
+    /// Append a user-added course to the on-disk store and refresh the grid.
+    /// Mirrors the parts of `ClassTableViewModel.addCourse(_:)` that are load-
+    /// bearing on macOS: tombstone clear, NameAbbr cache seeding so toggles
+    /// round-trip without a refetch, and a `dataDidUpdate` broadcast so the
+    /// Home page's widget cards also re-render. Triple-conflict guarding is
+    /// left to a future macOS pass (iPhone's `wouldCauseTripleConflict` lives
+    /// inside `ClassTableViewModel` and isn't reusable yet).
+    private func addUserCourse(_ course: SDCourse) {
+        let existing = DataCache.shared.loadUserAddedCourses()
+        guard !existing.contains(where: { $0.courseNo == course.courseNo }),
+              !courses.contains(where: { $0.courseNo == course.courseNo })
+        else { return }
+
+        var deleted = Set(DataCache.shared.loadDeletedCourseNos())
+        if deleted.remove(course.courseNo) != nil {
+            DataCache.shared.saveDeletedCourseNos(Array(deleted))
+        }
+
+        NameAbbrService.shared.storeRawName(
+            courseNo: course.courseNo, name: course.courseName
+        )
+        NameAbbrService.shared.storeRawClassroom(
+            courseNo: course.courseNo,
+            classroom: course.classroom,
+            map: course.classroomMap
+        )
+
+        DataCache.shared.saveUserAddedCourses(existing + [course])
+        cacheRevision &+= 1
+        NotificationCenter.default.post(name: AppConstants.dataDidUpdate, object: nil)
+    }
+
+    /// Undo a not-yet-committed user-added course without tombstoning the
+    /// `courseNo`. Tap-to-toggle in `AddCourseSheet` routes here when the user
+    /// adds and immediately removes a course in the same session.
+    private func removeUserAddedCourse(courseNo: String) {
+        let existing = DataCache.shared.loadUserAddedCourses()
+        guard existing.contains(where: { $0.courseNo == courseNo }) else { return }
+        DataCache.shared.saveUserAddedCourses(existing.filter { $0.courseNo != courseNo })
+        cacheRevision &+= 1
+        NotificationCenter.default.post(name: AppConstants.dataDidUpdate, object: nil)
     }
 }
 #endif

--- a/swift/TigerDuck/Platform/Mac/MacHomeView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacHomeView.swift
@@ -42,7 +42,7 @@ struct MacHomeView: View {
 
             VStack(alignment: .leading, spacing: 12) {
                 sectionHeader(title: String(localized: "desktop_home_section_upcoming_assignments"), systemImage: "list.bullet.rectangle")
-                MacAssignmentsList()
+                MacAssignmentsList(courses: courses)
             }
         }
     }

--- a/swift/TigerDuck/Platform/Mac/MacHomeView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacHomeView.swift
@@ -77,11 +77,12 @@ struct MacHomeView: View {
     // MARK: - Data
 
     private func currentCourses() -> [SDCourse] {
-        let semester = CourseSelectionService.currentSemesterCode()
-        let semesterCourses = DataCache.shared.loadCourses(semester: semester)
-        let userAdded = DataCache.shared.loadUserAddedCourses()
-            .filter { $0.semester == semester || $0.semester.isEmpty }
-        return semesterCourses + userAdded
+        // Delegate to the canonical provider so the deletedCourseNos
+        // tombstone filter and customNames overlay are applied. Inlining
+        // the raw load+merge here previously meant a course the user
+        // had hidden from the class table would reappear in the Home
+        // widget cards and assignment course matcher after refresh.
+        CanonicalCourseProvider().currentCourses()
     }
 }
 #endif

--- a/swift/TigerDuck/Platform/Mac/MacLoginView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacLoginView.swift
@@ -79,11 +79,10 @@ struct MacLoginView: View {
             Button {
                 Task { await attemptLogin() }
             } label: {
-                if appState.authService.isLoggingIn {
-                    ProgressView()
-                        .controlSize(.small)
-                        .frame(maxWidth: 200)
-                } else {
+                LoadingButtonLabel(
+                    isLoading: appState.authService.isLoggingIn,
+                    tint: .white
+                ) {
                     Text(String(localized: "action_login"))
                         .frame(maxWidth: 200)
                 }

--- a/swift/TigerDuck/Platform/Mac/MacWidgetCards.swift
+++ b/swift/TigerDuck/Platform/Mac/MacWidgetCards.swift
@@ -120,26 +120,40 @@ private struct NextClassWidgetCard: View {
     var body: some View {
         widgetCard(title: String(localized: "widget_next_class"), systemImage: "arrow.right.circle") {
             if let target = nextOrCurrent {
-                let color = TigerDuckTheme.courseColor(for: target.slot.course.courseNo)
+                let primary = target.slots[0]
+                let color = TigerDuckTheme.courseColor(for: primary.course.courseNo)
                 VStack(alignment: .leading, spacing: 6) {
                     HStack {
                         Text(target.label.uppercased())
                             .font(.caption2.weight(.bold))
                             .foregroundStyle(.secondary)
                         Spacer()
-                        Text(target.slot.course.timeRange(for: target.slot.date.scheduleWeekday) ?? "")
+                        Text(primary.course.timeRange(for: primary.date.scheduleWeekday) ?? "")
                             .font(.caption.monospacedDigit().weight(.semibold))
                             .foregroundStyle(color)
                     }
-                    Text(target.slot.course.displayName)
-                        .font(.title3.bold())
-                        .lineLimit(2)
-                    let classroom = target.slot.course.classroom(for: target.slot.date.scheduleWeekday)
-                    if !classroom.isEmpty {
-                        Label(classroom, systemImage: "mappin.and.ellipse")
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
+                    if target.slots.count >= 2 {
+                        // 衝堂: list every overlapping course on its own line so
+                        // neither is hidden. Names line-limit individually to
+                        // keep the card height roughly stable.
+                        VStack(alignment: .leading, spacing: 2) {
+                            ForEach(target.slots, id: \.course.courseNo) { slot in
+                                Text(slot.course.displayName)
+                                    .font(.title3.bold())
+                                    .lineLimit(1)
+                            }
+                        }
+                    } else {
+                        Text(primary.course.displayName)
+                            .font(.title3.bold())
+                            .lineLimit(2)
+                        let classroom = primary.course.classroom(for: primary.date.scheduleWeekday)
+                        if !classroom.isEmpty {
+                            Label(classroom, systemImage: "mappin.and.ellipse")
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
                     }
                     Text(target.countdownLabel(from: now))
                         .font(.callout.monospacedDigit())
@@ -154,22 +168,30 @@ private struct NextClassWidgetCard: View {
         }
     }
 
+    /// Returns every slot that shares the earliest "current" or "next" start
+    /// time so 衝堂 (two simultaneous classes) shows both courses instead of
+    /// silently dropping one to the `.first` selector.
     private var nextOrCurrent: NextClassTarget? {
-        if let live = slots.first(where: { $0.start <= now && now < $0.end }) {
-            return NextClassTarget(slot: live, label: String(localized: "live_activity_status_in_class"))
+        let liveSlots = slots.filter { $0.start <= now && now < $0.end }
+        if !liveSlots.isEmpty {
+            return NextClassTarget(slots: liveSlots, label: String(localized: "live_activity_status_in_class"))
         }
-        if let next = slots.first(where: { $0.start > now }) {
-            return NextClassTarget(slot: next, label: String(localized: "desktop_widget_up_next"))
-        }
-        return nil
+        guard let earliestNext = slots.filter({ $0.start > now }).min(by: { $0.start < $1.start })
+        else { return nil }
+        let tied = slots.filter { $0.start == earliestNext.start }
+        return NextClassTarget(slots: tied, label: String(localized: "desktop_widget_up_next"))
     }
 }
 
 private struct NextClassTarget {
-    let slot: CourseTimeSlot
+    /// 1 entry for solo classes, 2+ for 衝堂 (every slot sharing the same
+    /// start). Countdown reads from `slots[0]` since all members share their
+    /// start (and effectively their end, given a one-period block).
+    let slots: [CourseTimeSlot]
     let label: String
 
     func countdownLabel(from now: Date) -> String {
+        let slot = slots[0]
         if slot.start <= now && now < slot.end {
             let remaining = max(0, Int(slot.end.timeIntervalSince(now)))
             return "Ends in \(format(remaining))"

--- a/swift/TigerDuck/Platform/Mac/MacWidgetCards.swift
+++ b/swift/TigerDuck/Platform/Mac/MacWidgetCards.swift
@@ -185,18 +185,21 @@ private struct NextClassWidgetCard: View {
 
 private struct NextClassTarget {
     /// 1 entry for solo classes, 2+ for 衝堂 (every slot sharing the same
-    /// start). Countdown reads from `slots[0]` since all members share their
-    /// start (and effectively their end, given a one-period block).
+    /// start). Countdown reads start from `slots[0]` (all members share it)
+    /// and end from the latest finishing slot so a conflict block built from
+    /// courses with different period spans still ticks down to the moment
+    /// the block is fully over.
     let slots: [CourseTimeSlot]
     let label: String
 
     func countdownLabel(from now: Date) -> String {
-        let slot = slots[0]
-        if slot.start <= now && now < slot.end {
-            let remaining = max(0, Int(slot.end.timeIntervalSince(now)))
+        let start = slots[0].start
+        let end = slots.map(\.end).max() ?? slots[0].end
+        if start <= now && now < end {
+            let remaining = max(0, Int(end.timeIntervalSince(now)))
             return "Ends in \(format(remaining))"
         }
-        let until = max(0, Int(slot.start.timeIntervalSince(now)))
+        let until = max(0, Int(start.timeIntervalSince(now)))
         return "Starts in \(format(until))"
     }
 

--- a/swift/TigerDuck/Platform/Mac/MacWidgetCards.swift
+++ b/swift/TigerDuck/Platform/Mac/MacWidgetCards.swift
@@ -168,13 +168,17 @@ private struct NextClassWidgetCard: View {
         }
     }
 
-    /// Returns every slot that shares the earliest "current" or "next" start
+    /// Returns every slot that shares the same "current" or "next" start
     /// time so 衝堂 (two simultaneous classes) shows both courses instead of
-    /// silently dropping one to the `.first` selector.
+    /// silently dropping one. The live branch picks the most-recently-started
+    /// live slot as the target so a long-running class that happens to still
+    /// be in progress doesn't get grouped with a different class the user
+    /// just transitioned into.
     private var nextOrCurrent: NextClassTarget? {
         let liveSlots = slots.filter { $0.start <= now && now < $0.end }
-        if !liveSlots.isEmpty {
-            return NextClassTarget(slots: liveSlots, label: String(localized: "live_activity_status_in_class"))
+        if let targetStart = liveSlots.map(\.start).max() {
+            let tiedLive = liveSlots.filter { $0.start == targetStart }
+            return NextClassTarget(slots: tiedLive, label: String(localized: "live_activity_status_in_class"))
         }
         guard let earliestNext = slots.filter({ $0.start > now }).min(by: { $0.start < $1.start })
         else { return nil }

--- a/swift/TigerDuck/Shared/AppURLs.swift
+++ b/swift/TigerDuck/Shared/AppURLs.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Canonical TigerDuck-related URLs surfaced in Onboarding and Settings.
+/// Mirrors the Android equivalents at `OnboardingScreen.kt:73-76` so both
+/// platforms point users at the same website / docs / repos.
+enum AppURLs {
+    static let website        = URL(string: "https://tigerduck.app")!
+    static let github         = URL(string: "https://github.com/tigerduck-app")!
+    static let privacyPolicy  = URL(string: "https://tigerduck.app/privacy-policy")!
+    static let deleteAccount  = URL(string: "https://tigerduck.app/delete-account")!
+    static let issues         = URL(string: "https://github.com/tigerduck-app/tigerduck-app/issues")!
+    static let license        = URL(string: "https://github.com/tigerduck-app/tigerduck-app/blob/main/LICENSE")!
+}

--- a/swift/TigerDuck/Shared/ClassTableLayout.swift
+++ b/swift/TigerDuck/Shared/ClassTableLayout.swift
@@ -16,6 +16,12 @@ public enum ClassTableCellRole<Course> {
         courseB: Course, spanB: Int, offsetB: Int,
         combinedSpan: Int
     )
+    /// 3+ overlapping courses occupying the same row run. Offsets aren't
+    /// tracked individually because callers reach this case through the
+    /// per-slot fallback, where every member shares the same span starting
+    /// at the current row. Renderers should split horizontally across
+    /// `courses` so no course disappears from the grid.
+    case conflictMany(courses: [Course], combinedSpan: Int)
     /// This cell is part of a SoloStart / ConflictStart cluster that began
     /// at an earlier row; the renderer must emit nothing here so the
     /// parent's `combinedSpan` can occupy the rows.
@@ -138,10 +144,13 @@ public enum ClassTableLayout {
         if coursesHere.count == 1 {
             return .solo(coursesHere[0], spanCount: span)
         }
-        return .conflictStart(
-            courseA: coursesHere[0], spanA: span, offsetA: 0,
-            courseB: coursesHere[1], spanB: span, offsetB: 0,
-            combinedSpan: span
-        )
+        if coursesHere.count == 2 {
+            return .conflictStart(
+                courseA: coursesHere[0], spanA: span, offsetA: 0,
+                courseB: coursesHere[1], spanB: span, offsetB: 0,
+                combinedSpan: span
+            )
+        }
+        return .conflictMany(courses: coursesHere, combinedSpan: span)
     }
 }

--- a/swift/TigerDuck/Shared/ClassTableLayout.swift
+++ b/swift/TigerDuck/Shared/ClassTableLayout.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+/// Per-cell role produced by the class-table conflict-detection algorithm.
+/// Generic so the same value can carry an `SDCourse` (main app), a
+/// `SnapshotCourse` (WidgetKit), or any future surface's course model.
+public enum ClassTableCellRole<Course> {
+    case empty
+    case solo(Course, spanCount: Int)
+    /// Two overlapping courses occupying (possibly partially) this cluster.
+    /// `combinedSpan` is the total row count of the union;
+    /// `offsetA` / `offsetB` are 0-indexed row positions within the cluster
+    /// where each course's block begins; `spanA` / `spanB` are each course's
+    /// own contiguous block length.
+    case conflictStart(
+        courseA: Course, spanA: Int, offsetA: Int,
+        courseB: Course, spanB: Int, offsetB: Int,
+        combinedSpan: Int
+    )
+    /// This cell is part of a SoloStart / ConflictStart cluster that began
+    /// at an earlier row; the renderer must emit nothing here so the
+    /// parent's `combinedSpan` can occupy the rows.
+    case skip
+}
+
+/// Pure conflict-detection algorithm shared between the iPhone main view,
+/// the macOS class table, and the WeekWidget. Mirrors the iPhone
+/// `ClassTableViewModel.cellRole` semantics: 2-course overlaps emit a
+/// `conflictStart` at the cluster's earliest row plus `.skip` for every
+/// later cell in that cluster; a transitive closure of 3+ courses falls
+/// back to per-slot rendering so no course is dropped.
+public enum ClassTableLayout {
+    /// Returns the role for one cell, given a flat list of courses, the
+    /// chronologically-ordered period ids for the grid, and key/schedule
+    /// accessors. The algorithm is O(periods²) per call — acceptable for
+    /// the ≤14 period rows the school uses.
+    public static func cellRole<C>(
+        courses: [C],
+        periodIds: [String],
+        weekday: Int,
+        periodIndex: Int,
+        keyOf: (C) -> String,
+        scheduleOf: (C) -> [Int: [String]]
+    ) -> ClassTableCellRole<C> {
+        guard periodIndex >= 0, periodIndex < periodIds.count else { return .empty }
+
+        func coursesAt(_ idx: Int) -> [C] {
+            guard idx >= 0, idx < periodIds.count else { return [] }
+            let pid = periodIds[idx]
+            return courses.filter { (scheduleOf($0)[weekday] ?? []).contains(pid) }
+        }
+
+        let coursesHere = coursesAt(periodIndex)
+        guard !coursesHere.isEmpty else { return .empty }
+
+        // Transitive closure of overlapping blocks rooted at this cell.
+        var closure: [(course: C, first: Int, span: Int)] = []
+        var seenKeys = Set<String>()
+
+        func addCourse(_ c: C, seedIndex: Int) {
+            guard seenKeys.insert(keyOf(c)).inserted else { return }
+            let key = keyOf(c)
+            var first = seedIndex
+            while first - 1 >= 0,
+                  coursesAt(first - 1).contains(where: { keyOf($0) == key }) {
+                first -= 1
+            }
+            var last = seedIndex
+            while last + 1 < periodIds.count,
+                  coursesAt(last + 1).contains(where: { keyOf($0) == key }) {
+                last += 1
+            }
+            let span = last - first + 1
+            closure.append((c, first, span))
+            for i in first..<(first + span) {
+                for other in coursesAt(i) where !seenKeys.contains(keyOf(other)) {
+                    addCourse(other, seedIndex: i)
+                }
+            }
+        }
+        for c in coursesHere { addCourse(c, seedIndex: periodIndex) }
+
+        let clusterStart = closure.map(\.first).min() ?? periodIndex
+
+        // 3+ closure → per-slot fallback so every course stays on the grid.
+        if closure.count >= 3 {
+            return perSlotRole(
+                periodIds: periodIds,
+                periodIndex: periodIndex,
+                coursesHere: coursesHere,
+                coursesAt: coursesAt,
+                keyOf: keyOf
+            )
+        }
+
+        if clusterStart < periodIndex { return .skip }
+
+        if closure.count == 1 {
+            let only = closure[0]
+            return .solo(only.course, spanCount: only.span)
+        }
+
+        let a = closure[0]
+        let b = closure[1]
+        let clusterEnd = max(a.first + a.span, b.first + b.span)
+        return .conflictStart(
+            courseA: a.course, spanA: a.span, offsetA: a.first - clusterStart,
+            courseB: b.course, spanB: b.span, offsetB: b.first - clusterStart,
+            combinedSpan: clusterEnd - clusterStart
+        )
+    }
+
+    private static func perSlotRole<C>(
+        periodIds: [String],
+        periodIndex: Int,
+        coursesHere: [C],
+        coursesAt: (Int) -> [C],
+        keyOf: (C) -> String
+    ) -> ClassTableCellRole<C> {
+        let mySet = Set(coursesHere.map(keyOf))
+
+        if periodIndex > 0 {
+            let prev = coursesAt(periodIndex - 1)
+            if Set(prev.map(keyOf)) == mySet { return .skip }
+        }
+
+        var span = 1
+        var i = periodIndex + 1
+        while i < periodIds.count {
+            let next = coursesAt(i)
+            if Set(next.map(keyOf)) == mySet {
+                span += 1
+                i += 1
+            } else {
+                break
+            }
+        }
+
+        if coursesHere.count == 1 {
+            return .solo(coursesHere[0], spanCount: span)
+        }
+        return .conflictStart(
+            courseA: coursesHere[0], spanA: span, offsetA: 0,
+            courseB: coursesHere[1], spanB: span, offsetB: 0,
+            combinedSpan: span
+        )
+    }
+}

--- a/swift/TigerDuck/Shared/Components/LoadingButtonLabel.swift
+++ b/swift/TigerDuck/Shared/Components/LoadingButtonLabel.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Button label that swaps to a spinner without resizing.
+///
+/// The original content stays in the layout (rendered transparent) so the
+/// button keeps the same intrinsic width and height during the loading
+/// state. Use as the `label:` of any `Button`:
+///
+/// ```
+/// Button { ... } label: {
+///     LoadingButtonLabel(isLoading: viewModel.isWorking, tint: .white) {
+///         Text("Save")
+///     }
+/// }
+/// ```
+struct LoadingButtonLabel<Content: View>: View {
+    let isLoading: Bool
+    var tint: Color? = nil
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        ZStack {
+            content().opacity(isLoading ? 0 : 1)
+
+            if isLoading {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(tint)
+            }
+        }
+    }
+}

--- a/swift/TigerDuckWidgets/Views/WeekGridView.swift
+++ b/swift/TigerDuckWidgets/Views/WeekGridView.swift
@@ -123,17 +123,18 @@ struct WeekGridView: View {
         case let .solo(course, spanCount):
             courseBlock(course, spanCount: spanCount, cellHeight: cellHeight, fontScale: fontScale)
 
-        case let .conflictStart(courseA, _, _, courseB, _, _, combinedSpan):
-            // Widget cells are tight; render conflicts as a horizontal
-            // half-and-half split rather than the iPhone L-shape interlock.
-            // Each course gets a slim block with its display name; classroom
-            // is dropped for the conflict case to keep the text legible.
+        case let .conflictStart(courseA, spanA, offsetA, courseB, spanB, offsetB, combinedSpan):
+            // Two-course 衝堂: each half is a column sized to that course's
+            // own span and positioned at its offset within the cluster, so
+            // an overlap meeting in only part of the cluster (e.g. A on
+            // periods 1–3 overlapping B only on period 2) doesn't extend
+            // either course into the rows where they don't actually meet.
             let totalHeight = CGFloat(combinedSpan) * cellHeight + CGFloat(combinedSpan - 1) * rowSpacing
             Color.clear
                 .overlay(alignment: .top) {
                     HStack(spacing: 1) {
-                        conflictHalf(courseA, fontScale: fontScale)
-                        conflictHalf(courseB, fontScale: fontScale)
+                        conflictColumn(courseA, span: spanA, offset: offsetA, combinedSpan: combinedSpan, cellHeight: cellHeight, fontScale: fontScale)
+                        conflictColumn(courseB, span: spanB, offset: offsetB, combinedSpan: combinedSpan, cellHeight: cellHeight, fontScale: fontScale)
                     }
                     .frame(height: totalHeight)
                 }
@@ -191,6 +192,38 @@ struct WeekGridView: View {
                     .frame(height: totalHeight)
             }
             .zIndex(1)
+    }
+
+    /// One column of a 衝堂 cluster, sized to the course's own span and
+    /// positioned at its offset within the cluster via empty spacers.
+    @ViewBuilder
+    private func conflictColumn(
+        _ course: SnapshotCourse,
+        span: Int,
+        offset: Int,
+        combinedSpan: Int,
+        cellHeight: CGFloat,
+        fontScale: CGFloat
+    ) -> some View {
+        let topRows = offset
+        let bottomRows = max(combinedSpan - offset - span, 0)
+        let topHeight = topRows > 0
+            ? CGFloat(topRows) * cellHeight + CGFloat(topRows - 1) * rowSpacing
+            : 0
+        let bottomHeight = bottomRows > 0
+            ? CGFloat(bottomRows) * cellHeight + CGFloat(bottomRows - 1) * rowSpacing
+            : 0
+        let courseHeight = CGFloat(span) * cellHeight + CGFloat(max(span - 1, 0)) * rowSpacing
+        VStack(spacing: rowSpacing) {
+            if topRows > 0 {
+                Color.clear.frame(height: topHeight)
+            }
+            conflictHalf(course, fontScale: fontScale)
+                .frame(height: courseHeight)
+            if bottomRows > 0 {
+                Color.clear.frame(height: bottomHeight)
+            }
+        }
     }
 
     @ViewBuilder

--- a/swift/TigerDuckWidgets/Views/WeekGridView.swift
+++ b/swift/TigerDuckWidgets/Views/WeekGridView.swift
@@ -139,6 +139,19 @@ struct WeekGridView: View {
                 }
                 .zIndex(1)
 
+        case let .conflictMany(courses, combinedSpan):
+            let totalHeight = CGFloat(combinedSpan) * cellHeight + CGFloat(combinedSpan - 1) * rowSpacing
+            Color.clear
+                .overlay(alignment: .top) {
+                    HStack(spacing: 1) {
+                        ForEach(Array(courses.enumerated()), id: \.offset) { _, course in
+                            conflictHalf(course, fontScale: fontScale)
+                        }
+                    }
+                    .frame(height: totalHeight)
+                }
+                .zIndex(1)
+
         case .skip:
             Color.clear
         }

--- a/swift/TigerDuckWidgets/Views/WeekGridView.swift
+++ b/swift/TigerDuckWidgets/Views/WeekGridView.swift
@@ -36,7 +36,6 @@ struct WeekGridView: View {
         let weekdays = snapshot.activeWeekdays
         let periods = snapshot.activePeriodIds
         let todayWeekday = WidgetTimelineDerivation.weekdayFor(now)
-        let lookup = buildLookup()
 
         GeometryReader { geom in
             let totalRowSpacing = CGFloat(max(0, periods.count - 1)) * rowSpacing
@@ -70,7 +69,6 @@ struct WeekGridView: View {
                                 weekday: weekday,
                                 periodIndex: periodIndex,
                                 periods: periods,
-                                lookup: lookup,
                                 cellHeight: cellHeight,
                                 fontScale: fontScale
                             )
@@ -106,99 +104,100 @@ struct WeekGridView: View {
         weekday: Int,
         periodIndex: Int,
         periods: [String],
-        lookup: [Int: [String: SnapshotCourse]],
         cellHeight: CGFloat,
         fontScale: CGFloat
     ) -> some View {
-        switch cellRole(weekday: weekday, periodIndex: periodIndex, periods: periods, lookup: lookup) {
+        let role = ClassTableLayout.cellRole(
+            courses: snapshot.courses,
+            periodIds: periods,
+            weekday: weekday,
+            periodIndex: periodIndex,
+            keyOf: { $0.courseNo },
+            scheduleOf: { $0.schedule }
+        )
+        switch role {
         case .empty:
             RoundedRectangle(cornerRadius: cornerRadius)
                 .fill(palette.emptyCell)
 
-        case .blockStart(let course, let spanCount):
-            let totalHeight = CGFloat(spanCount) * cellHeight + CGFloat(spanCount - 1) * rowSpacing
-            let courseColor = Color(widgetHex: course.colorHex)
+        case let .solo(course, spanCount):
+            courseBlock(course, spanCount: spanCount, cellHeight: cellHeight, fontScale: fontScale)
+
+        case let .conflictStart(courseA, _, _, courseB, _, _, combinedSpan):
+            // Widget cells are tight; render conflicts as a horizontal
+            // half-and-half split rather than the iPhone L-shape interlock.
+            // Each course gets a slim block with its display name; classroom
+            // is dropped for the conflict case to keep the text legible.
+            let totalHeight = CGFloat(combinedSpan) * cellHeight + CGFloat(combinedSpan - 1) * rowSpacing
             Color.clear
                 .overlay(alignment: .top) {
-                    RoundedRectangle(cornerRadius: cornerRadius)
-                        .fill(courseColor.opacity(0.25))
-                        .overlay {
-                            RoundedRectangle(cornerRadius: cornerRadius)
-                                .strokeBorder(courseColor.opacity(0.4), lineWidth: 0.5)
-                        }
-                        .overlay {
-                            VStack(spacing: 1) {
-                                Text(course.displayName)
-                                    .font(.system(size: 9 * fontScale, weight: .medium))
-                                    .foregroundStyle(palette.onSurface)
-                                    .lineLimit(spanCount > 1 ? 3 : 2)
-                                    .multilineTextAlignment(.center)
-                                    .minimumScaleFactor(0.7)
-                                if !course.classroom.isEmpty && spanCount > 1 {
-                                    Text(course.classroom)
-                                        .font(.system(size: 7 * fontScale))
-                                        .foregroundStyle(palette.onSurfaceVariant)
-                                        .lineLimit(1)
-                                }
-                            }
-                            .padding(2)
-                        }
-                        .frame(height: totalHeight)
+                    HStack(spacing: 1) {
+                        conflictHalf(courseA, fontScale: fontScale)
+                        conflictHalf(courseB, fontScale: fontScale)
+                    }
+                    .frame(height: totalHeight)
                 }
                 .zIndex(1)
 
-        case .blockContinuation:
+        case .skip:
             Color.clear
         }
     }
 
-    private enum CellRole {
-        case empty
-        case blockStart(SnapshotCourse, spanCount: Int)
-        case blockContinuation
+    @ViewBuilder
+    private func courseBlock(
+        _ course: SnapshotCourse, spanCount: Int, cellHeight: CGFloat, fontScale: CGFloat
+    ) -> some View {
+        let totalHeight = CGFloat(spanCount) * cellHeight + CGFloat(spanCount - 1) * rowSpacing
+        let courseColor = Color(widgetHex: course.colorHex)
+        Color.clear
+            .overlay(alignment: .top) {
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(courseColor.opacity(0.25))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: cornerRadius)
+                            .strokeBorder(courseColor.opacity(0.4), lineWidth: 0.5)
+                    }
+                    .overlay {
+                        VStack(spacing: 1) {
+                            Text(course.displayName)
+                                .font(.system(size: 9 * fontScale, weight: .medium))
+                                .foregroundStyle(palette.onSurface)
+                                .lineLimit(spanCount > 1 ? 3 : 2)
+                                .multilineTextAlignment(.center)
+                                .minimumScaleFactor(0.7)
+                            if !course.classroom.isEmpty && spanCount > 1 {
+                                Text(course.classroom)
+                                    .font(.system(size: 7 * fontScale))
+                                    .foregroundStyle(palette.onSurfaceVariant)
+                                    .lineLimit(1)
+                            }
+                        }
+                        .padding(2)
+                    }
+                    .frame(height: totalHeight)
+            }
+            .zIndex(1)
     }
 
-    private func buildLookup() -> [Int: [String: SnapshotCourse]] {
-        var lookup: [Int: [String: SnapshotCourse]] = [:]
-        for course in snapshot.courses {
-            for (weekday, ids) in course.schedule {
-                for periodId in ids {
-                    lookup[weekday, default: [:]][periodId] = course
-                }
+    @ViewBuilder
+    private func conflictHalf(_ course: SnapshotCourse, fontScale: CGFloat) -> some View {
+        let courseColor = Color(widgetHex: course.colorHex)
+        RoundedRectangle(cornerRadius: cornerRadius)
+            .fill(courseColor.opacity(0.25))
+            .overlay {
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .strokeBorder(courseColor.opacity(0.4), lineWidth: 0.5)
             }
-        }
-        return lookup
-    }
-
-    private func cellRole(
-        weekday: Int,
-        periodIndex: Int,
-        periods: [String],
-        lookup: [Int: [String: SnapshotCourse]]
-    ) -> CellRole {
-        guard periodIndex >= 0, periodIndex < periods.count else { return .empty }
-        let periodId = periods[periodIndex]
-        guard let course = lookup[weekday]?[periodId] else { return .empty }
-
-        if periodIndex > 0 {
-            let prevId = periods[periodIndex - 1]
-            if let prev = lookup[weekday]?[prevId], prev.courseNo == course.courseNo {
-                return .blockContinuation
+            .overlay {
+                Text(course.displayName)
+                    .font(.system(size: 8 * fontScale, weight: .medium))
+                    .foregroundStyle(palette.onSurface)
+                    .lineLimit(3)
+                    .multilineTextAlignment(.center)
+                    .minimumScaleFactor(0.55)
+                    .padding(1)
             }
-        }
-
-        var span = 1
-        var nextIdx = periodIndex + 1
-        while nextIdx < periods.count {
-            let nextId = periods[nextIdx]
-            if let next = lookup[weekday]?[nextId], next.courseNo == course.courseNo {
-                span += 1
-                nextIdx += 1
-            } else {
-                break
-            }
-        }
-        return .blockStart(course, spanCount: span)
     }
 
     private func weekdayKey(_ weekday: Int) -> String {


### PR DESCRIPTION
## Summary

- **Onboarding (iPhone)**: rebuilt landing flow to match Android (Welcome → Privacy → Apple Watch → Login → Notifications → Ready), with pinned actions, scrollable body, haptic feedback on privacy toggles, logged-in indicator with flashing lock, keyboard dismiss on tap/scroll, and a `LoadingButtonLabel` that keeps button size stable while spinning.
- **ClassTable / macOS parity**: extracted shared `ClassTableLayout` so iPhone, macOS, and the Week widget all derive cells, spans and 衝堂 from the same algorithm; macOS gains Add/Detail course sheets matching iPhone UX.
- **macOS widget cards**: hide skipped classes, scan future weekdays for Next Class, repaint Home on cache update, and (this PR) tick the conflict-block countdown down to the latest finishing end so mismatched-span 衝堂 reads correctly.
- **More / Debug / Settings**: drop unused pin badge, enlarge & top-align the settings button, promote Notifications to its own Developer entry, dismiss keyboard on sign-in.

## Test plan

- [ ] First-launch onboarding on iPhone: complete each page, verify pinned Next/Allow buttons, keyboard dismiss on tap/scroll, haptic on checkbox tap, login persistence + flashing lock state.
- [ ] iPhone classtable: 衝堂 still renders as L-shape interlock; macOS classtable: 衝堂 renders as horizontal split; widget Week grid: 衝堂 renders with shared algorithm.
- [ ] macOS Add Course / Course Detail sheets behave like iPhone counterparts; Moodle link launches.
- [ ] macOS Home widget: skipped classes hidden, Next Class card surfaces correct upcoming class, countdown ticks for both single and conflicting classes.
- [ ] Settings: tapping sign-in dismisses keyboard immediately; debug Notifications entry visible in Developer.