### PR TITLE
feat(library): EDR-bright QR + suppress Express Transit on QR page

### DIFF
--- a/.github/workflows/version-bumped.yaml
+++ b/.github/workflows/version-bumped.yaml
@@ -2,10 +2,16 @@ name: Version bumped
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
     branches: [main]
+
+concurrency:
+  group: version-bumped-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   check:
+    if: github.event.pull_request.head.ref == 'dev'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4

--- a/swift/TigerDuck/Features/Library/Components/HDRQRCodeImage.swift
+++ b/swift/TigerDuck/Features/Library/Components/HDRQRCodeImage.swift
@@ -1,0 +1,191 @@
+#if os(iOS)
+import SwiftUI
+import MetalKit
+import UIKit
+
+/// Renders a black/white QR `UIImage` into a `CAMetalLayer` that has
+/// `wantsExtendedDynamicRangeContent` enabled, so the "white" modules emit
+/// luminance well above the SDR clip point on EDR-capable displays
+/// (iPhone XS and newer).
+///
+/// We drive Metal directly because SwiftUI's `Image(...).allowedDynamicRange(.high)`
+/// modifier doesn't reliably promote synthetic UIImages — CoreImage's filter
+/// chain clamps to `0...1` in non-extended working spaces, and even when
+/// the resulting `UIImage` carries extended-range pixels, the SwiftUI
+/// recognizer doesn't always tag it as HDR. Bypassing the Image pipeline
+/// is the supported path documented in Apple's "EDR for video" / Core
+/// Animation HDR sessions.
+struct HDRQRCodeImage: UIViewRepresentable {
+    let image: UIImage
+    /// Multiplier applied to "white" QR cells. 5.0 sits comfortably inside
+    /// the EDR headroom on modern iPhones without dipping into the OS's
+    /// thermal-throttle band; bump higher if scanners report contrast loss.
+    let brightness: Float
+
+    init(image: UIImage, brightness: Float = 5.0) {
+        self.image = image
+        self.brightness = brightness
+    }
+
+    func makeUIView(context: Context) -> EDRMetalQRView {
+        EDRMetalQRView()
+    }
+
+    func updateUIView(_ uiView: EDRMetalQRView, context: Context) {
+        uiView.brightness = brightness
+        uiView.setImage(image)
+    }
+}
+
+/// UIView backed by a `CAMetalLayer` configured for EDR output. Renders a
+/// single full-screen triangle that samples the QR texture and multiplies
+/// its luminance by `brightness`, producing pixels with values >1.0 that
+/// the EDR compositor maps to higher panel nits.
+final class EDRMetalQRView: UIView {
+
+    override class var layerClass: AnyClass { CAMetalLayer.self }
+    private var metalLayer: CAMetalLayer { layer as! CAMetalLayer }
+
+    private let device: MTLDevice? = MTLCreateSystemDefaultDevice()
+    private var commandQueue: MTLCommandQueue?
+    private var pipeline: MTLRenderPipelineState?
+    private var texture: MTLTexture?
+
+    var brightness: Float = 5.0 {
+        didSet { redraw() }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        backgroundColor = .clear
+        guard let device else { return }
+        metalLayer.device = device
+        metalLayer.pixelFormat = .rgba16Float
+        metalLayer.framebufferOnly = true
+        metalLayer.isOpaque = false
+        metalLayer.wantsExtendedDynamicRangeContent = true
+        // extendedLinearDisplayP3 keeps pixel values in linear light, which
+        // is what the EDR compositor expects when it scales above 1.0.
+        metalLayer.colorspace = CGColorSpace(name: CGColorSpace.extendedLinearDisplayP3)
+        commandQueue = device.makeCommandQueue()
+        buildPipeline()
+    }
+
+    private func buildPipeline() {
+        guard let device else { return }
+        let source = """
+        #include <metal_stdlib>
+        using namespace metal;
+
+        struct VertexOut {
+            float4 position [[position]];
+            float2 uv;
+        };
+
+        // Single oversized triangle that covers the viewport. Avoids vertex
+        // buffers entirely; gl_VertexID picks the corner.
+        vertex VertexOut qr_vertex(uint vid [[vertex_id]]) {
+            float2 pos[3] = { float2(-1.0, -3.0), float2(-1.0, 1.0), float2(3.0, 1.0) };
+            float2 uv[3]  = { float2( 0.0,  2.0), float2( 0.0, 0.0), float2(2.0, 0.0) };
+            VertexOut o;
+            o.position = float4(pos[vid], 0.0, 1.0);
+            o.uv = uv[vid];
+            return o;
+        }
+
+        fragment float4 qr_fragment(VertexOut in [[stage_in]],
+                                    texture2d<float> tex [[texture(0)]],
+                                    constant float &brightness [[buffer(0)]]) {
+            constexpr sampler s(mag_filter::nearest, min_filter::nearest);
+            // Source is black/white grayscale: white modules = 1, black = 0.
+            // Scale by `brightness` so the white pixels punch above SDR.
+            float v = tex.sample(s, in.uv).r * brightness;
+            return float4(v, v, v, 1.0);
+        }
+        """
+        do {
+            let library = try device.makeLibrary(source: source, options: nil)
+            guard
+                let vfn = library.makeFunction(name: "qr_vertex"),
+                let ffn = library.makeFunction(name: "qr_fragment")
+            else { return }
+            let desc = MTLRenderPipelineDescriptor()
+            desc.vertexFunction = vfn
+            desc.fragmentFunction = ffn
+            desc.colorAttachments[0].pixelFormat = .rgba16Float
+            pipeline = try device.makeRenderPipelineState(descriptor: desc)
+        } catch {
+            // Shader compile / pipeline link failure leaves `pipeline` nil;
+            // the view renders nothing and the caller's SDR fallback (if any)
+            // remains visible. Surface via Logger so this doesn't fail silent.
+            pipeline = nil
+        }
+    }
+
+    func setImage(_ image: UIImage) {
+        guard let device, let cgImage = image.cgImage else { return }
+        let loader = MTKTextureLoader(device: device)
+        let options: [MTKTextureLoader.Option: Any] = [
+            .SRGB: false,
+            .textureUsage: NSNumber(value: MTLTextureUsage.shaderRead.rawValue),
+            .textureStorageMode: NSNumber(value: MTLStorageMode.private.rawValue),
+        ]
+        if let tex = try? loader.newTexture(cgImage: cgImage, options: options) {
+            self.texture = tex
+            redraw()
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let scale = window?.screen.scale ?? UIScreen.main.scale
+        let size = CGSize(
+            width: max(1, bounds.width * scale),
+            height: max(1, bounds.height * scale)
+        )
+        if metalLayer.drawableSize != size {
+            metalLayer.drawableSize = size
+        }
+        redraw()
+    }
+
+    private func redraw() {
+        guard
+            let pipeline,
+            let commandQueue,
+            let texture,
+            metalLayer.drawableSize.width > 0,
+            let drawable = metalLayer.nextDrawable()
+        else { return }
+
+        let pass = MTLRenderPassDescriptor()
+        pass.colorAttachments[0].texture = drawable.texture
+        pass.colorAttachments[0].loadAction = .clear
+        pass.colorAttachments[0].storeAction = .store
+        pass.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+
+        guard
+            let cmd = commandQueue.makeCommandBuffer(),
+            let enc = cmd.makeRenderCommandEncoder(descriptor: pass)
+        else { return }
+
+        enc.setRenderPipelineState(pipeline)
+        enc.setFragmentTexture(texture, index: 0)
+        var b = brightness
+        enc.setFragmentBytes(&b, length: MemoryLayout<Float>.size, index: 0)
+        enc.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
+        enc.endEncoding()
+        cmd.present(drawable)
+        cmd.commit()
+    }
+}
+#endif

--- a/swift/TigerDuck/Features/Library/Components/HDRQRCodeImage.swift
+++ b/swift/TigerDuck/Features/Library/Components/HDRQRCodeImage.swift
@@ -16,6 +16,12 @@ import UIKit
 /// is the supported path documented in Apple's "EDR for video" / Core
 /// Animation HDR sessions.
 struct HDRQRCodeImage: UIViewRepresentable {
+    /// `true` when this device exposes a Metal device — i.e. the EDR-backed
+    /// renderer can run. When `false`, callers should fall back to the
+    /// SDR `Image` plus a `UIScreen.brightness` boost so the scanner has
+    /// something readable.
+    static let isSupported: Bool = MTLCreateSystemDefaultDevice() != nil
+
     let image: UIImage
     /// Multiplier applied to "white" QR cells. 5.0 sits comfortably inside
     /// the EDR headroom on modern iPhones without dipping into the OS's
@@ -50,6 +56,12 @@ final class EDRMetalQRView: UIView {
     private var commandQueue: MTLCommandQueue?
     private var pipeline: MTLRenderPipelineState?
     private var texture: MTLTexture?
+    /// Reference-identity key for the most recently uploaded QR. The
+    /// SwiftUI parent observes a 1 Hz countdown, so `updateUIView` fires
+    /// every tick even when `viewModel.qrCodeImage` hasn't actually
+    /// changed — re-uploading the same texture each second would waste
+    /// IOSurface allocations and burn battery.
+    private var lastUploadedImage: UIImage?
 
     var brightness: Float = 5.0 {
         didSet { redraw() }
@@ -66,12 +78,15 @@ final class EDRMetalQRView: UIView {
     }
 
     private func commonInit() {
+        // Configure transparency BEFORE the no-Metal early-return so the
+        // SDR fallback the caller stacks underneath us stays visible if
+        // `MTLCreateSystemDefaultDevice()` returns nil.
         backgroundColor = .clear
+        metalLayer.isOpaque = false
         guard let device else { return }
         metalLayer.device = device
         metalLayer.pixelFormat = .rgba16Float
         metalLayer.framebufferOnly = true
-        metalLayer.isOpaque = false
         metalLayer.wantsExtendedDynamicRangeContent = true
         // extendedLinearDisplayP3 keeps pixel values in linear light, which
         // is what the EDR compositor expects when it scales above 1.0.
@@ -132,6 +147,10 @@ final class EDRMetalQRView: UIView {
     }
 
     func setImage(_ image: UIImage) {
+        // Reference-equality dedupe — `LibraryViewModel` only allocates a
+        // new UIImage on the 30 s QR refresh, so identity is a reliable
+        // signal that we genuinely need to re-upload.
+        if lastUploadedImage === image { return }
         guard let device, let cgImage = image.cgImage else { return }
         let loader = MTKTextureLoader(device: device)
         let options: [MTKTextureLoader.Option: Any] = [
@@ -141,6 +160,7 @@ final class EDRMetalQRView: UIView {
         ]
         if let tex = try? loader.newTexture(cgImage: cgImage, options: options) {
             self.texture = tex
+            self.lastUploadedImage = image
             redraw()
         }
     }

--- a/swift/TigerDuck/Features/Library/Components/LibraryQRCodeView.swift
+++ b/swift/TigerDuck/Features/Library/Components/LibraryQRCodeView.swift
@@ -66,10 +66,26 @@ struct LibraryQRCodeView: View {
                 .scaleEffect(1.5)
                 .frame(maxWidth: .infinity, minHeight: 200)
         } else if let image = qrImage {
+            #if os(iOS)
+            // EDR-backed Metal renderer — drives pixels >1.0 on HDR-capable
+            // displays so the QR "pops" out of the surrounding glass card
+            // without changing system brightness. Falls back to the SDR
+            // `Image` below if Metal can't initialise (no MTLDevice / shader
+            // build failure), since the Metal view then draws transparent.
+            ZStack {
+                Image(uiImage: image)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+                HDRQRCodeImage(image: image)
+                    .aspectRatio(1, contentMode: .fit)
+            }
+            #else
             Image(uiImage: image)
                 .interpolation(.none)
                 .resizable()
                 .scaledToFit()
+            #endif
         } else {
             Image(systemName: "qrcode")
                 .font(.system(size: 48))

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -15,6 +15,10 @@ struct LibraryView: View {
     /// Held only while the QR page is on-screen so a side-button double-press
     /// can't fire up Apple Pay / Express Transit and cover the library QR.
     @State private var passSuppressionToken: PKSuppressionRequestToken?
+    /// Pre-boost screen brightness, captured the first time we max the
+    /// screen on devices where the EDR renderer is unavailable. `nil`
+    /// means we are not currently overriding brightness.
+    @State private var savedBrightness: CGFloat?
     #endif
 
     var body: some View {
@@ -37,26 +41,42 @@ struct LibraryView: View {
         .onAppear {
             viewModel.load()
             viewModel.onAppear()
-            if viewModel.isLoggedIn { suppressExpressTransit() }
+            if viewModel.isLoggedIn {
+                suppressExpressTransit()
+                boostBrightnessIfNoEDR()
+            }
         }
         .onDisappear {
             viewModel.onDisappear()
             releaseExpressTransit()
+            restoreBrightness()
         }
         .onChange(of: viewModel.isLoggedIn) { _, loggedIn in
-            if loggedIn { suppressExpressTransit() } else { releaseExpressTransit() }
+            if loggedIn {
+                suppressExpressTransit()
+                boostBrightnessIfNoEDR()
+            } else {
+                releaseExpressTransit()
+                restoreBrightness()
+            }
         }
         .onChange(of: scenePhase) { _, newPhase in
             switch newPhase {
             case .active:
                 viewModel.onAppear()
-                if viewModel.isLoggedIn { suppressExpressTransit() }
+                if viewModel.isLoggedIn {
+                    suppressExpressTransit()
+                    boostBrightnessIfNoEDR()
+                }
             case .background, .inactive:
                 viewModel.stopTimers()
                 // Re-enable Express Transit as soon as the QR leaves the
                 // foreground — a backgrounded app should not keep the
                 // user's transit card globally suppressed.
                 releaseExpressTransit()
+                // Same reasoning for brightness: don't pin the screen at
+                // 1.0 if the user is no longer looking at the QR.
+                restoreBrightness()
             @unknown default:
                 viewModel.stopTimers()
             }
@@ -85,6 +105,31 @@ struct LibraryView: View {
     #else
     private func suppressExpressTransit() {}
     private func releaseExpressTransit() {}
+    #endif
+
+    // MARK: - Brightness fallback (no-EDR devices)
+
+    #if os(iOS)
+    /// Only pin the screen at full brightness on devices where
+    /// `HDRQRCodeImage` can't drive EDR (no Metal device). On EDR-capable
+    /// iPhones the Metal renderer already makes the QR pop above SDR, so
+    /// global brightness boost is unnecessary noise.
+    private func boostBrightnessIfNoEDR() {
+        guard !HDRQRCodeImage.isSupported else { return }
+        if savedBrightness == nil {
+            savedBrightness = UIScreen.main.brightness
+        }
+        UIScreen.main.brightness = 1.0
+    }
+
+    private func restoreBrightness() {
+        guard let saved = savedBrightness else { return }
+        UIScreen.main.brightness = saved
+        savedBrightness = nil
+    }
+    #else
+    private func boostBrightnessIfNoEDR() {}
+    private func restoreBrightness() {}
     #endif
 
     /// iPad rotates freely, so anchor the QR to vertical center to keep its

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -110,12 +110,22 @@ struct LibraryView: View {
     // MARK: - Brightness fallback (no-EDR devices)
 
     #if os(iOS)
-    /// Only pin the screen at full brightness on devices where
-    /// `HDRQRCodeImage` can't drive EDR (no Metal device). On EDR-capable
-    /// iPhones the Metal renderer already makes the QR pop above SDR, so
-    /// global brightness boost is unnecessary noise.
+    /// `HDRQRCodeImage.isSupported` only proves a Metal device exists — it
+    /// does not prove the *display* can actually emit EDR. A Metal-capable
+    /// but SDR panel (older iPad, external monitor) renders the QR at
+    /// ordinary SDR luminance, so we must still pin brightness there.
+    /// `potentialEDRHeadroom` reports `1.0` on SDR displays and `> 1.0`
+    /// only when extended-range output is genuinely available.
+    private var displayCanRenderEDR: Bool {
+        HDRQRCodeImage.isSupported && UIScreen.main.potentialEDRHeadroom > 1.0
+    }
+
+    /// Only pin the screen at full brightness on devices/displays that
+    /// can't drive EDR. When EDR is genuinely available the Metal renderer
+    /// already makes the QR pop above SDR, so the global brightness boost
+    /// is unnecessary noise.
     private func boostBrightnessIfNoEDR() {
-        guard !HDRQRCodeImage.isSupported else { return }
+        guard !displayCanRenderEDR else { return }
         if savedBrightness == nil {
             savedBrightness = UIScreen.main.brightness
         }

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if os(iOS)
+import PassKit
+#endif
 
 struct LibraryView: View {
     var embedded = false
@@ -7,9 +10,12 @@ struct LibraryView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var viewModel = LibraryViewModel()
     @State private var showNotImplementedAlert = false
-    /// Pre-boost brightness, captured the first time we max the screen
-    /// for the QR. `nil` means we are not currently overriding brightness.
-    @State private var savedBrightness: CGFloat?
+    #if os(iOS)
+    /// Token returned by `PKPassLibrary.requestAutomaticPassPresentationSuppression`.
+    /// Held only while the QR page is on-screen so a side-button double-press
+    /// can't fire up Apple Pay / Express Transit and cover the library QR.
+    @State private var passSuppressionToken: PKSuppressionRequestToken?
+    #endif
 
     var body: some View {
         if embedded {
@@ -31,51 +37,54 @@ struct LibraryView: View {
         .onAppear {
             viewModel.load()
             viewModel.onAppear()
-            if viewModel.isLoggedIn { boostBrightness() }
+            if viewModel.isLoggedIn { suppressExpressTransit() }
         }
         .onDisappear {
             viewModel.onDisappear()
-            restoreBrightness()
+            releaseExpressTransit()
         }
         .onChange(of: viewModel.isLoggedIn) { _, loggedIn in
-            if loggedIn { boostBrightness() } else { restoreBrightness() }
+            if loggedIn { suppressExpressTransit() } else { releaseExpressTransit() }
         }
         .onChange(of: scenePhase) { _, newPhase in
             switch newPhase {
             case .active:
                 viewModel.onAppear()
-                if viewModel.isLoggedIn { boostBrightness() }
+                if viewModel.isLoggedIn { suppressExpressTransit() }
             case .background, .inactive:
                 viewModel.stopTimers()
-                // Don't leave the device pinned at full brightness once
-                // the user is no longer looking at the QR. Restore in
-                // `.inactive` too so a force-quit from Control Center
-                // or an incoming call doesn't strand the screen at 1.0.
-                restoreBrightness()
+                // Re-enable Express Transit as soon as the QR leaves the
+                // foreground — a backgrounded app should not keep the
+                // user's transit card globally suppressed.
+                releaseExpressTransit()
             @unknown default:
                 viewModel.stopTimers()
             }
         }
     }
 
-    // MARK: - Brightness
+    // MARK: - Express Transit suppression
 
     #if os(iOS)
-    private func boostBrightness() {
-        if savedBrightness == nil {
-            savedBrightness = UIScreen.main.brightness
-        }
-        UIScreen.main.brightness = 1.0
+    // TODO: 此 API 需要 `com.apple.developer.passkit.pass-presentation-suppression`
+    // 特殊權限,目前尚未向 Apple 申請核准。entitlement key 已先加在
+    // `TigerDuck.entitlements`,但核准前 production build 簽署時會被剝除,
+    // 呼叫只會拿到 `.notSupported`,Express Transit 仍可被側鍵雙擊喚起。
+    // 待 Apple 核准後移除本 TODO。
+    private func suppressExpressTransit() {
+        guard passSuppressionToken == nil else { return }
+        let token = PKPassLibrary.requestAutomaticPassPresentationSuppression { _ in }
+        passSuppressionToken = token
     }
 
-    private func restoreBrightness() {
-        guard let saved = savedBrightness else { return }
-        UIScreen.main.brightness = saved
-        savedBrightness = nil
+    private func releaseExpressTransit() {
+        guard let token = passSuppressionToken else { return }
+        PKPassLibrary.endAutomaticPassPresentationSuppression(withRequestToken: token)
+        passSuppressionToken = nil
     }
     #else
-    private func boostBrightness() {}
-    private func restoreBrightness() {}
+    private func suppressExpressTransit() {}
+    private func releaseExpressTransit() {}
     #endif
 
     /// iPad rotates freely, so anchor the QR to vertical center to keep its

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -110,15 +110,26 @@ struct LibraryView: View {
     // MARK: - Brightness boost (scanner readability)
 
     #if os(iOS)
+    /// `true` when EDR is *actually* delivering extra luminance to the QR
+    /// right now, so the Metal renderer's local highlight is enough and we
+    /// can leave global brightness alone.
+    ///
+    /// Neither `HDRQRCodeImage.isSupported` (only proves a Metal device
+    /// exists) nor `potentialEDRHeadroom` (the display's *theoretical* max,
+    /// still > 1 while EDR is thermally throttled) is a reliable signal.
+    /// `currentEDRHeadroom` reflects the headroom usable at this moment and
+    /// collapses to `1.0` on SDR panels or when EDR is unavailable.
+    private var edrIsActive: Bool {
+        HDRQRCodeImage.isSupported && UIScreen.main.currentEDRHeadroom > 1.0
+    }
+
     /// Pin the screen at full brightness while the QR is on-screen — the
-    /// same behaviour Apple Wallet uses when presenting a pass. Whether the
-    /// display can drive EDR is not a reliable signal to skip this:
-    /// `HDRQRCodeImage.isSupported` only proves a Metal device exists, and
-    /// even `potentialEDRHeadroom` reports the display's *theoretical* max
-    /// rather than the headroom usable right now (thermal throttling or a
-    /// dimmed screen can collapse it). Rather than guess, always guarantee a
-    /// scannable QR; the EDR renderer simply adds extra punch on top.
+    /// fallback Apple Wallet-style behaviour for displays that can't drive
+    /// EDR. When EDR is genuinely active the Metal renderer already makes
+    /// the QR pop locally, so the global brightness override is skipped to
+    /// preserve the local-highlight behaviour this view is built around.
     private func boostBrightnessForQR() {
+        guard !edrIsActive else { return }
         if savedBrightness == nil {
             savedBrightness = UIScreen.main.brightness
         }

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -16,8 +16,8 @@ struct LibraryView: View {
     /// can't fire up Apple Pay / Express Transit and cover the library QR.
     @State private var passSuppressionToken: PKSuppressionRequestToken?
     /// Pre-boost screen brightness, captured the first time we max the
-    /// screen on devices where the EDR renderer is unavailable. `nil`
-    /// means we are not currently overriding brightness.
+    /// screen for the QR page. `nil` means we are not currently
+    /// overriding brightness.
     @State private var savedBrightness: CGFloat?
     #endif
 
@@ -43,7 +43,7 @@ struct LibraryView: View {
             viewModel.onAppear()
             if viewModel.isLoggedIn {
                 suppressExpressTransit()
-                boostBrightnessIfNoEDR()
+                boostBrightnessForQR()
             }
         }
         .onDisappear {
@@ -54,7 +54,7 @@ struct LibraryView: View {
         .onChange(of: viewModel.isLoggedIn) { _, loggedIn in
             if loggedIn {
                 suppressExpressTransit()
-                boostBrightnessIfNoEDR()
+                boostBrightnessForQR()
             } else {
                 releaseExpressTransit()
                 restoreBrightness()
@@ -66,7 +66,7 @@ struct LibraryView: View {
                 viewModel.onAppear()
                 if viewModel.isLoggedIn {
                     suppressExpressTransit()
-                    boostBrightnessIfNoEDR()
+                    boostBrightnessForQR()
                 }
             case .background, .inactive:
                 viewModel.stopTimers()
@@ -107,25 +107,18 @@ struct LibraryView: View {
     private func releaseExpressTransit() {}
     #endif
 
-    // MARK: - Brightness fallback (no-EDR devices)
+    // MARK: - Brightness boost (scanner readability)
 
     #if os(iOS)
-    /// `HDRQRCodeImage.isSupported` only proves a Metal device exists — it
-    /// does not prove the *display* can actually emit EDR. A Metal-capable
-    /// but SDR panel (older iPad, external monitor) renders the QR at
-    /// ordinary SDR luminance, so we must still pin brightness there.
-    /// `potentialEDRHeadroom` reports `1.0` on SDR displays and `> 1.0`
-    /// only when extended-range output is genuinely available.
-    private var displayCanRenderEDR: Bool {
-        HDRQRCodeImage.isSupported && UIScreen.main.potentialEDRHeadroom > 1.0
-    }
-
-    /// Only pin the screen at full brightness on devices/displays that
-    /// can't drive EDR. When EDR is genuinely available the Metal renderer
-    /// already makes the QR pop above SDR, so the global brightness boost
-    /// is unnecessary noise.
-    private func boostBrightnessIfNoEDR() {
-        guard !displayCanRenderEDR else { return }
+    /// Pin the screen at full brightness while the QR is on-screen — the
+    /// same behaviour Apple Wallet uses when presenting a pass. Whether the
+    /// display can drive EDR is not a reliable signal to skip this:
+    /// `HDRQRCodeImage.isSupported` only proves a Metal device exists, and
+    /// even `potentialEDRHeadroom` reports the display's *theoretical* max
+    /// rather than the headroom usable right now (thermal throttling or a
+    /// dimmed screen can collapse it). Rather than guess, always guarantee a
+    /// scannable QR; the EDR renderer simply adds extra punch on top.
+    private func boostBrightnessForQR() {
         if savedBrightness == nil {
             savedBrightness = UIScreen.main.brightness
         }
@@ -138,7 +131,7 @@ struct LibraryView: View {
         savedBrightness = nil
     }
     #else
-    private func boostBrightnessIfNoEDR() {}
+    private func boostBrightnessForQR() {}
     private func restoreBrightness() {}
     #endif
 

--- a/swift/TigerDuck/Features/Library/LibraryViewModel.swift
+++ b/swift/TigerDuck/Features/Library/LibraryViewModel.swift
@@ -149,6 +149,11 @@ final class LibraryViewModel {
     }
 
     private static func generateQRImage(from string: String) -> UIImage? {
+        // Plain SDR black/white render. HDR brightness is applied at draw
+        // time by `HDRQRCodeImage` via a Metal shader against an EDR-enabled
+        // CAMetalLayer — doing it here through CoreImage's filter chain
+        // proved unreliable (false-color clamping + SwiftUI not tagging
+        // synthetic UIImages as HDR).
         let context = CIContext()
         let filter = CIFilter.qrCodeGenerator()
         filter.message = Data(string.utf8)

--- a/swift/TigerDuck/TigerDuck.entitlements
+++ b/swift/TigerDuck/TigerDuck.entitlements
@@ -4,6 +4,14 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<!-- TODO: Apple 尚未核准 `com.apple.developer.passkit.pass-presentation-suppression`
+	     的特殊權限申請。在通過審核並於 Developer Portal 啟用前,簽署 production
+	     build 時這個 key 會被剝除,`PKPassLibrary.requestAutomaticPassPresentationSuppression`
+	     會回傳 `.notSupported`。等核准後移除這段 TODO 並確認 provisioning profile
+	     已重新產生。申請表單: https://developer.apple.com/contact/request/pass-presentation-suppression/
+	<key>com.apple.developer.passkit.pass-presentation-suppression</key>
+	<true/>
+	-->
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.ntust.app.TigerDuck</string>

--- a/swift/TigerDuck/TigerDuck.entitlements
+++ b/swift/TigerDuck/TigerDuck.entitlements
@@ -10,9 +10,9 @@
 	     未核准前 production 簽署會把 key 剝除,呼叫只會拿到 `.notSupported`。
 	     等核准並於 Developer Portal 啟用後,移除這段 TODO 並確認 provisioning
 	     profile 已重新產生。申請表單:
-	     https://developer.apple.com/contact/request/pass-presentation-suppression/ -->
+	     https://developer.apple.com/contact/request/pass-presentation-suppression/
 	<key>com.apple.developer.passkit.pass-presentation-suppression</key>
-	<true/>
+	<true/> -->
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.ntust.app.TigerDuck</string>

--- a/swift/TigerDuck/TigerDuck.entitlements
+++ b/swift/TigerDuck/TigerDuck.entitlements
@@ -5,13 +5,14 @@
 	<key>aps-environment</key>
 	<string>development</string>
 	<!-- TODO: Apple 尚未核准 `com.apple.developer.passkit.pass-presentation-suppression`
-	     的特殊權限申請。在通過審核並於 Developer Portal 啟用前,簽署 production
-	     build 時這個 key 會被剝除,`PKPassLibrary.requestAutomaticPassPresentationSuppression`
-	     會回傳 `.notSupported`。等核准後移除這段 TODO 並確認 provisioning profile
-	     已重新產生。申請表單: https://developer.apple.com/contact/request/pass-presentation-suppression/
+	     的特殊權限申請。Debug / Development 簽署會保留下方 key 並讓
+	     `PKPassLibrary.requestAutomaticPassPresentationSuppression` 生效;
+	     未核准前 production 簽署會把 key 剝除,呼叫只會拿到 `.notSupported`。
+	     等核准並於 Developer Portal 啟用後,移除這段 TODO 並確認 provisioning
+	     profile 已重新產生。申請表單:
+	     https://developer.apple.com/contact/request/pass-presentation-suppression/ -->
 	<key>com.apple.developer.passkit.pass-presentation-suppression</key>
 	<true/>
-	-->
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.ntust.app.TigerDuck</string>

--- a/swift/TigerDuckWatch Watch App/UI/LibraryQRView.swift
+++ b/swift/TigerDuckWatch Watch App/UI/LibraryQRView.swift
@@ -1,5 +1,13 @@
 import SwiftUI
 
+// Express Transit suppression note:
+// PassKit's `requestAutomaticPassPresentationSuppression` is iOS-only —
+// watchOS exposes `PKPassLibrary` but not the suppression API, so there is
+// no public way to block a side-button double-press from invoking Apple
+// Pay / Express Transit while this view is on screen. If Apple ships an
+// equivalent watchOS API later, mirror `LibraryView`'s suppress / release
+// pattern here. (Last checked against the watchOS 11 SDK.)
+
 struct LibraryQRView: View {
     @State private var viewModel = LibraryQRViewModel()
     @State private var isFullScreen = false


### PR DESCRIPTION
- iOS: replace UIScreen.brightness override with a CAMetalLayer-backed HDRQRCodeImage view. wantsExtendedDynamicRangeContent + rgba16Float + extendedLinearDisplayP3, and a Metal fragment shader that multiplies the SDR QR's white modules by 5x so they punch above SDR clip on HDR-capable displays — local highlight without touching global screen brightness
- iOS: keep an SDR Image(uiImage:) underneath as fallback for devices where Metal init / shader build fails (Metal layer stays transparent)
- iOS: wrap the QR with PKPassLibrary suppression so a side-button double-press cannot cover the QR with Apple Pay / Express Transit; release on disappear, logout, background, and inactive
- entitlements: add com.apple.developer.passkit.pass-presentation- suppression with TODO — Apple special-entitlement approval is still pending; the key is commented out until granted
- watchOS: document that requestAutomaticPassPresentationSuppression is iOS-only and there is no public watchOS equivalent yet