### PR TITLE
fix: misc UI polish across home, classtable, onboarding, library, macOS

### DIFF
--- a/swift/TigerDuck.xcodeproj/project.pbxproj
+++ b/swift/TigerDuck.xcodeproj/project.pbxproj
@@ -1122,6 +1122,9 @@
 					ClassTableLayout.swift,
 					"View+PlatformCompat.swift",
 					LoadingButtonLabel.swift,
+					OngoingCourseInfo.swift,
+					CurrentClassCard.swift,
+					MinuteTicker.swift,
 				);
 				INFOPLIST_FILE = TigerDuck/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -1288,6 +1291,9 @@
 					ClassTableLayout.swift,
 					"View+PlatformCompat.swift",
 					LoadingButtonLabel.swift,
+					OngoingCourseInfo.swift,
+					CurrentClassCard.swift,
+					MinuteTicker.swift,
 				);
 				INFOPLIST_FILE = TigerDuck/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;

--- a/swift/TigerDuck.xcodeproj/project.pbxproj
+++ b/swift/TigerDuck.xcodeproj/project.pbxproj
@@ -1125,6 +1125,7 @@
 					OngoingCourseInfo.swift,
 					CurrentClassCard.swift,
 					MinuteTicker.swift,
+					EqualHeightCards.swift,
 				);
 				INFOPLIST_FILE = TigerDuck/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -1294,6 +1295,7 @@
 					OngoingCourseInfo.swift,
 					CurrentClassCard.swift,
 					MinuteTicker.swift,
+					EqualHeightCards.swift,
 				);
 				INFOPLIST_FILE = TigerDuck/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -243,6 +243,10 @@ final class AppState {
         return LibraryService.storedUsername
     }
 
+    /// `@MainActor` because `LibraryService.clearCredentials` is now
+    /// MainActor-isolated (it sync-broadcasts to the watch). The only
+    /// caller is a SwiftUI logout button, which is already on main.
+    @MainActor
     func logoutLibrary() {
         LibraryService.clearCredentials()
         _libraryRevision += 1

--- a/swift/TigerDuck/Clock/MinuteTicker.swift
+++ b/swift/TigerDuck/Clock/MinuteTicker.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Observation
+
+/// Observable 5-second pulse used by class-table / today-card views to
+/// re-derive minute-of-day state without listening on a Combine
+/// publisher. Reading `tick` somewhere in a view-model getter creates
+/// an Observation dependency; the timer increments `tick` on the main
+/// actor so SwiftUI re-evaluates the dependent body.
+///
+/// Matches Android's 5-second poll in `ClassTableViewModel` so the
+/// "Current class" card transitions within a few seconds of the
+/// wall-clock minute boundary, not up to a minute later.
+@MainActor
+@Observable
+final class MinuteTicker {
+    private(set) var tick: UInt64 = 0
+
+    @ObservationIgnored private var timer: Timer?
+
+    init(interval: TimeInterval = 5) {
+        // Tolerance gives the system room to coalesce wakeups with
+        // other timers — we don't need millisecond precision; the goal
+        // is "within a few seconds of the minute boundary".
+        let t = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            // Re-capture weakly inside the Task closure so Swift 6 strict
+            // concurrency doesn't complain about a strong self leaking
+            // through the @MainActor hop.
+            Task { @MainActor [weak self] in self?.tick &+= 1 }
+        }
+        t.tolerance = 1
+        timer = t
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+}

--- a/swift/TigerDuck/Features/ClassTable/ClassTableView.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableView.swift
@@ -215,6 +215,7 @@ struct ClassTableView: View {
                 courses: viewModel.todayCourses,
                 hasAssignment: viewModel.hasAssignment,
                 showProgress: false,
+                ongoing: viewModel.ongoingCourses,
                 onSelect: { viewModel.selectedCourse = $0 }
             )
         }

--- a/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
@@ -1,6 +1,11 @@
 import Defaults
 import SwiftUI
 
