### PR TITLE
feat(a11y): VoiceOver labels pass

### DIFF
--- a/swift/TigerDuck/Features/Bulletins/Components/BulletinDetailView.swift
+++ b/swift/TigerDuck/Features/Bulletins/Components/BulletinDetailView.swift
@@ -111,6 +111,7 @@ struct BulletinDetailView: View {
             .font(TigerDuckTheme.Typography.title)
             .foregroundStyle(Color.textPrimary)
             .fixedSize(horizontal: false, vertical: true)
+            .accessibilityHeading(.h1)
     }
 
     private var footerTagStrip: some View {

--- a/swift/TigerDuck/Features/Calendar/Components/MonthCalendarView.swift
+++ b/swift/TigerDuck/Features/Calendar/Components/MonthCalendarView.swift
@@ -84,6 +84,20 @@ private struct DayCellView: View {
     let events: [SDCalendarEvent]
     let onTap: () -> Void
 
+    /// `a11y_calendar_day`'s date argument, pinned to the app's
+    /// Taipei/Gregorian calendar. The grid and the visible day-of-month label
+    /// both use `AppConstants.taipeiCalendar`; formatting with the device
+    /// default could announce the previous local day for a user west of
+    /// Taiwan, so the spoken date would disagree with the cell.
+    private var accessibleDateString: String {
+        date.formatted(Date.FormatStyle(
+            date: .complete,
+            time: .omitted,
+            calendar: AppConstants.taipeiCalendar,
+            timeZone: AppConstants.taipeiTimeZone
+        ))
+    }
+
     var body: some View {
         Button(action: onTap) {
             VStack(spacing: 2) {
@@ -121,7 +135,7 @@ private struct DayCellView: View {
         .accessibilityLabel(
             Text(String(
                 format: String(localized: "a11y_calendar_day"),
-                date.formatted(date: .complete, time: .omitted),
+                accessibleDateString,
                 events.count
             ))
         )

--- a/swift/TigerDuck/Features/Calendar/Components/MonthCalendarView.swift
+++ b/swift/TigerDuck/Features/Calendar/Components/MonthCalendarView.swift
@@ -30,6 +30,7 @@ struct MonthCalendarView: View {
                     Image(systemName: "chevron.left")
                         .foregroundStyle(Color.accentPrimary)
                 }
+                .accessibilityLabel(String(localized: "a11y_calendar_nav_prev"))
                 Spacer()
                 Text(monthTitle)
                     .font(TigerDuckTheme.Typography.headline)
@@ -39,6 +40,7 @@ struct MonthCalendarView: View {
                     Image(systemName: "chevron.right")
                         .foregroundStyle(Color.accentPrimary)
                 }
+                .accessibilityLabel(String(localized: "a11y_calendar_nav_next"))
             }
             .padding(.horizontal, TigerDuckTheme.Spacing.lg)
 
@@ -115,5 +117,14 @@ private struct DayCellView: View {
         }
         .buttonStyle(.plain)
         .frame(height: 40)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            Text(String(
+                format: String(localized: "a11y_calendar_day"),
+                date.formatted(date: .complete, time: .omitted),
+                events.count
+            ))
+        )
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
 }

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
@@ -56,9 +56,7 @@ struct CourseDetailSheet: View {
                             .font(.system(size: 22))
                             .foregroundStyle(Color.accentPrimary)
                     }
-                    // TODO(l10n): add `course_detail_open_moodle_a11y` —
-                    // "在 Moodle 開啟課程" / "Open course in Moodle"
-                    // .accessibilityLabel(String(localized: "course_detail_open_moodle_a11y"))
+                    .accessibilityLabel(String(localized: "a11y_course_detail_open_moodle"))
                 }
             }
 

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -1,5 +1,24 @@
 import SwiftUI
 
+/// Maps the codebase weekday convention (1=Mon, 2=Tue, ..., 7=Sun) to a
+/// localized short weekday name. DateFormatter's symbol arrays use a
+/// 1=Sunday convention, so we remap before indexing. The fallback to the
+/// raw int keeps VoiceOver labels usable even if symbol lookup fails.
+private func weekdayDisplayName(_ weekday: Int) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale.current
+    let symbols = formatter.shortStandaloneWeekdaySymbols ?? formatter.shortWeekdaySymbols ?? []
+    // Codebase: 1=Mon...6=Sat,7=Sun → DateFormatter index: 2=Mon...7=Sat,1=Sun
+    let dfIndex: Int
+    switch weekday {
+    case 1...6: dfIndex = weekday + 1 // Mon..Sat → 2..7
+    case 7: dfIndex = 1               // Sun → 1
+    default: dfIndex = 0
+    }
+    guard dfIndex >= 1, dfIndex <= symbols.count else { return "\(weekday)" }
+    return symbols[dfIndex - 1]
+}
+
 struct TimetableGridView: View {
     let viewModel: ClassTableViewModel
 
@@ -85,6 +104,14 @@ struct TimetableGridView: View {
                             .frame(height: totalHeight)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel(
+                        Text(String(
+                            format: String(localized: "a11y_timetable_cell"),
+                            weekdayDisplayName(weekday),
+                            viewModel.activePeriods.first { $0.id == periodId }?.displayLabel ?? periodId,
+                            course.displayName
+                        ))
+                    )
                     .contextMenu {
                         Button {
                             viewModel.startRename(course)
@@ -255,6 +282,14 @@ private struct ConflictClusterView: View {
                     weekday: weekday, periodId: periodId
                 )
             }
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel(
+                Text("\(String(localized: "a11y_class_table_conflict_prefix")): " +
+                     String(format: String(localized: "a11y_timetable_cell"),
+                            weekdayDisplayName(weekday),
+                            viewModel.activePeriods.first { $0.id == periodId }?.displayLabel ?? periodId,
+                            "\(courseA.displayName), \(courseB.displayName)"))
+            )
             .contextMenu {
                 conflictContextMenu()
             }
@@ -305,6 +340,13 @@ private struct ConflictClusterView: View {
                     .frame(height: blockHeight(span))
             }
             .buttonStyle(.plain)
+            .accessibilityLabel(
+                Text("\(String(localized: "a11y_class_table_conflict_prefix")): " +
+                     String(format: String(localized: "a11y_timetable_cell"),
+                            weekdayDisplayName(weekday),
+                            viewModel.activePeriods.first { $0.id == periodId }?.displayLabel ?? periodId,
+                            course.displayName))
+            )
             .contextMenu {
                 Button {
                     viewModel.startRename(course)

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
@@ -86,7 +86,10 @@ struct CourseTimeCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .modifier(CourseCardSurfaceModifier(tint: course.color, policy: policy))
         .opacity(opacity)
+        .contentShape(Rectangle())
         .onTapGesture { onSelect?(slot) }
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint(Text(String(localized: "a11y_course_card_open_details_hint")))
     }
 
     private func subtitle(for course: SDCourse, weekday: Int) -> String {

--- a/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
+++ b/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
@@ -107,10 +107,16 @@ struct UpcomingAssignmentsView: View {
         @ViewBuilder content: () -> Content
     ) -> some View {
         let actions = rowSwipeActions(for: assignment, now: now)
+        // Tapping the row opens the Moodle assignment link; when there is no
+        // deep link the tap is a no-op, so don't expose a button trait/hint.
+        let tapHint = assignment.moodleDeepLink == nil
+            ? nil
+            : String(localized: "a11y_course_detail_open_moodle")
         return SwipeableRow(
             leadingAction: actions.leading,
             trailingAction: actions.trailing,
             onTap: { openAssignment(assignment) },
+            tapHint: tapHint,
             content: content
         )
     }
@@ -273,6 +279,10 @@ private struct SwipeableRow<Content: View>: View {
     let leadingAction: SwipeActionDescriptor?
     let trailingAction: SwipeActionDescriptor?
     let onTap: () -> Void
+    /// VoiceOver hint describing what a tap does. `nil` when the row has no
+    /// tap destination — the row then exposes neither a button trait nor a
+    /// hint so assistive tech doesn't advertise an action that does nothing.
+    let tapHint: String?
     let content: Content
 
     @State private var offset: CGFloat = 0
@@ -284,30 +294,42 @@ private struct SwipeableRow<Content: View>: View {
         leadingAction: SwipeActionDescriptor?,
         trailingAction: SwipeActionDescriptor?,
         onTap: @escaping () -> Void,
+        tapHint: String?,
         @ViewBuilder content: () -> Content
     ) {
         self.leadingAction = leadingAction
         self.trailingAction = trailingAction
         self.onTap = onTap
+        self.tapHint = tapHint
         self.content = content()
     }
 
     var body: some View {
         ZStack {
             actionBackdrop
-            content
-                .contentShape(Rectangle())
-                .offset(x: offset)
-                .gesture(dragGesture)
-                .onTapGesture {
-                    if offset != 0 {
-                        snapBack()
-                    } else {
-                        onTap()
-                    }
+            tappableContent
+        }
+    }
+
+    @ViewBuilder
+    private var tappableContent: some View {
+        let row = content
+            .contentShape(Rectangle())
+            .offset(x: offset)
+            .gesture(dragGesture)
+            .onTapGesture {
+                if offset != 0 {
+                    snapBack()
+                } else {
+                    onTap()
                 }
+            }
+        if let tapHint {
+            row
                 .accessibilityAddTraits(.isButton)
-                .accessibilityHint(Text(String(localized: "a11y_course_card_open_details_hint")))
+                .accessibilityHint(Text(tapHint))
+        } else {
+            row
         }
     }
 

--- a/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
+++ b/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
@@ -306,6 +306,8 @@ private struct SwipeableRow<Content: View>: View {
                         onTap()
                     }
                 }
+                .accessibilityAddTraits(.isButton)
+                .accessibilityHint(Text(String(localized: "a11y_course_card_open_details_hint")))
         }
     }
 

--- a/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
+++ b/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
@@ -111,7 +111,7 @@ struct UpcomingAssignmentsView: View {
         // deep link the tap is a no-op, so don't expose a button trait/hint.
         let tapHint = assignment.moodleDeepLink == nil
             ? nil
-            : String(localized: "a11y_course_detail_open_moodle")
+            : String(localized: "a11y_assignment_open_moodle_hint")
         return SwipeableRow(
             leadingAction: actions.leading,
             trailingAction: actions.trailing,

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -156,9 +156,11 @@ struct OnboardingView: View {
                 Toggle(label, isOn: isOn)
             }
 
+            // Kept reachable by VoiceOver: the checkbox above is exposed as
+            // a Toggle, so this is the only way an assistive-tech user can
+            // open the privacy / delete-account page before accepting it.
             Link(label, destination: destination)
                 .font(.callout)
-                .accessibilityHidden(true)
         }
     }
 

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -152,9 +152,13 @@ struct OnboardingView: View {
             }
             .buttonStyle(.plain)
             .sensoryFeedback(.selection, trigger: isOn.wrappedValue)
+            .accessibilityRepresentation {
+                Toggle(label, isOn: isOn)
+            }
 
             Link(label, destination: destination)
                 .font(.callout)
+                .accessibilityHidden(true)
         }
     }
 


### PR DESCRIPTION
## Summary

PR 1 of 3 in a stacked accessibility series. Adds VoiceOver labels, hints, and traits so the app is navigable with the screen reader.

## Changes

- Re-enable the Moodle button VoiceOver label on course detail
- Represent the privacy checkbox as a `Toggle` so VoiceOver announces its state
- Label timetable cells with weekday / period / course context
- Label calendar nav chevrons ("Previous/Next month") and day cells ("[date], N events")
- Mark tap-on-`HStack` Home cards as buttons with a "double tap for details" hint
- Mark the bulletin title as a level-1 heading
- Bump the localization submodule for the 6 new a11y label keys

## Stack

- **PR1 → this** · base `dev`
- PR2 `feat/dynamic-type-fonts` · base `feat/voiceover-labels`
- PR3 `feat/reduce-motion-guards` · base `feat/dynamic-type-fonts`

## Testing

Build passes (`xcodebuild` → iPhone 17). Manual VoiceOver smoke test recommended before merge.