### PR TITLE
feat(a11y): Dynamic Type font sweep

### DIFF
--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -137,12 +137,13 @@ struct MainTabView: View {
 
 struct PlaceholderFeatureView: View {
     let feature: AppFeature
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 48
 
     var body: some View {
         NavigationStack {
             VStack(spacing: TigerDuckTheme.Spacing.lg) {
                 Image(systemName: feature.iconName)
-                    .font(.system(size: 48))
+                    .font(.system(size: heroIconSize))
                     .foregroundStyle(Color.accentPrimary)
                 Text(feature.displayName)
                     .font(TigerDuckTheme.Typography.title)

--- a/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
@@ -35,6 +35,8 @@ struct BulletinsView: View {
     @State private var searchIsPresented: Bool = false
     @State private var lastBackgroundedAt: Date?
 
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 36
+
     var body: some View {
         Group {
             if embedded {
@@ -300,7 +302,7 @@ struct BulletinsView: View {
     private func errorState(message: String) -> some View {
         VStack(spacing: TigerDuckTheme.Spacing.sm) {
             Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 36))
+                .font(.system(size: heroIconSize))
                 .foregroundStyle(Color.orange)
             Text(String(localized: "bulletin_load_failed_title"))
                 .font(TigerDuckTheme.Typography.headline)

--- a/swift/TigerDuck/Features/ClassTable/Components/AssignmentBadge.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/AssignmentBadge.swift
@@ -9,7 +9,7 @@ struct AssignmentCountBadge: View {
     var body: some View {
         if count > 0 {
             Text("\(count)")
-                .font(.system(size: 10, weight: .bold))
+                .font(.caption2.bold())
                 .foregroundStyle(.white)
                 .padding(.horizontal, 5)
                 .padding(.vertical, 2)

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseColorPickerSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseColorPickerSheet.swift
@@ -171,7 +171,7 @@ struct CourseColorPickerSheet: View {
                 }
             if isSelected {
                 Image(systemName: "checkmark")
-                    .font(.system(size: 16, weight: .bold))
+                    .font(.headline)
                     .foregroundStyle(.white)
                     .shadow(color: .black.opacity(0.25), radius: 1)
             }

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseColorPickerSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseColorPickerSheet.swift
@@ -171,7 +171,10 @@ struct CourseColorPickerSheet: View {
                 }
             if isSelected {
                 Image(systemName: "checkmark")
-                    .font(.headline)
+                    // Fixed size: the swatch circle (42pt) and row (50pt) are
+                    // fixed, so a dynamic font would let the checkmark grow
+                    // past the swatch at accessibility text sizes.
+                    .font(.system(size: 16, weight: .bold))
                     .foregroundStyle(.white)
                     .shadow(color: .black.opacity(0.25), radius: 1)
             }

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
@@ -53,7 +53,7 @@ struct CourseDetailSheet: View {
                 if course.moodleDeepLink != nil {
                     Button(action: openMoodleCourse) {
                         Image(systemName: "arrow.up.right.square.fill")
-                            .font(.system(size: 22))
+                            .font(.title2)
                             .foregroundStyle(Color.accentPrimary)
                     }
                     .accessibilityLabel(String(localized: "a11y_course_detail_open_moodle"))

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
@@ -202,7 +202,7 @@ private struct EmphasisCard: View {
                 .foregroundStyle(Color.textSecondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
             Text(value)
-                .font(.system(size: 22, weight: .semibold, design: .rounded))
+                .font(.system(.title2, design: .rounded).weight(.semibold).monospacedDigit())
                 .foregroundStyle(Color.textPrimary)
                 .lineLimit(2)
                 .minimumScaleFactor(0.7)

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -56,7 +56,7 @@ struct TimetableGridView: View {
                 HStack(spacing: colSpacing) {
                     // Period label
                     Text(period.displayLabel)
-                        .font(.system(size: 10))
+                        .font(.caption2)
                         .foregroundStyle(Color.textSecondary)
                         .lineLimit(1)
                         .minimumScaleFactor(0.7)
@@ -94,9 +94,10 @@ struct TimetableGridView: View {
                             .fill(course.color.opacity(0.4))
                             .overlay {
                                 Text(course.displayName)
-                                    .font(.system(size: 11, weight: .medium))
+                                    .font(.caption.weight(.medium))
                                     .foregroundStyle(Color.textPrimary)
                                     .lineLimit(spanCount > 1 ? 3 : 2)
+                                    .minimumScaleFactor(0.7)
                                     .multilineTextAlignment(.center)
                                     .padding(2)
                             }
@@ -169,6 +170,8 @@ private struct ConflictClusterView: View {
     let rowSpacing: CGFloat
     let weekday: Int
     let periodId: String
+
+    @ScaledMetric(relativeTo: .caption2) private var badgeIconSize: CGFloat = 8
 
     private var courseA: SDCourse { segments[0].course }
     private var spanA: Int { segments[0].span }
@@ -330,9 +333,10 @@ private struct ConflictClusterView: View {
                     .fill(course.color.opacity(0.4))
                     .overlay {
                         Text(course.displayName)
-                            .font(.system(size: 11, weight: .medium))
+                            .font(.caption.weight(.medium))
                             .foregroundStyle(Color.textPrimary)
                             .lineLimit(span > 1 ? 3 : 2)
+                            .minimumScaleFactor(0.7)
                             .multilineTextAlignment(.center)
                             .padding(2)
                     }
@@ -412,9 +416,10 @@ private struct ConflictClusterView: View {
                 // tail width). Aligning top-right (Γ) / bottom-left (L)
                 // keeps the text inside the visible color region.
                 Text(course.displayName)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.caption.weight(.medium))
                     .foregroundStyle(Color.textPrimary)
                     .lineLimit(2)
+                    .minimumScaleFactor(0.7)
                     .multilineTextAlignment(.center)
                     .padding(2)
                     .frame(
@@ -424,7 +429,7 @@ private struct ConflictClusterView: View {
 
                 if hasBadge {
                     Image(systemName: "book.fill")
-                        .font(.system(size: 8))
+                        .font(.system(size: badgeIconSize))
                         .foregroundStyle(Color.textPrimary.opacity(0.7))
                         .padding(3)
                 }

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -22,11 +22,14 @@ private func weekdayDisplayName(_ weekday: Int) -> String {
 struct TimetableGridView: View {
     let viewModel: ClassTableViewModel
 
-    private let cellHeight: CGFloat = 52
+    // Course-name cells render a dynamic `.caption` font; scale the row
+    // height with it so larger text gets more room instead of clipping.
+    @ScaledMetric(relativeTo: .caption) private var cellHeight: CGFloat = 52
     private let rowSpacing: CGFloat = 3
     private let colSpacing: CGFloat = 3
     private let headerHeight: CGFloat = 30
     private let periodWidth: CGFloat = 12
+    @ScaledMetric(relativeTo: .caption2) private var badgeIconSize: CGFloat = 8
 
     private static let allWeekdayLabels = AppConstants.Periods.weekdays + AppConstants.Periods.weekendDays
 
@@ -101,7 +104,7 @@ struct TimetableGridView: View {
                                     .multilineTextAlignment(.center)
                                     .padding(2)
                             }
-                            .assignmentBadge(show: hasBadge, iconSize: 8, padding: 4)
+                            .assignmentBadge(show: hasBadge, iconSize: badgeIconSize, padding: 4)
                             .frame(height: totalHeight)
                     }
                     .buttonStyle(.plain)
@@ -340,7 +343,7 @@ private struct ConflictClusterView: View {
                             .multilineTextAlignment(.center)
                             .padding(2)
                     }
-                    .assignmentBadge(show: hasBadge, iconSize: 8, padding: 4)
+                    .assignmentBadge(show: hasBadge, iconSize: badgeIconSize, padding: 4)
                     .frame(height: blockHeight(span))
             }
             .buttonStyle(.plain)

--- a/swift/TigerDuck/Features/Library/Components/LibraryQRCodeView.swift
+++ b/swift/TigerDuck/Features/Library/Components/LibraryQRCodeView.swift
@@ -11,6 +11,8 @@ struct LibraryQRCodeView: View {
     /// 1:1 aspect ratio below.
     private static let qrCodeMaxWidth: CGFloat = 250
 
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 48
+
     var body: some View {
         VStack(spacing: 0) {
             // Title bar
@@ -88,7 +90,7 @@ struct LibraryQRCodeView: View {
             #endif
         } else {
             Image(systemName: "qrcode")
-                .font(.system(size: 48))
+                .font(.system(size: heroIconSize))
                 .foregroundStyle(Color.textSecondary)
                 .frame(maxWidth: .infinity, minHeight: 200)
         }

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -21,6 +21,8 @@ struct LibraryView: View {
     @State private var savedBrightness: CGFloat?
     #endif
 
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 56
+
     var body: some View {
         if embedded {
             content
@@ -245,7 +247,7 @@ struct LibraryView: View {
     private var loginPrompt: some View {
         VStack(spacing: TigerDuckTheme.Spacing.lg) {
             Image(systemName: "qrcode")
-                .font(.system(size: 56))
+                .font(.system(size: heroIconSize))
                 .foregroundStyle(Color.accentPrimary)
 
             Text(String(localized: "library_login_qr_prompt"))

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -17,6 +17,8 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
     @ViewBuilder let content: () -> Content
     @ViewBuilder let actions: () -> Actions
 
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 64
+
     var body: some View {
         VStack(spacing: TigerDuckTheme.Spacing.lg) {
             iconView
@@ -71,7 +73,7 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
         switch iconAnimation {
         case .pulse:
             Image(systemName: icon)
-                .font(.system(size: 64))
+                .font(.system(size: heroIconSize))
                 .foregroundStyle(accentColor)
                 .symbolEffect(.pulse)
         case .layerFlash:
@@ -80,7 +82,7 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
             // pulse both layers).
             ZStack {
                 Image(systemName: "shield.fill")
-                    .font(.system(size: 64))
+                    .font(.system(size: heroIconSize))
                     .foregroundStyle(accentColor)
                 Image(systemName: "lock.fill")
                     .font(.system(size: 32, weight: .semibold))

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -85,10 +85,10 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
                     .font(.system(size: heroIconSize))
                     .foregroundStyle(accentColor)
                 Image(systemName: "lock.fill")
-                    .font(.system(size: 32, weight: .semibold))
+                    .font(.system(size: heroIconSize * 0.5, weight: .semibold))
                     .foregroundStyle(.white)
                     .symbolEffect(.pulse, options: .repeating.speed(0.35))
-                    .offset(y: -4)
+                    .offset(y: -heroIconSize / 16)
             }
         }
     }

--- a/swift/TigerDuck/Features/Score/Components/CreditSummaryBento.swift
+++ b/swift/TigerDuck/Features/Score/Components/CreditSummaryBento.swift
@@ -40,7 +40,9 @@ struct CreditSummaryBento: View {
 
             HStack(alignment: .lastTextBaseline, spacing: 4) {
                 Text("\(breakdown.total)")
-                    .font(.system(size: 34, weight: .bold, design: .rounded))
+                    .font(.system(.largeTitle, design: .rounded).weight(.bold).monospacedDigit())
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
                     .foregroundStyle(accent)
                 Text(String(localized: "course_detail_credits_label"))
                     .font(TigerDuckTheme.Typography.caption2)

--- a/swift/TigerDuck/Features/Score/Components/ScoreCourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/Score/Components/ScoreCourseDetailSheet.swift
@@ -59,7 +59,9 @@ struct ScoreCourseDetailSheet: View {
             }
             Spacer()
             Text(gradeDisplay)
-                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .font(.system(.largeTitle, design: .rounded).weight(.bold).monospacedDigit())
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
                 .foregroundStyle(gradeColor)
         }
         .padding(TigerDuckTheme.Spacing.md)

--- a/swift/TigerDuck/Features/Score/Components/ScoreCourseRow.swift
+++ b/swift/TigerDuck/Features/Score/Components/ScoreCourseRow.swift
@@ -75,7 +75,9 @@ private struct GradeChip: View {
                     .font(.caption2)
             }
             Text(descriptor.label)
-                .font(.system(size: 18, weight: .bold, design: .rounded))
+                .font(.system(.title3, design: .rounded).weight(.bold).monospacedDigit())
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
         }
         .foregroundStyle(descriptor.color)
         .padding(.horizontal, 10)

--- a/swift/TigerDuck/SharedUI/EmptyStateView.swift
+++ b/swift/TigerDuck/SharedUI/EmptyStateView.swift
@@ -5,10 +5,12 @@ struct EmptyStateView: View {
     let title: String
     var message: String? = nil
 
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 48
+
     var body: some View {
         VStack(spacing: TigerDuckTheme.Spacing.md) {
             Image(systemName: icon)
-                .font(.system(size: 48))
+                .font(.system(size: heroIconSize))
                 .foregroundStyle(Color.textSecondary)
             Text(title)
                 .font(TigerDuckTheme.Typography.headline)

--- a/swift/TigerDuck/SharedUI/LoginRequiredView.swift
+++ b/swift/TigerDuck/SharedUI/LoginRequiredView.swift
@@ -21,6 +21,8 @@ struct LoginRequiredView: View {
     let onPrimary: () -> Void
     var onSecondary: (() -> Void)? = nil
 
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 48
+
     var body: some View {
         switch layout {
         case .page:
@@ -33,7 +35,7 @@ struct LoginRequiredView: View {
     private var pageBody: some View {
         VStack(spacing: TigerDuckTheme.Spacing.lg) {
             Image(systemName: "lock.shield")
-                .font(.system(size: 48))
+                .font(.system(size: heroIconSize))
                 .foregroundStyle(Color.accentPrimary)
             Text(title)
                 .font(TigerDuckTheme.Typography.title)


### PR DESCRIPTION
## Summary

PR 2 of 3 in a stacked accessibility series. Replaces hard-coded font sizes with semantic / scaled fonts so text responds to the user's Larger Text setting.

## Changes

- Scale onboarding hero icons with Dynamic Type via `@ScaledMetric`
- Use semantic rounded-design fonts for the score / GPA number clusters
- Use semantic fonts for class table text and badges

## Stack

- PR1 `feat/voiceover-labels` · base `dev` (#141)
- **PR2 → this** · base `feat/voiceover-labels`
- PR3 `feat/reduce-motion-guards` · base `feat/dynamic-type-fonts`

> Review/merge after PR1. The diff against `dev` will shrink once PR1 merges.

## Testing

Build passes (`xcodebuild` → iPhone 17). Recommend checking layouts at Accessibility text size AX5 and back down to xSmall.