### PR TITLE
chore: clear Swift 6 strict-concurrency warnings

### DIFF
--- a/swift/Shared/Watch/WatchCourse.swift
+++ b/swift/Shared/Watch/WatchCourse.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// Wire-format DTO. Decoupled from `SDCourse` so phone-side schema churn does
 /// not ripple to the watch unless this struct's fields change.
-public struct WatchCourse: Codable, Hashable, Identifiable, Sendable {
+public nonisolated struct WatchCourse: Codable, Hashable, Identifiable, Sendable {
     public let id: String         // "<courseNo>-<weekday>-<firstPeriod>"
     public let courseNo: String
     public let name: String

--- a/swift/Shared/Watch/WatchPayloadCodec.swift
+++ b/swift/Shared/Watch/WatchPayloadCodec.swift
@@ -10,7 +10,7 @@ public enum WatchPayloadCodec {
         case invalidType(String)
     }
 
-    private enum CourseKey {
+    private nonisolated enum CourseKey {
         static let id           = "id"
         static let courseNo     = "courseNo"
         static let name         = "name"
@@ -43,7 +43,7 @@ public enum WatchPayloadCodec {
         return dict
     }
 
-    private static func encodeCourse(_ c: WatchCourse) -> [String: Any] {
+    private nonisolated static func encodeCourse(_ c: WatchCourse) -> [String: Any] {
         [
             CourseKey.id:          c.id,
             CourseKey.courseNo:    c.courseNo,
@@ -90,7 +90,7 @@ public enum WatchPayloadCodec {
         )
     }
 
-    private static func decodeCourse(_ dict: [String: Any]) throws -> WatchCourse {
+    private nonisolated static func decodeCourse(_ dict: [String: Any]) throws -> WatchCourse {
         func req<T>(_ key: String) throws -> T {
             guard let any = dict[key] else { throw DecodingError.missingRequiredKey(key) }
             guard let v = any as? T else { throw DecodingError.invalidType(key) }

--- a/swift/Shared/Watch/WatchSnapshot.swift
+++ b/swift/Shared/Watch/WatchSnapshot.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Decoded watch-side view of one applicationContext push. Lives in the
 /// shared App Group file so the widget can read it without WC.
-public struct WatchSnapshot: Codable, Equatable, Sendable {
+public nonisolated struct WatchSnapshot: Codable, Equatable, Sendable {
     public let version: Int
     public let courses: [WatchCourse]
     public let accentHex: String

--- a/swift/TigerDuck/App/AppConstants.swift
+++ b/swift/TigerDuck/App/AppConstants.swift
@@ -9,7 +9,7 @@ extension URL {
     /// string in the diagnostic so the regression is obvious in crash
     /// reports. Also throws at the type-load site so static service
     /// URLs cannot ship with a malformed literal.
-    static func knownGood(_ string: StaticString) -> URL {
+    nonisolated static func knownGood(_ string: StaticString) -> URL {
         let raw = "\(string)"
         guard let url = URL(string: raw) else {
             preconditionFailure("URL.knownGood received a malformed literal: \(raw)")

--- a/swift/TigerDuck/App/AppDefaults.swift
+++ b/swift/TigerDuck/App/AppDefaults.swift
@@ -4,7 +4,7 @@ import Foundation
 extension BrowserPreference: Defaults.Serializable, Defaults.PreferRawRepresentable {}
 extension VisualPreset: Defaults.Serializable, Defaults.PreferRawRepresentable {}
 
-extension Defaults.Keys {
+nonisolated extension Defaults.Keys {
     static let hasCompletedOnboarding = Key<Bool>(
         AppConstants.UserDefaultsKeys.hasCompletedOnboarding,
         default: false

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -471,7 +471,12 @@ final class AppState {
                         classroomAbbrEnabled: classroomAbbrEnabled,
                         classroomMandarinDisplay: classroomMandarinDisplay
                     )
-                    if changed {
+                    // Re-check cancellation inside the MainActor body: a
+                    // newer toggle can have cancelled this task while it
+                    // was queued for the main actor, and persisting now
+                    // would clobber the newer task's save with stale
+                    // toggle values captured at the top of this closure.
+                    if changed && !Task.isCancelled {
                         DataCache.shared.saveCourses(courses, semester: semesterCode)
                     }
                     return (changed, false)
@@ -502,7 +507,9 @@ final class AppState {
                     classroomAbbrEnabled: classroomAbbrEnabled,
                     classroomMandarinDisplay: classroomMandarinDisplay
                 )
-                if changed {
+                // Same rationale as the per-semester save above: skip the
+                // write if a newer relabel has already superseded this one.
+                if changed && !Task.isCancelled {
                     DataCache.shared.saveUserAddedCourses(userAdded)
                 }
                 return changed

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -442,6 +442,11 @@ final class AppState {
     /// so the latest settings always win the save race.
     private func relabelAllCachedCourses() {
         relabelTask?.cancel()
+        // `Task.detached` lets the loop body yield to the runtime between
+        // iterations, so a long relabel sweep doesn't pin the MainActor.
+        // The actual disk/SwiftData work hops to MainActor per iteration
+        // because `DataCache` and `NameAbbrService.relabelInPlace` touch
+        // SwiftData-managed types that are themselves MainActor-isolated.
         relabelTask = Task.detached(priority: .userInitiated) {
             let courseAbbrEnabled = Defaults[.useEnglishCourseAbbreviation]
             let classroomAbbrEnabled = Defaults[.useEnglishClassroomAbbreviation]
@@ -452,17 +457,14 @@ final class AppState {
             var consecutiveEmpty = 0
             for _ in 0..<AppConstants.cachedSemesterRelabelDepth {
                 if Task.isCancelled { return }
-                let courses = DataCache.shared.loadCourses(semester: code)
-                if courses.isEmpty {
-                    consecutiveEmpty += 1
-                    // Two empty semesters in a row means we've walked past
-                    // any data the user has fetched; further iterations just
-                    // hit disk for nothing.
-                    if consecutiveEmpty >= 2 { break }
-                } else {
-                    consecutiveEmpty = 0
-                }
-                if !courses.isEmpty {
+                // Snapshot `code` into a `let` so the Sendable closure passed
+                // to `MainActor.run` captures an immutable value — Swift 6
+                // rejects capturing the mutating outer `var` from a
+                // concurrently-executing context.
+                let semesterCode = code
+                let iter = await MainActor.run { () -> (changed: Bool, wasEmpty: Bool) in
+                    let courses = DataCache.shared.loadCourses(semester: semesterCode)
+                    if courses.isEmpty { return (false, true) }
                     let changed = NameAbbrService.shared.relabelInPlace(
                         courses,
                         courseAbbrEnabled: courseAbbrEnabled,
@@ -470,10 +472,20 @@ final class AppState {
                         classroomMandarinDisplay: classroomMandarinDisplay
                     )
                     if changed {
-                        DataCache.shared.saveCourses(courses, semester: code)
-                        anyChanged = true
+                        DataCache.shared.saveCourses(courses, semester: semesterCode)
                     }
+                    return (changed, false)
                 }
+                if iter.wasEmpty {
+                    consecutiveEmpty += 1
+                    // Two empty semesters in a row means we've walked past any
+                    // data the user has fetched; further iterations just hit
+                    // disk for nothing.
+                    if consecutiveEmpty >= 2 { break }
+                } else {
+                    consecutiveEmpty = 0
+                }
+                if iter.changed { anyChanged = true }
                 code = CourseSelectionService.previousSemesterCode(code)
             }
 
@@ -481,8 +493,9 @@ final class AppState {
             // fetch cache, so the loop above never sees them. Relabel separately
             // so manually-added Mandarin classrooms also honor the display toggle.
             if Task.isCancelled { return }
-            let userAdded = DataCache.shared.loadUserAddedCourses()
-            if !userAdded.isEmpty {
+            let userChanged = await MainActor.run { () -> Bool in
+                let userAdded = DataCache.shared.loadUserAddedCourses()
+                guard !userAdded.isEmpty else { return false }
                 let changed = NameAbbrService.shared.relabelInPlace(
                     userAdded,
                     courseAbbrEnabled: courseAbbrEnabled,
@@ -491,9 +504,10 @@ final class AppState {
                 )
                 if changed {
                     DataCache.shared.saveUserAddedCourses(userAdded)
-                    anyChanged = true
                 }
+                return changed
             }
+            if userChanged { anyChanged = true }
 
             if anyChanged && !Task.isCancelled {
                 await MainActor.run {

--- a/swift/TigerDuck/App/LanguageManager.swift
+++ b/swift/TigerDuck/App/LanguageManager.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum LanguageManager {
+nonisolated enum LanguageManager {
     static let system = "system"
     private static let zhHant = "zh-Hant"
     private static let zhHans = "zh-Hans"

--- a/swift/TigerDuck/Bridge/AppServiceBridge.swift
+++ b/swift/TigerDuck/Bridge/AppServiceBridge.swift
@@ -191,7 +191,13 @@ enum AppServiceBridge {
 
             let courseDataList = await withTaskGroup(of: CourseData?.self) { group in
                 for courseNo in orderedCourseNos {
-                    group.addTask {
+                    // Hop into MainActor for the body. `buildSDCourse` returns
+                    // a SwiftData-managed `SDCourse` whose accessors are
+                    // MainActor-isolated, and `NameAbbrService.shared` is a
+                    // MainActor singleton — running the closure on MainActor
+                    // avoids per-statement `MainActor.run` while leaving the
+                    // network `lookupCourse(…)` to suspend cooperatively.
+                    group.addTask { @MainActor in
                         do {
                             let results = try await CourseLookupService.lookupCourse(
                                 semester: semester, courseNo: courseNo, language: courseApiLanguage

--- a/swift/TigerDuck/Clock/AppClock.swift
+++ b/swift/TigerDuck/Clock/AppClock.swift
@@ -6,7 +6,12 @@ import os
 ///
 /// Auth/network code (session expiry, cookie TTL, login timestamps, cache TTLs)
 /// intentionally does NOT use AppClock — see spec for rationale.
-enum AppClock {
+///
+/// Marked `nonisolated`: synchronisation is provided by `OSAllocatedUnfairLock`
+/// (`State` is the lock's protected payload) and `UserDefaults` is thread-safe,
+/// so any caller — UI, scheduler, Sendable closures, background tasks — can
+/// hit these statics directly without a hop to `MainActor`.
+nonisolated enum AppClock {
 
     private static let lock = OSAllocatedUnfairLock<State>(initialState: State())
 

--- a/swift/TigerDuck/Clock/ClockOverride.swift
+++ b/swift/TigerDuck/Clock/ClockOverride.swift
@@ -4,7 +4,7 @@ import Foundation
 /// instant at which this override was saved; it anchors ticking-mode math
 /// so a value persisted in App Group `UserDefaults` and applied later still
 /// computes the right elapsed delta.
-struct ClockOverride: Codable, Equatable, Sendable {
+nonisolated struct ClockOverride: Codable, Equatable, Sendable {
     let instant: Date
     let frozen: Bool
     let savedAtReal: Date

--- a/swift/TigerDuck/Extensions/Data+Hex.swift
+++ b/swift/TigerDuck/Extensions/Data+Hex.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension Data {
+nonisolated extension Data {
     /// Lowercase hex encoding. Used for APNs/PTS token hex strings sent to the
     /// push server.
     func hexEncodedString() -> String {

--- a/swift/TigerDuck/Features/Bulletins/BulletinBodyRenderer.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinBodyRenderer.swift
@@ -68,7 +68,7 @@ nonisolated enum BulletinBodyRenderer {
     }
 }
 
-private extension String {
+private nonisolated extension String {
     var trimmedNilIfEmpty: String? {
         let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed

--- a/swift/TigerDuck/Features/Calendar/CalendarViewModel.swift
+++ b/swift/TigerDuck/Features/Calendar/CalendarViewModel.swift
@@ -21,9 +21,14 @@ final class CalendarViewModel {
     private let eventStore = EKEventStore()
     var calendarAccessGranted = false
     private var hasLoaded = false
-    // `nonisolated` so `deinit` (which is nonisolated under Swift 6 on
-    // a @MainActor class) can read this to remove the
-    // NotificationCenter observer at end-of-life.
+    // `nonisolated(unsafe)` so `deinit` (which is nonisolated under
+    // Swift 6 on a @MainActor class) can read this to remove the
+    // NotificationCenter observer at end-of-life. `@ObservationIgnored`
+    // is required for the isolation modifier to take effect — without
+    // it the `@Observable` macro replaces the stored var with a
+    // computed accessor, which strips the modifier and produces a
+    // "'nonisolated(unsafe)' has no effect" warning.
+    @ObservationIgnored
     private nonisolated(unsafe) var dataObserver: Any? = nil
 
     /// Pre-grouped events by day for O(1) lookups in the month grid.

--- a/swift/TigerDuck/LiveActivity/Preferences/LiveActivityPreferencesStore.swift
+++ b/swift/TigerDuck/LiveActivity/Preferences/LiveActivityPreferencesStore.swift
@@ -15,13 +15,13 @@ import Defaults
 /// - All scenario toggles on
 @Observable
 final class LiveActivityPreferencesStore {
-    static let defaultOffsets: Set<AssignmentReminderOffset> = [.hr48, .hr24, .hr8, .hr2, .hr1, .min30]
-    static let defaultAssignmentLeadTime: TimeInterval = 8 * 3600
-    static let defaultClassPreparingLeadTime: TimeInterval = 60 * 60
-    static let minimumClassPreparingLeadTime: TimeInterval = 5 * 60
-    static let maximumClassPreparingLeadTime: TimeInterval = 4 * 3600
+    nonisolated static let defaultOffsets: Set<AssignmentReminderOffset> = [.hr48, .hr24, .hr8, .hr2, .hr1, .min30]
+    nonisolated static let defaultAssignmentLeadTime: TimeInterval = 8 * 3600
+    nonisolated static let defaultClassPreparingLeadTime: TimeInterval = 60 * 60
+    nonisolated static let minimumClassPreparingLeadTime: TimeInterval = 5 * 60
+    nonisolated static let maximumClassPreparingLeadTime: TimeInterval = 4 * 3600
     /// Spec invariant: Live Activity lead time must not exceed 8 hours to fit the activity lifecycle.
-    static let maximumAssignmentLeadTime: TimeInterval = 8 * 3600
+    nonisolated static let maximumAssignmentLeadTime: TimeInterval = 8 * 3600
 
     var assignmentReminderOffsets: Set<AssignmentReminderOffset> {
         didSet { persistOffsets(); notifyChange() }

--- a/swift/TigerDuck/Services/API/Moodle/MoodleAPIModels.swift
+++ b/swift/TigerDuck/Services/API/Moodle/MoodleAPIModels.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - Shared webservice session
 
-enum MoodleWebserviceClient {
+nonisolated enum MoodleWebserviceClient {
     static let siteBaseURL = URL(string: "https://moodle2.ntust.edu.tw")!
     static let webservicePath = "/webservice/rest/server.php"
     static let session: URLSession = {

--- a/swift/TigerDuck/Services/API/NTUST/CourseSelectionService.swift
+++ b/swift/TigerDuck/Services/API/NTUST/CourseSelectionService.swift
@@ -89,20 +89,20 @@ enum CourseSelectionService {
         return courseNos
     }
 
-    static let enrolledCoursesCacheTTL: TimeInterval = 86_400
+    nonisolated static let enrolledCoursesCacheTTL: TimeInterval = 86_400
 
-    private static let enrolledCoursesCacheKey = "enrolledCourseNosCache"
+    nonisolated private static let enrolledCoursesCacheKey = "enrolledCourseNosCache"
 
     // Serializes read-modify-write of the per-(studentId,semester) cache dict
     // so concurrent fetches/invalidations cannot lose updates.
-    private static let cacheLock = OSAllocatedUnfairLock()
+    nonisolated private static let cacheLock = OSAllocatedUnfairLock()
 
-    private struct CachedCourseNos: Codable {
+    nonisolated private struct CachedCourseNos: Codable {
         let courseNos: [String]
         let cachedAt: TimeInterval
     }
 
-    static func invalidateEnrolledCoursesCache(for studentId: String? = nil) {
+    nonisolated static func invalidateEnrolledCoursesCache(for studentId: String? = nil) {
         cacheLock.withLock {
             let defaults = UserDefaults.standard
             guard let studentId else {
@@ -115,7 +115,7 @@ enum CourseSelectionService {
         }
     }
 
-    private static func loadEnrolledCoursesCache(studentId: String, semester: String) -> [String]? {
+    nonisolated private static func loadEnrolledCoursesCache(studentId: String, semester: String) -> [String]? {
         cacheLock.withLock {
             let dict = readCacheDict()
             guard let entry = dict["\(studentId):\(semester)"] else { return nil }
@@ -124,7 +124,7 @@ enum CourseSelectionService {
         }
     }
 
-    private static func saveEnrolledCoursesCache(studentId: String, semester: String, courseNos: [String]) {
+    nonisolated private static func saveEnrolledCoursesCache(studentId: String, semester: String, courseNos: [String]) {
         guard !courseNos.isEmpty else { return }
         cacheLock.withLock {
             var dict = readCacheDict()
@@ -133,7 +133,7 @@ enum CourseSelectionService {
         }
     }
 
-    private static func readCacheDict() -> [String: CachedCourseNos] {
+    nonisolated private static func readCacheDict() -> [String: CachedCourseNos] {
         guard let data = UserDefaults.standard.data(forKey: enrolledCoursesCacheKey),
               let dict = try? JSONDecoder().decode([String: CachedCourseNos].self, from: data) else {
             return [:]
@@ -141,7 +141,7 @@ enum CourseSelectionService {
         return dict
     }
 
-    private static func writeCacheDict(_ dict: [String: CachedCourseNos]) {
+    nonisolated private static func writeCacheDict(_ dict: [String: CachedCourseNos]) {
         let defaults = UserDefaults.standard
         if dict.isEmpty {
             defaults.removeObject(forKey: enrolledCoursesCacheKey)

--- a/swift/TigerDuck/Services/Core/DataCache.swift
+++ b/swift/TigerDuck/Services/Core/DataCache.swift
@@ -3,6 +3,13 @@ import Foundation
 
 /// Persists network-fetched data to disk so it survives app restarts.
 /// Uses JSON files in the app's caches directory.
+///
+/// Stays on `@MainActor` (the module-default isolation under
+/// `SWIFT_APPROACHABLE_CONCURRENCY = YES`) because the public surface
+/// hands back SwiftData-managed types (`SDCourse`, `SDAssignment`,
+/// `SDCalendarEvent`) whose accessors are themselves MainActor-isolated.
+/// Callers running off MainActor (e.g. `Task.detached`) must hop via
+/// `await MainActor.run { … }` before touching the cache.
 final class DataCache {
     static let shared = DataCache()
 

--- a/swift/TigerDuck/Widgets/WidgetReloadCoordinator.swift
+++ b/swift/TigerDuck/Widgets/WidgetReloadCoordinator.swift
@@ -5,11 +5,11 @@ import WidgetKit
 
 @MainActor
 final class WidgetReloadCoordinator {
-    protocol Reloader {
+    nonisolated protocol Reloader: Sendable {
         func reloadAllTimelines()
     }
 
-    struct WidgetKitReloader: Reloader {
+    nonisolated struct WidgetKitReloader: Reloader {
         func reloadAllTimelines() {
             #if canImport(WidgetKit)
             WidgetCenter.shared.reloadAllTimelines()
@@ -17,8 +17,8 @@ final class WidgetReloadCoordinator {
         }
     }
 
-    private let reloader: Reloader
-    private let debounce: TimeInterval
+    nonisolated private let reloader: Reloader
+    nonisolated private let debounce: TimeInterval
     private var pendingTask: Task<Void, Never>?
 
     nonisolated init(reloader: Reloader = WidgetKitReloader(), debounceMs: Int = 300) {

--- a/swift/TigerDuck/Widgets/WidgetSnapshot.swift
+++ b/swift/TigerDuck/Widgets/WidgetSnapshot.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct WidgetSnapshot: Codable, Equatable, Hashable, Sendable {
+nonisolated struct WidgetSnapshot: Codable, Equatable, Hashable, Sendable {
     let version: Int
     let generatedAt: Date
     let isLoggedIn: Bool
@@ -16,7 +16,7 @@ struct WidgetSnapshot: Codable, Equatable, Hashable, Sendable {
     static let appGroupIdentifier = "group.org.ntust.app.TigerDuck"
 }
 
-struct SnapshotCourse: Codable, Equatable, Hashable, Sendable {
+nonisolated struct SnapshotCourse: Codable, Equatable, Hashable, Sendable {
     let courseNo: String
     let displayName: String
     let classroom: String
@@ -45,7 +45,7 @@ struct SnapshotCourse: Codable, Equatable, Hashable, Sendable {
     }
 }
 
-extension SnapshotCourse {
+nonisolated extension SnapshotCourse {
     private enum CodingKeys: String, CodingKey {
         case courseNo, displayName, classroom, schedule, colorHex, skippedDates
     }
@@ -63,7 +63,7 @@ extension SnapshotCourse {
     }
 }
 
-struct PeriodTime: Codable, Equatable, Hashable, Sendable {
+nonisolated struct PeriodTime: Codable, Equatable, Hashable, Sendable {
     let start: String   // "HH:mm"
     let end: String     // "HH:mm"
 }

--- a/swift/TigerDuck/Widgets/WidgetSnapshotWriter.swift
+++ b/swift/TigerDuck/Widgets/WidgetSnapshotWriter.swift
@@ -30,18 +30,24 @@ final class WidgetSnapshotWriter {
 
     private var observers: [NSObjectProtocol] = []
 
+    // Defaults are resolved in the init body rather than as parameter
+    // default expressions because `DataCache.shared` and the nested
+    // `WidgetReloadCoordinator()` factory call land in MainActor-isolated
+    // code; under Swift 6 strict concurrency parameter default
+    // expressions evaluate in a nonisolated context even on a
+    // MainActor-isolated init, so the MainActor references warn there.
     init(
         appState: AppState,
-        cache: DataCache = .shared,
-        store: WidgetSnapshotStore = WidgetSnapshotStore(),
-        coordinator: WidgetReloadCoordinator = WidgetReloadCoordinator(),
-        courseProvider: CanonicalCourseProvider = CanonicalCourseProvider()
+        cache: DataCache? = nil,
+        store: WidgetSnapshotStore? = nil,
+        coordinator: WidgetReloadCoordinator? = nil,
+        courseProvider: CanonicalCourseProvider? = nil
     ) {
         self.appState = appState
-        self.cache = cache
-        self.store = store
-        self.coordinator = coordinator
-        self.courseProvider = courseProvider
+        self.cache = cache ?? .shared
+        self.store = store ?? WidgetSnapshotStore()
+        self.coordinator = coordinator ?? WidgetReloadCoordinator()
+        self.courseProvider = courseProvider ?? CanonicalCourseProvider()
         attachObservers()
     }
 

--- a/swift/TigerDuckWatch Watch App/Services/SharedAppGroup.swift
+++ b/swift/TigerDuckWatch Watch App/Services/SharedAppGroup.swift
@@ -11,7 +11,7 @@ import os
 /// shared between the app and widget — they exist so a misconfigured
 /// build degrades to the existing "no snapshot yet" empty state instead
 /// of crashing the process.
-enum SharedAppGroup {
+nonisolated enum SharedAppGroup {
     static let identifier = "group.org.ntust.app.TigerDuck.watch"
 
     private static let logger = Logger(


### PR DESCRIPTION
## Summary
- Under `SWIFT_APPROACHABLE_CONCURRENCY = YES` the module-default isolation is `@MainActor`, which surfaced a swath of "main actor-isolated … cannot be referenced from a nonisolated context" warnings across the iOS app and Watch target. This sweep silences them in the way Swift 6 strict mode will eventually require — without retreating to `SWIFT_VERSION` 5 semantics or sprinkling `@unchecked Sendable`.
- Pure-data types and thread-safe utilities are marked `nonisolated` so they cross isolation boundaries cleanly: `WatchSnapshot` / `WatchCourse` / `WatchPayloadCodec` helpers, `WidgetSnapshot` DTOs, `ClockOverride`, `AppClock` (lock-protected), `SharedAppGroup`, `LanguageManager`, `MoodleWebserviceClient`, the `Data` hex helper, `URL.knownGood`, and the `Defaults.Keys` extension. `NameAbbrService` (already `@unchecked Sendable` behind `NSLock`) is now `nonisolated` end-to-end.
- SwiftData-coupled code stays MainActor — `DataCache` hands back `SDCourse`/`SDAssignment`/`SDCalendarEvent`, so `AppState.relabelAllCachedCourses` and the `AppServiceBridge` task group now hop to `MainActor` per iteration / closure instead of trying to call MainActor surface from `Task.detached`. The `WidgetReloadCoordinator.Reloader` protocol is now `nonisolated + Sendable` so detached callers can plumb the reload through without touching MainActor state; `WidgetSnapshotWriter` folds its default collaborators into the init body so default-argument expressions don't cross the MainActor boundary.
- `CalendarViewModel.dataObserver` picks up `@ObservationIgnored` so `nonisolated(unsafe)` actually applies to the storage (the `@Observable` macro otherwise wraps it in a computed accessor that strips the modifier).

## Test plan
- [x] `xcodebuild -scheme TigerDuck -destination 'generic/platform=iOS' build` — `** BUILD SUCCEEDED **`, zero warnings.
- [x] `xcodebuild -scheme "TigerDuckWatch Watch App" -destination 'generic/platform=watchOS' build` — zero warnings.
- [ ] Smoke-launch the app in Simulator and confirm:
  - [ ] Class table renders / refreshes (exercises `DataCache.shared.loadCourses` on MainActor).
  - [ ] Toggling course / classroom abbreviation in Settings still triggers a relabel sweep across cached semesters (exercises the `Task.detached` → `MainActor.run` hops in `AppState.relabelAllCachedCourses`).
  - [ ] Watch app receives an `applicationContext` push and persists the snapshot (exercises the now-`nonisolated` `WatchPayloadCodec`).
  - [ ] Widget timeline refreshes after a data update (exercises `WidgetReloadCoordinator.requestReload`).