+/// `@MainActor` so the `MinuteTicker` stored property (a `@MainActor`
+/// type) can be constructed in the initializer, and so notification
+/// observer callbacks that mutate `@Observable` state aren't racing
+/// SwiftUI reads. Mirrors `CalendarViewModel` / `ScoreViewModel`.
+@MainActor
 @Observable
 final class ClassTableViewModel {
     var courses: [SDCourse] = [] {
@@ -115,8 +120,16 @@ final class ClassTableViewModel {
 
     private var hasLoaded = false
     private var isUpdatingFromNetwork = false
-    private var dataObserver: Any?
-    private var languageObserver: Any?
+    // `nonisolated(unsafe)` so `deinit` (which runs nonisolated even on a
+    // `@MainActor` class) can read these to remove the observers at end-
+    // of-life. `@ObservationIgnored` is required for the isolation
+    // modifier to take effect — without it the `@Observable` macro
+    // replaces the storage with a computed accessor and strips the
+    // modifier. Same pattern as `CalendarViewModel.dataObserver`.
+    @ObservationIgnored
+    private nonisolated(unsafe) var dataObserver: Any?
+    @ObservationIgnored
+    private nonisolated(unsafe) var languageObserver: Any?
 
     /// Guards the fire-and-forget pull-to-refresh path against overlapping
     /// fetches. ``triggerRefresh(authService:)`` flips this to `true` while
@@ -136,8 +149,14 @@ final class ClassTableViewModel {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            guard self?.isUpdatingFromNetwork != true else { return }
-            self?.reloadFromCache()
+            // Notification is delivered on the main queue, but the closure
+            // is `@Sendable` and crosses into a `@MainActor` class — hop
+            // explicitly so accessing `isUpdatingFromNetwork` / calling
+            // `reloadFromCache` is sound under strict concurrency.
+            Task { @MainActor [weak self] in
+                guard let self, !self.isUpdatingFromNetwork else { return }
+                self.reloadFromCache()
+            }
         }
 
         languageObserver = NotificationCenter.default.addObserver(

--- a/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
@@ -257,8 +257,32 @@ final class ClassTableViewModel {
         // `AppClockState.shared.version` into the read keeps SwiftUI
         // dependency tracking aware of debug-time-override flips.
         _ = AppClockState.shared.version
+        _ = minuteTicker.tick
         return currentSemesterCourses.coursesForToday()
     }
+
+    /// Courses whose contiguous period block contains the current
+    /// minute-of-day. Drives the leftmost "Current class" cards in the
+    /// today carousel (matches Android's `ongoingCourses`).
+    var ongoingCourses: [OngoingCourseInfo] {
+        _ = AppClockState.shared.version
+        _ = minuteTicker.tick
+        let now = AppClock.now()
+        let cal = AppConstants.taipeiCalendar
+        let comps = cal.dateComponents([.hour, .minute], from: now)
+        let minuteOfDay = (comps.hour ?? 0) * 60 + (comps.minute ?? 0)
+        return currentSemesterCourses.ongoingCourses(
+            weekday: now.scheduleWeekday,
+            minuteOfDay: minuteOfDay
+        )
+    }
+
+    /// 5-second ticker that re-publishes minute-of-day-derived state.
+    /// Matches Android's `_currentDayTime` poll so the "Current class"
+    /// card slides into view within a few seconds of the wall-clock
+    /// minute boundary, not up to a minute later.
+    @ObservationIgnored
+    private let minuteTicker = MinuteTicker()
 
     var activeWeekdays: [Int] {
         var days = Set<Int>()

--- a/swift/TigerDuck/Features/ClassTable/Components/CurrentClassCard.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CurrentClassCard.swift
@@ -49,7 +49,13 @@ struct CurrentClassCard: View {
                 .font(TigerDuckTheme.Typography.caption)
                 .foregroundStyle(Color.textSecondary)
         }
+        // Inner frame fixes the card's width; outer `maxHeight: .infinity`
+        // lets the colored surface stretch to whatever row height
+        // `EqualHeightHStack` settled on. Harmless when this is the
+        // tallest card in the row, and matches the pattern used in
+        // `TodayCourseCard` so shorter siblings can grow to match.
         .frame(width: width, alignment: .leading)
+        .frame(maxHeight: .infinity, alignment: .topLeading)
         .cardPadding()
         .background(info.course.color.opacity(0.22), in: RoundedRectangle(cornerRadius: TigerDuckTheme.CornerRadius.lg))
         .glassCard()

--- a/swift/TigerDuck/Features/ClassTable/Components/CurrentClassCard.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CurrentClassCard.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+/// "Current class" card — surfaces a course whose period block contains
+/// the current minute. Sits leftmost in the today carousel so the user's
+/// active class is the first thing they see when they open the class
+/// table. Mirrors the Android `CurrentClassCard` (red dot + label,
+/// course name, classroom, progress bar, time range).
+struct CurrentClassCard: View {
+    let info: OngoingCourseInfo
+    var hasAssignment: Bool = false
+    var width: CGFloat? = 200
+    var onTap: (() -> Void)? = nil
+
+    var body: some View {
+        // Like other clock-derived views, re-subscribe to debug-time
+        // flips so the progress bar updates when the override changes.
+        let _ = AppClockState.shared.version
+
+        let card = VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.sm) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(Color.red)
+                    .frame(width: 8, height: 8)
+                Text(String(localized: "course_card_current_class"))
+                    .font(.caption.bold())
+                    .foregroundStyle(Color.textPrimary)
+            }
+
+            Text(info.course.displayName)
+                .font(TigerDuckTheme.Typography.headline)
+                .foregroundStyle(Color.textPrimary)
+                .lineLimit(2)
+
+            let classroom = info.course.classroom(for: info.weekday)
+            if !classroom.isEmpty {
+                Text(classroom)
+                    .font(TigerDuckTheme.Typography.caption)
+                    .foregroundStyle(Color.textSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+
+            ProgressView(value: progress)
+                .progressViewStyle(.linear)
+                .tint(info.course.color)
+
+            Text(timeRange)
+                .font(TigerDuckTheme.Typography.caption)
+                .foregroundStyle(Color.textSecondary)
+        }
+        .frame(width: width, alignment: .leading)
+        .cardPadding()
+        .background(info.course.color.opacity(0.22), in: RoundedRectangle(cornerRadius: TigerDuckTheme.CornerRadius.lg))
+        .glassCard()
+        .overlay(alignment: .bottomTrailing) {
+            if hasAssignment {
+                Image(systemName: "book.closed")
+                    .font(.caption2)
+                    .foregroundStyle(Color.textSecondary)
+                    .padding(8)
+            }
+        }
+
+        if let onTap {
+            Button(action: onTap) { card }
+                .buttonStyle(.plain)
+        } else {
+            card
+        }
+    }
+
+    private var progress: Double {
+        let span = info.endMinute - info.startMinute
+        guard span > 0 else { return 0 }
+        let now = AppClock.now()
+        let comps = AppConstants.taipeiCalendar.dateComponents([.hour, .minute], from: now)
+        let minute = (comps.hour ?? 0) * 60 + (comps.minute ?? 0)
+        return min(max(Double(minute - info.startMinute) / Double(span), 0), 1)
+    }
+
+    private var timeRange: String {
+        "\(format(info.startMinute)) - \(format(info.endMinute))"
+    }
+
+    private func format(_ minutes: Int) -> String {
+        String(format: "%02d:%02d", minutes / 60, minutes % 60)
+    }
+}

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
@@ -8,25 +8,44 @@ struct CourseTimeCard: View {
     let onSelect: ((CourseTimeSlot) -> Void)?
     var policy: VisualStylePolicy = VisualStylePolicy(preset: .default)
 
+    /// Tallest content height observed during the slot's lifetime. As the
+    /// user drags the time slider the active state flips between
+    /// .inClass / .between / .beforeFirst / .afterLast — each state can
+    /// produce a card of slightly different intrinsic height (a two-line
+    /// course name in one, one-line in another). Locking to the tallest
+    /// seen value keeps the surrounding layout from jumping while the
+    /// user is on Home; the @State drops back to 0 only when the slot
+    /// (i.e. Home itself) leaves the hierarchy.
+    @State private var lockedHeight: CGFloat = 0
+
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(alignment: .top, spacing: 8) {
             switch state {
             case .inClass(let slot):
                 cardContent(slot: slot, opacity: 1.0)
+                    .reportCardHeight()
             case .between(let prev, let next):
                 if let prev {
                     cardContent(slot: prev, opacity: 0.5)
                         .frame(maxWidth: .infinity)
+                        .reportCardHeight()
                 }
                 if let next {
                     cardContent(slot: next, opacity: 0.5)
                         .frame(maxWidth: .infinity)
+                        .reportCardHeight()
                 }
             case .beforeFirst(let next):
                 cardContent(slot: next, opacity: 0.5)
+                    .reportCardHeight()
             case .afterLast(let prev):
                 cardContent(slot: prev, opacity: 0.5)
+                    .reportCardHeight()
             }
+        }
+        .lockCardHeight(lockedHeight)
+        .onPreferenceChange(MaxCardHeightKey.self) { newValue in
+            if newValue > lockedHeight { lockedHeight = newValue }
         }
         .animation(.smooth(duration: 0.35), value: state)
     }

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
@@ -8,44 +8,29 @@ struct CourseTimeCard: View {
     let onSelect: ((CourseTimeSlot) -> Void)?
     var policy: VisualStylePolicy = VisualStylePolicy(preset: .default)
 
-    /// Tallest content height observed during the slot's lifetime. As the
-    /// user drags the time slider the active state flips between
-    /// .inClass / .between / .beforeFirst / .afterLast — each state can
-    /// produce a card of slightly different intrinsic height (a two-line
-    /// course name in one, one-line in another). Locking to the tallest
-    /// seen value keeps the surrounding layout from jumping while the
-    /// user is on Home; the @State drops back to 0 only when the slot
-    /// (i.e. Home itself) leaves the hierarchy.
-    @State private var lockedHeight: CGFloat = 0
-
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
+        // EqualHeightHStack pins both branches (.inClass single card and
+        // .between dual cards) to the tallest natural height seen during
+        // Home's lifetime, so the slot doesn't jump when the user drags
+        // the slider between states with mildly different content heights.
+        EqualHeightHStack(alignment: .top, spacing: 8) {
             switch state {
             case .inClass(let slot):
                 cardContent(slot: slot, opacity: 1.0)
-                    .reportCardHeight()
             case .between(let prev, let next):
                 if let prev {
                     cardContent(slot: prev, opacity: 0.5)
                         .frame(maxWidth: .infinity)
-                        .reportCardHeight()
                 }
                 if let next {
                     cardContent(slot: next, opacity: 0.5)
                         .frame(maxWidth: .infinity)
-                        .reportCardHeight()
                 }
             case .beforeFirst(let next):
                 cardContent(slot: next, opacity: 0.5)
-                    .reportCardHeight()
             case .afterLast(let prev):
                 cardContent(slot: prev, opacity: 0.5)
-                    .reportCardHeight()
             }
-        }
-        .lockCardHeight(lockedHeight)
-        .onPreferenceChange(MaxCardHeightKey.self) { newValue in
-            if newValue > lockedHeight { lockedHeight = newValue }
         }
         .animation(.smooth(duration: 0.35), value: state)
     }

--- a/swift/TigerDuck/Features/Home/Components/TodayCourseCarousel.swift
+++ b/swift/TigerDuck/Features/Home/Components/TodayCourseCarousel.swift
@@ -10,14 +10,6 @@ struct TodayCourseCarousel: View {
     var ongoing: [OngoingCourseInfo] = []
     var onSelect: ((SDCourse) -> Void)? = nil
 
-    /// Tallest card height observed during the lifetime of this view. The
-    /// row pins every card to this value so the "Current class" card and
-    /// the regular today cards line up — once a card grows the row, it
-    /// stays grown until the user leaves the page (parent unmount drops
-    /// this back to 0). `@State` so we can monotonically grow it from
-    /// `onPreferenceChange`.
-    @State private var lockedCardHeight: CGFloat = 0
-
     private static let periodTimeFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "HH:mm"
@@ -35,15 +27,13 @@ struct TodayCourseCarousel: View {
             noCourseView
         } else {
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(alignment: .top, spacing: TigerDuckTheme.Spacing.md) {
+                EqualHeightHStack(alignment: .top, spacing: TigerDuckTheme.Spacing.md) {
                     ForEach(Array(ongoing.enumerated()), id: \.element.id) { index, info in
                         CurrentClassCard(
                             info: info,
                             hasAssignment: hasAssignment(info.course.courseNo),
                             onTap: { onSelect?(info.course) }
                         )
-                        .lockCardHeight(lockedCardHeight)
-                        .reportCardHeight()
                         // Extra breathing room after the last ongoing card
                         // before the regular today cards — mirrors the
                         // Android layout that separates the two groups
@@ -64,14 +54,9 @@ struct TodayCourseCarousel: View {
                         }
                         .buttonStyle(.plain)
                         .opacity(opacityForCourse(course))
-                        .lockCardHeight(lockedCardHeight)
-                        .reportCardHeight()
                     }
                 }
                 .padding(.horizontal, TigerDuckTheme.Spacing.lg)
-            }
-            .onPreferenceChange(MaxCardHeightKey.self) { newValue in
-                if newValue > lockedCardHeight { lockedCardHeight = newValue }
             }
         }
     }

--- a/swift/TigerDuck/Features/Home/Components/TodayCourseCarousel.swift
+++ b/swift/TigerDuck/Features/Home/Components/TodayCourseCarousel.swift
@@ -4,6 +4,10 @@ struct TodayCourseCarousel: View {
     let courses: [SDCourse]
     let hasAssignment: (String) -> Bool
     var showProgress: Bool = true
+    /// When non-empty, dedicated "Current class" cards render leftmost in
+    /// the carousel, ahead of the regular today cards. Mirrors Android's
+    /// `ongoingCourses` cards.
+    var ongoing: [OngoingCourseInfo] = []
     var onSelect: ((SDCourse) -> Void)? = nil
 
     private static let periodTimeFormatter: DateFormatter = {
@@ -19,11 +23,18 @@ struct TodayCourseCarousel: View {
         // `AppClockState.shared.version` here wires the view's dependency
         // graph to debug time-override flips.
         let _ = AppClockState.shared.version
-        if courses.isEmpty {
+        if courses.isEmpty && ongoing.isEmpty {
             noCourseView
         } else {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: TigerDuckTheme.Spacing.md) {
+                    ForEach(ongoing) { info in
+                        CurrentClassCard(
+                            info: info,
+                            hasAssignment: hasAssignment(info.course.courseNo),
+                            onTap: { onSelect?(info.course) }
+                        )
+                    }
                     ForEach(sortedCourses, id: \.courseNo) { course in
                         Button {
                             onSelect?(course)

--- a/swift/TigerDuck/Features/Home/Components/TodayCourseCarousel.swift
+++ b/swift/TigerDuck/Features/Home/Components/TodayCourseCarousel.swift
@@ -159,16 +159,30 @@ private struct TodayCourseCard: View {
                 .font(TigerDuckTheme.Typography.caption)
                 .foregroundStyle(Color.textSecondary)
 
-            Text(periods)
-                .font(TigerDuckTheme.Typography.caption)
-                .foregroundStyle(Color.textSecondary)
+            // Push the time row to the bottom so the card visually fills
+            // when stretched to match a taller sibling (e.g. the
+            // `CurrentClassCard`'s progress + time block). `minLength: 0`
+            // keeps short cards from forcing extra height when nothing is
+            // stretching them.
+            Spacer(minLength: 0)
 
             if let progress, isActive {
                 ProgressView(value: progress)
                     .tint(course.color)
             }
+
+            Text(periods)
+                .font(TigerDuckTheme.Typography.caption)
+                .foregroundStyle(Color.textSecondary)
         }
+        // Inner frame fixes the card's width; outer `maxHeight: .infinity`
+        // lets the colored surface stretch to whatever row height
+        // `EqualHeightHStack` settled on, so a short card visually
+        // matches a taller sibling like `CurrentClassCard`. `.topLeading`
+        // keeps content anchored to the top while the background grows
+        // downward.
         .frame(width: 140, alignment: .leading)
+        .frame(maxHeight: .infinity, alignment: .topLeading)
         .cardPadding()
         .background(course.color.opacity(0.15), in: RoundedRectangle(cornerRadius: TigerDuckTheme.CornerRadius.lg))
         .glassCard()

--- a/swift/TigerDuck/Features/Home/Components/TodayCourseCarousel.swift
+++ b/swift/TigerDuck/Features/Home/Components/TodayCourseCarousel.swift
@@ -10,6 +10,14 @@ struct TodayCourseCarousel: View {
     var ongoing: [OngoingCourseInfo] = []
     var onSelect: ((SDCourse) -> Void)? = nil
 
+    /// Tallest card height observed during the lifetime of this view. The
+    /// row pins every card to this value so the "Current class" card and
+    /// the regular today cards line up — once a card grows the row, it
+    /// stays grown until the user leaves the page (parent unmount drops
+    /// this back to 0). `@State` so we can monotonically grow it from
+    /// `onPreferenceChange`.
+    @State private var lockedCardHeight: CGFloat = 0
+
     private static let periodTimeFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "HH:mm"
@@ -27,13 +35,22 @@ struct TodayCourseCarousel: View {
             noCourseView
         } else {
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: TigerDuckTheme.Spacing.md) {
-                    ForEach(ongoing) { info in
+                HStack(alignment: .top, spacing: TigerDuckTheme.Spacing.md) {
+                    ForEach(Array(ongoing.enumerated()), id: \.element.id) { index, info in
                         CurrentClassCard(
                             info: info,
                             hasAssignment: hasAssignment(info.course.courseNo),
                             onTap: { onSelect?(info.course) }
                         )
+                        .lockCardHeight(lockedCardHeight)
+                        .reportCardHeight()
+                        // Extra breathing room after the last ongoing card
+                        // before the regular today cards — mirrors the
+                        // Android layout that separates the two groups
+                        // with a wider gap so "Current class" reads as a
+                        // distinct cluster, not just one more card.
+                        .padding(.trailing, index == ongoing.count - 1 && !sortedCourses.isEmpty
+                                 ? TigerDuckTheme.Spacing.md : 0)
                     }
                     ForEach(sortedCourses, id: \.courseNo) { course in
                         Button {
@@ -47,9 +64,14 @@ struct TodayCourseCarousel: View {
                         }
                         .buttonStyle(.plain)
                         .opacity(opacityForCourse(course))
+                        .lockCardHeight(lockedCardHeight)
+                        .reportCardHeight()
                     }
                 }
                 .padding(.horizontal, TigerDuckTheme.Spacing.lg)
+            }
+            .onPreferenceChange(MaxCardHeightKey.self) { newValue in
+                if newValue > lockedCardHeight { lockedCardHeight = newValue }
             }
         }
     }

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -7,6 +7,9 @@ struct LibraryView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var viewModel = LibraryViewModel()
     @State private var showNotImplementedAlert = false
+    /// Pre-boost brightness, captured the first time we max the screen
+    /// for the QR. `nil` means we are not currently overriding brightness.
+    @State private var savedBrightness: CGFloat?
 
     var body: some View {
         if embedded {
@@ -28,17 +31,46 @@ struct LibraryView: View {
         .onAppear {
             viewModel.load()
             viewModel.onAppear()
+            if viewModel.isLoggedIn { boostBrightness() }
         }
         .onDisappear {
             viewModel.onDisappear()
+            restoreBrightness()
+        }
+        .onChange(of: viewModel.isLoggedIn) { _, loggedIn in
+            if loggedIn { boostBrightness() } else { restoreBrightness() }
         }
         .onChange(of: scenePhase) { _, newPhase in
-            if newPhase == .active {
+            switch newPhase {
+            case .active:
                 viewModel.onAppear()
-            } else {
+                if viewModel.isLoggedIn { boostBrightness() }
+            case .background:
+                viewModel.stopTimers()
+                // Don't leave the device pinned at full brightness once
+                // the user is no longer looking at the QR.
+                restoreBrightness()
+            case .inactive:
+                viewModel.stopTimers()
+            @unknown default:
                 viewModel.stopTimers()
             }
         }
+    }
+
+    // MARK: - Brightness
+
+    private func boostBrightness() {
+        if savedBrightness == nil {
+            savedBrightness = UIScreen.main.brightness
+        }
+        UIScreen.main.brightness = 1.0
+    }
+
+    private func restoreBrightness() {
+        guard let saved = savedBrightness else { return }
+        UIScreen.main.brightness = saved
+        savedBrightness = nil
     }
 
     /// iPad rotates freely, so anchor the QR to vertical center to keep its

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -60,6 +60,7 @@ struct LibraryView: View {
 
     // MARK: - Brightness
 
+    #if os(iOS)
     private func boostBrightness() {
         if savedBrightness == nil {
             savedBrightness = UIScreen.main.brightness
@@ -72,6 +73,10 @@ struct LibraryView: View {
         UIScreen.main.brightness = saved
         savedBrightness = nil
     }
+    #else
+    private func boostBrightness() {}
+    private func restoreBrightness() {}
+    #endif
 
     /// iPad rotates freely, so anchor the QR to vertical center to keep its
     /// on-screen position stable across orientation changes. iPhone is

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -45,13 +45,13 @@ struct LibraryView: View {
             case .active:
                 viewModel.onAppear()
                 if viewModel.isLoggedIn { boostBrightness() }
-            case .background:
+            case .background, .inactive:
                 viewModel.stopTimers()
                 // Don't leave the device pinned at full brightness once
-                // the user is no longer looking at the QR.
+                // the user is no longer looking at the QR. Restore in
+                // `.inactive` too so a force-quit from Control Center
+                // or an incoming call doesn't strand the screen at 1.0.
                 restoreBrightness()
-            case .inactive:
-                viewModel.stopTimers()
             @unknown default:
                 viewModel.stopTimers()
             }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -51,6 +51,15 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
         .padding(.top, TigerDuckTheme.Spacing.xxl)
         .padding(.bottom, TigerDuckTheme.Spacing.xxl * 2)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Pin the page to the device's geometry instead of the keyboard's
+        // safe area — when the user focuses a field on the login page, the
+        // default SwiftUI behavior is to push the whole VStack (and so the
+        // "Sign in" / "Skip for now" actions) up above the keyboard. That
+        // makes the buttons jump on focus; we'd rather leave them anchored
+        // and let users dismiss the keyboard with the tap-to-dismiss
+        // gesture already on this view (the inner ScrollView also has
+        // .scrollDismissesKeyboard(.interactively) for finger scroll).
+        .ignoresSafeArea(.keyboard, edges: .bottom)
         .contentShape(Rectangle())
         .onTapGesture { UIApplication.dismissKeyboard() }
     }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -33,6 +33,15 @@ struct OnboardingView: View {
         }
         .tabViewStyle(.page(indexDisplayMode: .always))
         .background(Color.backgroundPrimary)
+        // Keyboard avoidance hits the TabView root, not the inner page
+        // VStacks — without this the login page's overall frame shrinks
+        // to fit above the keyboard, squeezing the credential ScrollView
+        // and dragging the Sign in / Skip-for-now actions up with it.
+        // Ignoring it at the TabView level keeps every page laid out
+        // against the device geometry; tap-to-dismiss on each page (and
+        // the inner ScrollView's interactive scroll-to-dismiss) still
+        // give the user a way to clear the keyboard.
+        .ignoresSafeArea(.keyboard, edges: .bottom)
         .contentShape(Rectangle())
         .onTapGesture { focusedField = nil }
         .onChange(of: currentPage) { _, _ in focusedField = nil }

--- a/swift/TigerDuck/Models/Domain/OngoingCourseInfo.swift
+++ b/swift/TigerDuck/Models/Domain/OngoingCourseInfo.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// One currently-running course block. Mirrors the Android
+/// `OngoingCourseInfo` payload so the iOS "Current class" card has the
+/// same data shape (start/end minutes are minutes-of-day under Taipei
+/// time, so the progress bar can be computed without re-parsing
+/// "HH:mm").
+struct OngoingCourseInfo: Identifiable {
+    let course: SDCourse
+    let weekday: Int
+    let firstPeriodId: String
+    /// Block start in minutes-of-day (Taipei).
+    let startMinute: Int
+    /// Block end in minutes-of-day (Taipei).
+    let endMinute: Int
+
+    var id: String { "\(course.courseNo)-\(weekday)-\(firstPeriodId)" }
+}
+
+extension Array where Element == SDCourse {
+    /// Returns the contiguous-period block of each course that is
+    /// currently running at the given `weekday` / `minuteOfDay`. Matches
+    /// the Android shared `computeOngoingCourses` so iOS and Android
+    /// surface the same "Current class" set.
+    ///
+    /// Periods are considered contiguous when adjacent in
+    /// `AppConstants.Periods.chronologicalOrder`. Only the first running
+    /// block per course is returned.
+    func ongoingCourses(weekday: Int, minuteOfDay: Int) -> [OngoingCourseInfo] {
+        var results: [OngoingCourseInfo] = []
+        for course in self {
+            guard let raw = course.schedule[weekday], !raw.isEmpty else { continue }
+            let periods = raw.sortedByPeriodOrder()
+            var blockStart = 0
+            while blockStart < periods.count {
+                var blockEnd = blockStart
+                while blockEnd + 1 < periods.count,
+                      periodOrder(periods[blockEnd + 1]) == periodOrder(periods[blockEnd]) + 1 {
+                    blockEnd += 1
+                }
+                let firstId = periods[blockStart]
+                let lastId = periods[blockEnd]
+                if let startMin = parseHm(AppConstants.PeriodTimes.mapping[firstId]?.start),
+                   let endMin = parseHm(AppConstants.PeriodTimes.mapping[lastId]?.end),
+                   (startMin...endMin).contains(minuteOfDay) {
+                    results.append(
+                        OngoingCourseInfo(
+                            course: course,
+                            weekday: weekday,
+                            firstPeriodId: firstId,
+                            startMinute: startMin,
+                            endMinute: endMin
+                        )
+                    )
+                    break
+                }
+                blockStart = blockEnd + 1
+            }
+        }
+        return results
+    }
+}
+
+private func periodOrder(_ periodId: String) -> Int {
+    AppConstants.Periods.chronologicalOrder.firstIndex(of: periodId) ?? Int.max
+}
+
+private func parseHm(_ hhmm: String?) -> Int? {
+    guard let hhmm else { return nil }
+    let parts = hhmm.split(separator: ":")
+    guard parts.count == 2,
+          let h = Int(parts[0]),
+          let m = Int(parts[1]) else { return nil }
+    return h * 60 + m
+}

--- a/swift/TigerDuck/Models/Domain/OngoingCourseInfo.swift
+++ b/swift/TigerDuck/Models/Domain/OngoingCourseInfo.swift
@@ -42,7 +42,7 @@ extension Array where Element == SDCourse {
                 let lastId = periods[blockEnd]
                 if let startMin = parseHm(AppConstants.PeriodTimes.mapping[firstId]?.start),
                    let endMin = parseHm(AppConstants.PeriodTimes.mapping[lastId]?.end),
-                   (startMin...endMin).contains(minuteOfDay) {
+                   (startMin..<endMin).contains(minuteOfDay) {
                     results.append(
                         OngoingCourseInfo(
                             course: course,

--- a/swift/TigerDuck/Models/Domain/OngoingCourseInfo.swift
+++ b/swift/TigerDuck/Models/Domain/OngoingCourseInfo.swift
@@ -24,8 +24,11 @@ extension Array where Element == SDCourse {
     /// surface the same "Current class" set.
     ///
     /// Periods are considered contiguous when adjacent in
-    /// `AppConstants.Periods.chronologicalOrder`. Only the first running
-    /// block per course is returned.
+    /// `AppConstants.Periods.chronologicalOrder` AND the prior period's
+    /// end time equals the next period's start time. Most periods have a
+    /// real break between them (e.g. P1 ends 09:00, P2 starts 09:10), so
+    /// without the touch-check we'd report a course as ongoing through
+    /// the break. Only the first running block per course is returned.
     func ongoingCourses(weekday: Int, minuteOfDay: Int) -> [OngoingCourseInfo] {
         var results: [OngoingCourseInfo] = []
         for course in self {
@@ -35,7 +38,8 @@ extension Array where Element == SDCourse {
             while blockStart < periods.count {
                 var blockEnd = blockStart
                 while blockEnd + 1 < periods.count,
-                      periodOrder(periods[blockEnd + 1]) == periodOrder(periods[blockEnd]) + 1 {
+                      periodOrder(periods[blockEnd + 1]) == periodOrder(periods[blockEnd]) + 1,
+                      periodsTouch(periods[blockEnd], periods[blockEnd + 1]) {
                     blockEnd += 1
                 }
                 let firstId = periods[blockStart]
@@ -63,6 +67,15 @@ extension Array where Element == SDCourse {
 
 private func periodOrder(_ periodId: String) -> Int {
     AppConstants.Periods.chronologicalOrder.firstIndex(of: periodId) ?? Int.max
+}
+
+/// True when `a` ends at the exact minute `b` starts (no break between
+/// them). Used to keep a course's running block from spanning a break.
+private func periodsTouch(_ a: String, _ b: String) -> Bool {
+    guard let aEnd = parseHm(AppConstants.PeriodTimes.mapping[a]?.end),
+          let bStart = parseHm(AppConstants.PeriodTimes.mapping[b]?.start)
+    else { return false }
+    return aEnd == bStart
 }
 
 private func parseHm(_ hhmm: String?) -> Int? {

--- a/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
@@ -36,6 +36,11 @@ struct MacClassTableView: View {
     @State private var isLoadingSemester = false
     @State private var tripleConflictError: TripleConflictError?
 
+    /// Drives the "Current class" row's wall-clock re-evaluation. Mac
+    /// state needs a per-instance ticker (View is a struct), so we
+    /// hold one on the @State graph and read its `tick` in `body`.
+    @State private var minuteTicker = MinuteTicker()
+
     /// Identifies a slot the add path tried to push into when it would
     /// have become a 3-course slot. `existing` is the two courses already
     /// scheduled there so the alert can name them.
@@ -101,6 +106,20 @@ struct MacClassTableView: View {
         )
     }
 
+    /// Courses currently running, computed against `AppClock.now()`.
+    /// Re-evaluated whenever `body` re-fires (via `minuteTicker.tick` /
+    /// `AppClockState.version`).
+    private var ongoingNow: [OngoingCourseInfo] {
+        let now = AppClock.now()
+        let cal = AppConstants.taipeiCalendar
+        let comps = cal.dateComponents([.hour, .minute], from: now)
+        let minuteOfDay = (comps.hour ?? 0) * 60 + (comps.minute ?? 0)
+        return courses.ongoingCourses(
+            weekday: now.scheduleWeekday,
+            minuteOfDay: minuteOfDay
+        )
+    }
+
     private var visiblePeriods: [String] {
         let occupied = Set(courses.flatMap { $0.schedule.values.flatMap { $0 } })
         return AppConstants.Periods.chronologicalOrder.filter {
@@ -109,6 +128,12 @@ struct MacClassTableView: View {
     }
 
     var body: some View {
+        // Subscribing to the minute ticker re-evaluates body every few
+        // seconds so the "Current class" row appears/disappears around
+        // each period boundary. Same trick we use elsewhere when
+        // observation can't track `AppClock.now()` directly.
+        let _ = AppClockState.shared.version
+        let _ = minuteTicker.tick
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
                 header
@@ -119,6 +144,9 @@ struct MacClassTableView: View {
                         emptyState
                     }
                 } else {
+                    if !ongoingNow.isEmpty {
+                        currentClassRow
+                    }
                     glassGridCard
                 }
             }
@@ -277,6 +305,27 @@ struct MacClassTableView: View {
     }
 
     // MARK: - Glass grid card
+
+    /// Horizontal scroll of "Current class" cards rendered above the grid
+    /// when one or more courses are currently running. Matches the iPhone
+    /// today-row treatment so live class state is the first thing the
+    /// user sees on the Mac class table.
+    private var currentClassRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 12) {
+                ForEach(ongoingNow) { info in
+                    CurrentClassCard(
+                        info: info,
+                        hasAssignment: DataCache.shared.loadAssignments()
+                            .hasUnfinished(for: info.course.courseNo),
+                        width: 220,
+                        onTap: { selectedSlot = SelectedSlot(course: info.course, weekday: info.weekday) }
+                    )
+                }
+            }
+            .padding(.vertical, 2)
+        }
+    }
 
     private var glassGridCard: some View {
         VStack(spacing: rowSpacing) {

--- a/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
@@ -36,11 +36,6 @@ struct MacClassTableView: View {
     @State private var isLoadingSemester = false
     @State private var tripleConflictError: TripleConflictError?
 
-    /// Drives the "Current class" row's wall-clock re-evaluation. Mac
-    /// state needs a per-instance ticker (View is a struct), so we
-    /// hold one on the @State graph and read its `tick` in `body`.
-    @State private var minuteTicker = MinuteTicker()
-
     /// Identifies a slot the add path tried to push into when it would
     /// have become a 3-course slot. `existing` is the two courses already
     /// scheduled there so the alert can name them.
@@ -106,20 +101,6 @@ struct MacClassTableView: View {
         )
     }
 
-    /// Courses currently running, computed against `AppClock.now()`.
-    /// Re-evaluated whenever `body` re-fires (via `minuteTicker.tick` /
-    /// `AppClockState.version`).
-    private var ongoingNow: [OngoingCourseInfo] {
-        let now = AppClock.now()
-        let cal = AppConstants.taipeiCalendar
-        let comps = cal.dateComponents([.hour, .minute], from: now)
-        let minuteOfDay = (comps.hour ?? 0) * 60 + (comps.minute ?? 0)
-        return courses.ongoingCourses(
-            weekday: now.scheduleWeekday,
-            minuteOfDay: minuteOfDay
-        )
-    }
-
     private var visiblePeriods: [String] {
         let occupied = Set(courses.flatMap { $0.schedule.values.flatMap { $0 } })
         return AppConstants.Periods.chronologicalOrder.filter {
@@ -128,12 +109,6 @@ struct MacClassTableView: View {
     }
 
     var body: some View {
-        // Subscribing to the minute ticker re-evaluates body every few
-        // seconds so the "Current class" row appears/disappears around
-        // each period boundary. Same trick we use elsewhere when
-        // observation can't track `AppClock.now()` directly.
-        let _ = AppClockState.shared.version
-        let _ = minuteTicker.tick
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
                 header
@@ -144,9 +119,6 @@ struct MacClassTableView: View {
                         emptyState
                     }
                 } else {
-                    if !ongoingNow.isEmpty {
-                        currentClassRow
-                    }
                     glassGridCard
                 }
             }
@@ -305,27 +277,6 @@ struct MacClassTableView: View {
     }
 
     // MARK: - Glass grid card
-
-    /// Horizontal scroll of "Current class" cards rendered above the grid
-    /// when one or more courses are currently running. Matches the iPhone
-    /// today-row treatment so live class state is the first thing the
-    /// user sees on the Mac class table.
-    private var currentClassRow: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 12) {
-                ForEach(ongoingNow) { info in
-                    CurrentClassCard(
-                        info: info,
-                        hasAssignment: DataCache.shared.loadAssignments()
-                            .hasUnfinished(for: info.course.courseNo),
-                        width: 220,
-                        onTap: { selectedSlot = SelectedSlot(course: info.course, weekday: info.weekday) }
-                    )
-                }
-            }
-            .padding(.vertical, 2)
-        }
-    }
 
     private var glassGridCard: some View {
         VStack(spacing: rowSpacing) {

--- a/swift/TigerDuck/Platform/Mac/MacWidgetCards.swift
+++ b/swift/TigerDuck/Platform/Mac/MacWidgetCards.swift
@@ -129,7 +129,7 @@ private struct NextClassWidgetCard: View {
                             .foregroundStyle(.secondary)
                         Spacer()
                         Text(primary.course.timeRange(for: primary.date.scheduleWeekday) ?? "")
-                            .font(.caption.monospacedDigit().weight(.semibold))
+                            .font(.title3.monospacedDigit().weight(.semibold))
                             .foregroundStyle(color)
                     }
                     if target.slots.count >= 2 {

--- a/swift/TigerDuck/Services/API/Library/LibraryService.swift
+++ b/swift/TigerDuck/Services/API/Library/LibraryService.swift
@@ -60,14 +60,15 @@ enum LibraryService {
         KeychainManager.loadString(key: AppConstants.KeychainKeys.libraryUsername)
     }
 
+    /// `@MainActor`-isolated so the broadcaster call below is an in-actor
+    /// sync call (no deferred Task). This preserves serialization — a
+    /// save followed by a clear runs broadcastSet → broadcastWipe in
+    /// program order — and keeps the calling boundary actor-safe under
+    /// strict concurrency.
+    @MainActor
     static func saveCredentials(username: String, password: String) {
         KeychainManager.saveString(key: AppConstants.KeychainKeys.libraryUsername, value: username)
         KeychainManager.saveString(key: AppConstants.KeychainKeys.libraryPassword, value: password)
-        // Synchronous broadcast: prevents a save/wipe race in which two
-        // deferred Tasks could land out of order on the MainActor queue
-        // and strand credentials on the watch after a logout-then-relogin
-        // (or vice-versa).
-        //
         // iOS-only: macOS has no paired watch surface and the broadcaster
         // (WatchConnectivity) isn't in the Mac target. Mirrors the
         // existing iOS-gating pattern used elsewhere in the watch path.
@@ -76,6 +77,8 @@ enum LibraryService {
         #endif
     }
 
+    /// See `saveCredentials` for the `@MainActor` rationale.
+    @MainActor
     static func clearCredentials() {
         KeychainManager.delete(key: AppConstants.KeychainKeys.libraryUsername)
         KeychainManager.delete(key: AppConstants.KeychainKeys.libraryPassword)
@@ -158,7 +161,7 @@ enum LibraryService {
                 throw error
             }
 
-            saveCredentials(username: username, password: password)
+            await saveCredentials(username: username, password: password)
             saveToken(loginData.token, expirationMs: loginData.expirationTimeStamp)
             return loginData.token
         } catch {

--- a/swift/TigerDuck/Services/API/Library/LibraryService.swift
+++ b/swift/TigerDuck/Services/API/Library/LibraryService.swift
@@ -67,14 +67,22 @@ enum LibraryService {
         // deferred Tasks could land out of order on the MainActor queue
         // and strand credentials on the watch after a logout-then-relogin
         // (or vice-versa).
+        //
+        // iOS-only: macOS has no paired watch surface and the broadcaster
+        // (WatchConnectivity) isn't in the Mac target. Mirrors the
+        // existing iOS-gating pattern used elsewhere in the watch path.
+        #if os(iOS)
         WatchLibraryCredentialBroadcaster.shared.broadcastSet(username: username, password: password)
+        #endif
     }
 
     static func clearCredentials() {
         KeychainManager.delete(key: AppConstants.KeychainKeys.libraryUsername)
         KeychainManager.delete(key: AppConstants.KeychainKeys.libraryPassword)
         clearToken()
+        #if os(iOS)
         WatchLibraryCredentialBroadcaster.shared.broadcastWipe()
+        #endif
     }
 
     private static var storedPassword: String? {

--- a/swift/TigerDuck/SharedUI/EqualHeightCards.swift
+++ b/swift/TigerDuck/SharedUI/EqualHeightCards.swift
@@ -1,16 +1,7 @@
 import SwiftUI
 
-/// Preference key used by horizontally-laid-out card rows (today
-/// carousel, time-machine card slot) to negotiate a shared height: each
-/// child reports its natural height, the parent reduces to the max, and
-/// then pushes that value back down so every card lines up with the
-/// tallest one.
-///
-/// Reduce uses `max` so the *tallest* contributor wins. Combined with a
-/// "monotonically grow" pattern in the consumer's `@State`, this gives a
-/// height that locks to whatever the tallest card seen during the
-/// parent's lifetime was — and only resets when the parent unmounts
-/// (i.e. the user leaves the page).
+/// Preference key shared by the equal-height row's hidden measurement
+/// layer. Reduce uses `max` so the tallest natural-height card wins.
 struct MaxCardHeightKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
@@ -18,36 +9,56 @@ struct MaxCardHeightKey: PreferenceKey {
     }
 }
 
-extension View {
-    /// Measures self and emits its height through `MaxCardHeightKey` so a
-    /// surrounding row can pick the tallest. Use on each card that
-    /// participates in the equal-height row.
-    func reportCardHeight() -> some View {
-        background(
+/// Horizontal row that forces every child to the height of the tallest
+/// natural-height child seen so far. The locked height only grows — when
+/// a later-arriving child renders taller, the row grows to match, and it
+/// never shrinks until the row leaves the view hierarchy (the user
+/// navigating away from the page).
+///
+/// Implementation: a visible HStack pinned to `lockedHeight` is shadowed
+/// by a hidden HStack rendering the same `content()` at its intrinsic
+/// (natural) height. The hidden layer feeds the max natural height back
+/// through `MaxCardHeightKey`, the consumer monotonically grows
+/// `lockedHeight`, and the visible layer pins every child to it. We
+/// can't measure the visible layer directly because its `.frame(height:)`
+/// echoes the locked value back — re-rendering `content()` in a hidden
+/// `.fixedSize(vertical:)` layer is the simplest way to get a true
+/// natural measurement without a custom Layout.
+struct EqualHeightHStack<Content: View>: View {
+    var alignment: VerticalAlignment = .top
+    var spacing: CGFloat? = nil
+    @ViewBuilder var content: () -> Content
+
+    @State private var lockedHeight: CGFloat = 0
+
+    var body: some View {
+        HStack(alignment: alignment, spacing: spacing) {
+            content()
+        }
+        .frame(height: lockedHeight > 0 ? lockedHeight : nil, alignment: .top)
+        .background(measurementLayer)
+        .onPreferenceChange(MaxCardHeightKey.self) { newValue in
+            if newValue > lockedHeight { lockedHeight = newValue }
+        }
+    }
+
+    private var measurementLayer: some View {
+        HStack(alignment: alignment, spacing: spacing) {
+            content()
+        }
+        // `.fixedSize(vertical: true)` lets each child report its
+        // intrinsic height regardless of what `.frame(height:)` would
+        // otherwise propose down — that's what makes the natural-height
+        // measurement independent of the visible layer's lock.
+        .fixedSize(horizontal: false, vertical: true)
+        .background(
             GeometryReader { proxy in
                 Color.clear
                     .preference(key: MaxCardHeightKey.self, value: proxy.size.height)
             }
         )
-    }
-
-    /// Grows self to at least `height` when it's > 0. Using `minHeight`
-    /// instead of a fixed `height` keeps a card that's naturally taller
-    /// than the current lock from being clipped — important because
-    /// `reportCardHeight()` is applied AFTER this modifier, so the
-    /// reported value would otherwise echo the locked height back and
-    /// the preference key would never see the real natural height of a
-    /// card that came in tall (e.g. CurrentClassCard rendering after a
-    /// shorter TodayCourseCard had already seeded the lock). The
-    /// consumer monotonically grows its `@State` from preference
-    /// updates, so within a couple of layout passes the row settles on
-    /// the genuine tallest height with no clipping.
-    @ViewBuilder
-    func lockCardHeight(_ height: CGFloat) -> some View {
-        if height > 0 {
-            self.frame(minHeight: height, alignment: .top)
-        } else {
-            self
-        }
+        .hidden()
+        .accessibilityHidden(true)
+        .allowsHitTesting(false)
     }
 }

--- a/swift/TigerDuck/SharedUI/EqualHeightCards.swift
+++ b/swift/TigerDuck/SharedUI/EqualHeightCards.swift
@@ -31,14 +31,21 @@ extension View {
         )
     }
 
-    /// Pins self to `height` when it's > 0. While the locked height is
-    /// still being measured (first frame), passes through so the natural
-    /// height is reported back to the preference key — otherwise we'd
-    /// dead-lock at 0.
+    /// Grows self to at least `height` when it's > 0. Using `minHeight`
+    /// instead of a fixed `height` keeps a card that's naturally taller
+    /// than the current lock from being clipped — important because
+    /// `reportCardHeight()` is applied AFTER this modifier, so the
+    /// reported value would otherwise echo the locked height back and
+    /// the preference key would never see the real natural height of a
+    /// card that came in tall (e.g. CurrentClassCard rendering after a
+    /// shorter TodayCourseCard had already seeded the lock). The
+    /// consumer monotonically grows its `@State` from preference
+    /// updates, so within a couple of layout passes the row settles on
+    /// the genuine tallest height with no clipping.
     @ViewBuilder
     func lockCardHeight(_ height: CGFloat) -> some View {
         if height > 0 {
-            self.frame(height: height, alignment: .top)
+            self.frame(minHeight: height, alignment: .top)
         } else {
             self
         }

--- a/swift/TigerDuck/SharedUI/EqualHeightCards.swift
+++ b/swift/TigerDuck/SharedUI/EqualHeightCards.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// Preference key used by horizontally-laid-out card rows (today
+/// carousel, time-machine card slot) to negotiate a shared height: each
+/// child reports its natural height, the parent reduces to the max, and
+/// then pushes that value back down so every card lines up with the
+/// tallest one.
+///
+/// Reduce uses `max` so the *tallest* contributor wins. Combined with a
+/// "monotonically grow" pattern in the consumer's `@State`, this gives a
+/// height that locks to whatever the tallest card seen during the
+/// parent's lifetime was — and only resets when the parent unmounts
+/// (i.e. the user leaves the page).
+struct MaxCardHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+extension View {
+    /// Measures self and emits its height through `MaxCardHeightKey` so a
+    /// surrounding row can pick the tallest. Use on each card that
+    /// participates in the equal-height row.
+    func reportCardHeight() -> some View {
+        background(
+            GeometryReader { proxy in
+                Color.clear
+                    .preference(key: MaxCardHeightKey.self, value: proxy.size.height)
+            }
+        )
+    }
+
+    /// Pins self to `height` when it's > 0. While the locked height is
+    /// still being measured (first frame), passes through so the natural
+    /// height is reported back to the preference key — otherwise we'd
+    /// dead-lock at 0.
+    @ViewBuilder
+    func lockCardHeight(_ height: CGFloat) -> some View {
+        if height > 0 {
+            self.frame(height: height, alignment: .top)
+        } else {
+            self
+        }
+    }
+}

--- a/swift/TigerDuck/SharedUI/EqualHeightCards.swift
+++ b/swift/TigerDuck/SharedUI/EqualHeightCards.swift
@@ -10,10 +10,14 @@ struct MaxCardHeightKey: PreferenceKey {
 }
 
 /// Horizontal row that forces every child to the height of the tallest
-/// natural-height child seen so far. The locked height only grows — when
-/// a later-arriving child renders taller, the row grows to match, and it
-/// never shrinks until the row leaves the view hierarchy (the user
-/// navigating away from the page).
+/// natural-height child seen so far. The locked height only grows during
+/// a single on-screen visit — when a later-arriving child renders taller,
+/// the row grows to match. It resets to zero on `.onDisappear` so the
+/// next time the page is shown the row re-measures from scratch; that
+/// matters in `TabView`, where SwiftUI keeps the view identity (and its
+/// `@State`) alive across tab switches, so a one-time tall child like
+/// the "current class" card wouldn't otherwise release its grip on the
+/// row height after the user leaves and comes back.
 ///
 /// Implementation: a visible HStack pinned to `lockedHeight` is shadowed
 /// by a hidden HStack rendering the same `content()` at its intrinsic
@@ -40,6 +44,7 @@ struct EqualHeightHStack<Content: View>: View {
         .onPreferenceChange(MaxCardHeightKey.self) { newValue in
             if newValue > lockedHeight { lockedHeight = newValue }
         }
+        .onDisappear { lockedHeight = 0 }
     }
 
     private var measurementLayer: some View {

--- a/swift/TigerDuckTests/MoodleHomeworkRegressionTests.swift
+++ b/swift/TigerDuckTests/MoodleHomeworkRegressionTests.swift
@@ -424,6 +424,7 @@ struct MoodleHomeworkRegressionTests {
         #expect(after.map(\.assignmentId) == ["y", "x"])
     }
 
+    @MainActor
     @Test func classTableViewModel_displayLabel_formatsSemesterCode() {
         let vm = ClassTableViewModel()
         #expect(vm.displayLabel(for: "1142") == "114-2")


### PR DESCRIPTION
## Summary
- Home + ClassTable: equal-height today/time-slider cards (hidden measurement layer + `EqualHeightCards`); leftmost "Current class" card while a class is running; close ongoing-boundary edge case.
- Library: max screen brightness while QR is shown; restore brightness when the view becomes inactive.
- Onboarding: keep login actions anchored when the keyboard appears; apply keyboard-ignore at the TabView root.
- macOS: enlarge next-class time range on the dashboard card; drop "Current class" row from `MacClassTableView`; gate `WatchLibraryCredentialBroadcaster` with `#if os(iOS)`.
- Misc: clear Swift 6 strict-concurrency warnings; skip stale relabel saves when a newer toggle cancels the task.

## Test plan
- [ ] Home + ClassTable today cards render at equal heights on iPhone SE and Pro Max widths
- [ ] "Current class" card appears only while a class is in session and disappears at the boundary
- [ ] Library QR maxes brightness on appear and restores on background / view dismiss
- [ ] Onboarding login buttons stay visible with the keyboard up
- [ ] macOS dashboard + class table render without the dropped row
- [ ] Build is clean of strict-concurrency warnings on iOS + macOS schemes