### PR TITLE
feat(a11y): land Dynamic Type sweep into dev

### DIFF
--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -137,12 +137,13 @@ struct MainTabView: View {
 
 struct PlaceholderFeatureView: View {
     let feature: AppFeature
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 48
 
     var body: some View {
         NavigationStack {
             VStack(spacing: TigerDuckTheme.Spacing.lg) {
                 Image(systemName: feature.iconName)
-                    .font(.system(size: 48))
+                    .font(.system(size: heroIconSize))
                     .foregroundStyle(Color.accentPrimary)
                 Text(feature.displayName)
                     .font(TigerDuckTheme.Typography.title)

--- a/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
@@ -35,6 +35,8 @@ struct BulletinsView: View {
     @State private var searchIsPresented: Bool = false
     @State private var lastBackgroundedAt: Date?
 
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 36
+
     var body: some View {
         Group {
             if embedded {
@@ -300,7 +302,7 @@ struct BulletinsView: View {
     private func errorState(message: String) -> some View {
         VStack(spacing: TigerDuckTheme.Spacing.sm) {
             Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 36))
+                .font(.system(size: heroIconSize))
                 .foregroundStyle(Color.orange)
             Text(String(localized: "bulletin_load_failed_title"))
                 .font(TigerDuckTheme.Typography.headline)

--- a/swift/TigerDuck/Features/ClassTable/Components/AssignmentBadge.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/AssignmentBadge.swift
@@ -9,7 +9,7 @@ struct AssignmentCountBadge: View {
     var body: some View {
         if count > 0 {
             Text("\(count)")
-                .font(.system(size: 10, weight: .bold))
+                .font(.caption2.bold())
                 .foregroundStyle(.white)
                 .padding(.horizontal, 5)
                 .padding(.vertical, 2)

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseColorPickerSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseColorPickerSheet.swift
@@ -171,7 +171,7 @@ struct CourseColorPickerSheet: View {
                 }
             if isSelected {
                 Image(systemName: "checkmark")
-                    .font(.system(size: 16, weight: .bold))
+                    .font(.headline)
                     .foregroundStyle(.white)
                     .shadow(color: .black.opacity(0.25), radius: 1)
             }

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseColorPickerSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseColorPickerSheet.swift
@@ -171,7 +171,10 @@ struct CourseColorPickerSheet: View {
                 }
             if isSelected {
                 Image(systemName: "checkmark")
-                    .font(.headline)
+                    // Fixed size: the swatch circle (42pt) and row (50pt) are
+                    // fixed, so a dynamic font would let the checkmark grow
+                    // past the swatch at accessibility text sizes.
+                    .font(.system(size: 16, weight: .bold))
                     .foregroundStyle(.white)
                     .shadow(color: .black.opacity(0.25), radius: 1)
             }

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
@@ -53,7 +53,7 @@ struct CourseDetailSheet: View {
                 if course.moodleDeepLink != nil {
                     Button(action: openMoodleCourse) {
                         Image(systemName: "arrow.up.right.square.fill")
-                            .font(.system(size: 22))
+                            .font(.title2)
                             .foregroundStyle(Color.accentPrimary)
                     }
                     .accessibilityLabel(String(localized: "a11y_course_detail_open_moodle"))

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
@@ -202,7 +202,7 @@ private struct EmphasisCard: View {
                 .foregroundStyle(Color.textSecondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
             Text(value)
-                .font(.system(size: 22, weight: .semibold, design: .rounded))
+                .font(.system(.title2, design: .rounded).weight(.semibold).monospacedDigit())
                 .foregroundStyle(Color.textPrimary)
                 .lineLimit(2)
                 .minimumScaleFactor(0.7)

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -171,6 +171,7 @@ private struct ConflictClusterView: View {
     let weekday: Int
     let periodId: String
 
+    @Environment(\.accessibilityDifferentiateWithoutColor) private var diffWithoutColor
     @ScaledMetric(relativeTo: .caption2) private var badgeIconSize: CGFloat = 8
 
     private var courseA: SDCourse { segments[0].course }
@@ -274,6 +275,15 @@ private struct ConflictClusterView: View {
                 .frame(width: proxy.size.width, height: bHeight)
                 .offset(y: bTop)
             }
+            .overlay(alignment: .topTrailing) {
+                if diffWithoutColor {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .padding(2)
+                        .accessibilityHidden(true)
+                }
+            }
             // One tap anywhere in the cluster opens the picker; the picker
             // resolves which course to inspect. Per-shape hit-testing would
             // bypass the picker entirely, but the Android version still goes
@@ -311,6 +321,15 @@ private struct ConflictClusterView: View {
         HStack(spacing: rowSpacing) {
             ForEach(segments, id: \.course.courseNo) { segment in
                 conflictColumn(segment: segment)
+            }
+        }
+        .overlay(alignment: .topTrailing) {
+            if diffWithoutColor {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .padding(2)
+                    .accessibilityHidden(true)
             }
         }
     }

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -56,7 +56,7 @@ struct TimetableGridView: View {
                 HStack(spacing: colSpacing) {
                     // Period label
                     Text(period.displayLabel)
-                        .font(.system(size: 10))
+                        .font(.caption2)
                         .foregroundStyle(Color.textSecondary)
                         .lineLimit(1)
                         .minimumScaleFactor(0.7)
@@ -94,9 +94,10 @@ struct TimetableGridView: View {
                             .fill(course.color.opacity(0.4))
                             .overlay {
                                 Text(course.displayName)
-                                    .font(.system(size: 11, weight: .medium))
+                                    .font(.caption.weight(.medium))
                                     .foregroundStyle(Color.textPrimary)
                                     .lineLimit(spanCount > 1 ? 3 : 2)
+                                    .minimumScaleFactor(0.7)
                                     .multilineTextAlignment(.center)
                                     .padding(2)
                             }
@@ -169,6 +170,8 @@ private struct ConflictClusterView: View {
     let rowSpacing: CGFloat
     let weekday: Int
     let periodId: String
+
+    @ScaledMetric(relativeTo: .caption2) private var badgeIconSize: CGFloat = 8
 
     private var courseA: SDCourse { segments[0].course }
     private var spanA: Int { segments[0].span }
@@ -330,9 +333,10 @@ private struct ConflictClusterView: View {
                     .fill(course.color.opacity(0.4))
                     .overlay {
                         Text(course.displayName)
-                            .font(.system(size: 11, weight: .medium))
+                            .font(.caption.weight(.medium))
                             .foregroundStyle(Color.textPrimary)
                             .lineLimit(span > 1 ? 3 : 2)
+                            .minimumScaleFactor(0.7)
                             .multilineTextAlignment(.center)
                             .padding(2)
                     }
@@ -412,9 +416,10 @@ private struct ConflictClusterView: View {
                 // tail width). Aligning top-right (Γ) / bottom-left (L)
                 // keeps the text inside the visible color region.
                 Text(course.displayName)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.caption.weight(.medium))
                     .foregroundStyle(Color.textPrimary)
                     .lineLimit(2)
+                    .minimumScaleFactor(0.7)
                     .multilineTextAlignment(.center)
                     .padding(2)
                     .frame(
@@ -424,7 +429,7 @@ private struct ConflictClusterView: View {
 
                 if hasBadge {
                     Image(systemName: "book.fill")
-                        .font(.system(size: 8))
+                        .font(.system(size: badgeIconSize))
                         .foregroundStyle(Color.textPrimary.opacity(0.7))
                         .padding(3)
                 }

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -29,7 +29,7 @@ struct TimetableGridView: View {
     private let periodWidth: CGFloat = 12
     @ScaledMetric(relativeTo: .caption2) private var badgeIconSize: CGFloat = 8
 
-    private let courseNameSize: CGFloat = 11
+    @ScaledMetric(relativeTo: .caption2) private var courseNameSize: CGFloat = 8
 
     private static let allWeekdayLabels = AppConstants.Periods.weekdays + AppConstants.Periods.weekendDays
 
@@ -176,7 +176,7 @@ private struct ConflictClusterView: View {
 
     @Environment(\.accessibilityDifferentiateWithoutColor) private var diffWithoutColor
     @ScaledMetric(relativeTo: .caption2) private var badgeIconSize: CGFloat = 8
-    private let courseNameSize: CGFloat = 11
+    @ScaledMetric(relativeTo: .caption2) private var courseNameSize: CGFloat = 8
 
     private var courseA: SDCourse { segments[0].course }
     private var spanA: Int { segments[0].span }

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -22,17 +22,14 @@ private func weekdayDisplayName(_ weekday: Int) -> String {
 struct TimetableGridView: View {
     let viewModel: ClassTableViewModel
 
-    // Scale the row height on the same Dynamic Type curve as the course
-    // name (`courseNameSize`, caption2-relative) so larger text gets more
-    // room instead of clipping.
-    @ScaledMetric(relativeTo: .caption2) private var cellHeight: CGFloat = 52
+    private let cellHeight: CGFloat = 52
     private let rowSpacing: CGFloat = 3
     private let colSpacing: CGFloat = 3
     private let headerHeight: CGFloat = 30
     private let periodWidth: CGFloat = 12
     @ScaledMetric(relativeTo: .caption2) private var badgeIconSize: CGFloat = 8
 
-    @ScaledMetric(relativeTo: .caption2) private var courseNameSize: CGFloat = 8
+    private let courseNameSize: CGFloat = 11
 
     private static let allWeekdayLabels = AppConstants.Periods.weekdays + AppConstants.Periods.weekendDays
 
@@ -179,7 +176,7 @@ private struct ConflictClusterView: View {
 
     @Environment(\.accessibilityDifferentiateWithoutColor) private var diffWithoutColor
     @ScaledMetric(relativeTo: .caption2) private var badgeIconSize: CGFloat = 8
-    @ScaledMetric(relativeTo: .caption2) private var courseNameSize: CGFloat = 8
+    private let courseNameSize: CGFloat = 11
 
     private var courseA: SDCourse { segments[0].course }
     private var spanA: Int { segments[0].span }

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -28,6 +28,8 @@ struct TimetableGridView: View {
     private let headerHeight: CGFloat = 30
     private let periodWidth: CGFloat = 12
 
+    @ScaledMetric(relativeTo: .caption2) private var courseNameSize: CGFloat = 8
+
     private static let allWeekdayLabels = AppConstants.Periods.weekdays + AppConstants.Periods.weekendDays
 
     private var weekdayLabels: [String] {
@@ -94,7 +96,7 @@ struct TimetableGridView: View {
                             .fill(course.color.opacity(0.4))
                             .overlay {
                                 Text(course.displayName)
-                                    .font(.caption.weight(.medium))
+                                    .font(.system(size: courseNameSize, weight: .medium))
                                     .foregroundStyle(Color.textPrimary)
                                     .lineLimit(spanCount > 1 ? 3 : 2)
                                     .minimumScaleFactor(0.7)
@@ -173,6 +175,7 @@ private struct ConflictClusterView: View {
 
     @Environment(\.accessibilityDifferentiateWithoutColor) private var diffWithoutColor
     @ScaledMetric(relativeTo: .caption2) private var badgeIconSize: CGFloat = 8
+    @ScaledMetric(relativeTo: .caption2) private var courseNameSize: CGFloat = 8
 
     private var courseA: SDCourse { segments[0].course }
     private var spanA: Int { segments[0].span }
@@ -352,7 +355,7 @@ private struct ConflictClusterView: View {
                     .fill(course.color.opacity(0.4))
                     .overlay {
                         Text(course.displayName)
-                            .font(.caption.weight(.medium))
+                            .font(.system(size: courseNameSize, weight: .medium))
                             .foregroundStyle(Color.textPrimary)
                             .lineLimit(span > 1 ? 3 : 2)
                             .minimumScaleFactor(0.7)
@@ -435,7 +438,7 @@ private struct ConflictClusterView: View {
                 // tail width). Aligning top-right (Γ) / bottom-left (L)
                 // keeps the text inside the visible color region.
                 Text(course.displayName)
-                    .font(.caption.weight(.medium))
+                    .font(.system(size: courseNameSize, weight: .medium))
                     .foregroundStyle(Color.textPrimary)
                     .lineLimit(2)
                     .minimumScaleFactor(0.7)

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -22,11 +22,14 @@ private func weekdayDisplayName(_ weekday: Int) -> String {
 struct TimetableGridView: View {
     let viewModel: ClassTableViewModel
 
-    private let cellHeight: CGFloat = 52
+    // Course-name cells render a dynamic `.caption` font; scale the row
+    // height with it so larger text gets more room instead of clipping.
+    @ScaledMetric(relativeTo: .caption) private var cellHeight: CGFloat = 52
     private let rowSpacing: CGFloat = 3
     private let colSpacing: CGFloat = 3
     private let headerHeight: CGFloat = 30
     private let periodWidth: CGFloat = 12
+    @ScaledMetric(relativeTo: .caption2) private var badgeIconSize: CGFloat = 8
 
     private static let allWeekdayLabels = AppConstants.Periods.weekdays + AppConstants.Periods.weekendDays
 
@@ -101,7 +104,7 @@ struct TimetableGridView: View {
                                     .multilineTextAlignment(.center)
                                     .padding(2)
                             }
-                            .assignmentBadge(show: hasBadge, iconSize: 8, padding: 4)
+                            .assignmentBadge(show: hasBadge, iconSize: badgeIconSize, padding: 4)
                             .frame(height: totalHeight)
                     }
                     .buttonStyle(.plain)
@@ -340,7 +343,7 @@ private struct ConflictClusterView: View {
                             .multilineTextAlignment(.center)
                             .padding(2)
                     }
-                    .assignmentBadge(show: hasBadge, iconSize: 8, padding: 4)
+                    .assignmentBadge(show: hasBadge, iconSize: badgeIconSize, padding: 4)
                     .frame(height: blockHeight(span))
             }
             .buttonStyle(.plain)

--- a/swift/TigerDuck/Features/Home/Components/ReorderDropSupport.swift
+++ b/swift/TigerDuck/Features/Home/Components/ReorderDropSupport.swift
@@ -1,5 +1,6 @@
 import CoreTransferable
 import SwiftUI
+import UIKit
 import UniformTypeIdentifiers
 
 extension UTType {
@@ -77,7 +78,7 @@ struct ReorderDropDelegate: DropDelegate {
             return
         }
 
-        withAnimation(.smoothSpring) {
+        withAnimation(UIAccessibility.isReduceMotionEnabled ? nil : .smoothSpring) {
             moveAction(fromOffsets, destination)
         }
         didReorder = true

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/TimeSliderViewModel.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/TimeSliderViewModel.swift
@@ -3,6 +3,8 @@ import UIKit
 
 @Observable
 final class TimeSliderViewModel {
+    private var prefersReducedMotion: Bool { UIAccessibility.isReduceMotionEnabled }
+
     // MARK: - Data
     var timeSlots: [CourseTimeSlot] = []
 
@@ -275,7 +277,7 @@ final class TimeSliderViewModel {
     }
 
     func returnToNow() {
-        withAnimation(.bouncy(duration: 0.6)) {
+        withAnimation(prefersReducedMotion ? nil : .bouncy(duration: 0.6)) {
             isUserDragging = false
             selectedTime = AppClock.now()
         }

--- a/swift/TigerDuck/Features/Home/Components/WidgetGridEditMode.swift
+++ b/swift/TigerDuck/Features/Home/Components/WidgetGridEditMode.swift
@@ -4,6 +4,7 @@ struct WidgetGridEditMode: View {
     @Binding var widgets: [WidgetItem]
     @Binding var isEditing: Bool
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let availableFeatures = AppFeature.widgetFeatures
 
     var body: some View {
@@ -20,7 +21,7 @@ struct WidgetGridEditMode: View {
                         isEditing: .constant(true),
                         dragContainerID: "widget-grid-edit-mode",
                         onRemove: { widget in
-                            withAnimation(.smoothSpring) {
+                            withAnimation(reduceMotion ? nil : .smoothSpring) {
                                 widgets.removeAll { $0.id == widget.id }
                             }
                         }
@@ -40,7 +41,7 @@ struct WidgetGridEditMode: View {
                     ) {
                         ForEach(addable) { feature in
                             Button {
-                                withAnimation(.smoothSpring) {
+                                withAnimation(reduceMotion ? nil : .smoothSpring) {
                                     widgets.append(
                                         WidgetItem(
                                             id: UUID().uuidString,

--- a/swift/TigerDuck/Features/Home/Components/WidgetGridView.swift
+++ b/swift/TigerDuck/Features/Home/Components/WidgetGridView.swift
@@ -9,6 +9,7 @@ struct WidgetGridView: View {
     var onAdd: (() -> Void)? = nil
     var onReorder: (() -> Void)? = nil
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var activeWidgetDrag: ReorderDragPayload?
     @State private var didReorder = false
 
@@ -76,7 +77,7 @@ struct WidgetGridView: View {
             card
                 .onTapGesture { onTap?(widget.feature) }
                 .onLongPressGesture {
-                    withAnimation(.smoothSpring) { isEditing = true }
+                    withAnimation(reduceMotion ? nil : .smoothSpring) { isEditing = true }
                 }
         }
     }
@@ -160,26 +161,27 @@ extension View {
 
 struct WiggleModifier: ViewModifier {
     let isWiggling: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var angle: Double = 0
 
     func body(content: Content) -> some View {
         content
-            .rotationEffect(.degrees(isWiggling ? angle : 0))
+            .rotationEffect(.degrees(isWiggling && !reduceMotion ? angle : 0))
             .onAppear {
-                if isWiggling {
+                if isWiggling, !reduceMotion {
                     withAnimation(.linear(duration: 0.15).repeatForever(autoreverses: true)) {
                         angle = 1.5
                     }
                 }
             }
             .onChange(of: isWiggling) { _, newValue in
-                if newValue {
+                if newValue, !reduceMotion {
                     angle = -1.5
                     withAnimation(.linear(duration: 0.15).repeatForever(autoreverses: true)) {
                         angle = 1.5
                     }
                 } else {
-                    withAnimation(.quickSpring) {
+                    withAnimation(reduceMotion ? nil : .quickSpring) {
                         angle = 0
                     }
                 }

--- a/swift/TigerDuck/Features/Home/HomeView.swift
+++ b/swift/TigerDuck/Features/Home/HomeView.swift
@@ -6,6 +6,7 @@ struct HomeView: View {
     var embedded = false
 
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var viewModel = HomeViewModel()
     @State private var showAddSection = false
     @State private var showNotImplementedAlert = false
@@ -74,7 +75,7 @@ struct HomeView: View {
             .contentShape(Rectangle())
             .onLongPressGesture {
                 if !viewModel.isEditingHome {
-                    withAnimation(.smoothSpring) {
+                    withAnimation(reduceMotion ? nil : .smoothSpring) {
                         viewModel.isEditingHome = true
                     }
                 }
@@ -109,7 +110,7 @@ struct HomeView: View {
                         .accessibilityLabel(Text("home_add_section_title"))
                     }
                     Button(String(localized: "action_done")) {
-                        withAnimation(.smoothSpring) {
+                        withAnimation(reduceMotion ? nil : .smoothSpring) {
                             finishSectionDrag()
                             viewModel.isEditingHome = false
                         }
@@ -201,7 +202,7 @@ struct HomeView: View {
         .overlay(alignment: .topTrailing) {
             if viewModel.isEditingHome {
                 Button {
-                    withAnimation(.smoothSpring) {
+                    withAnimation(reduceMotion ? nil : .smoothSpring) {
                         viewModel.removeSection(section)
                     }
                 } label: {
@@ -297,6 +298,8 @@ private struct HomeSectionView: View {
     let appState: AppState
     var onFeatureTap: ((AppFeature) -> Void)? = nil
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @ViewBuilder
     private var upcomingAssignmentsContent: some View {
         VStack(spacing: TigerDuckTheme.Spacing.sm) {
@@ -386,7 +389,7 @@ private struct HomeSectionView: View {
                     ),
                     dragContainerID: section.id,
                     onRemove: { widget in
-                        withAnimation(.smoothSpring) {
+                        withAnimation(reduceMotion ? nil : .smoothSpring) {
                             viewModel.removeWidget(from: section.id, widget: widget)
                         }
                     },

--- a/swift/TigerDuck/Features/Home/HomeViewModel.swift
+++ b/swift/TigerDuck/Features/Home/HomeViewModel.swift
@@ -1,9 +1,12 @@
 import SwiftUI
+import UIKit
 import Defaults
 
 @Observable
 final class HomeViewModel {
     private static let assignmentMutationAnimation = Animation.snappy(duration: 0.28, extraBounce: 0)
+
+    private var prefersReducedMotion: Bool { UIAccessibility.isReduceMotionEnabled }
 
     var sections: [HomeSection] = []
     var allCourses: [SDCourse] = []
@@ -215,7 +218,7 @@ final class HomeViewModel {
 
     func archiveAssignment(_ assignment: SDAssignment) {
         guard let idx = allAssignmentsCache.firstIndex(where: { $0.assignmentId == assignment.assignmentId }) else { return }
-        withAnimation(Self.assignmentMutationAnimation) {
+        withAnimation(prefersReducedMotion ? nil : Self.assignmentMutationAnimation) {
             allAssignmentsCache[idx].isArchived = true
             DataCache.shared.addArchivedAssignmentId(assignment.assignmentId)
             recomputeUpcomingAssignments()
@@ -224,7 +227,7 @@ final class HomeViewModel {
 
     func unarchiveAssignment(_ assignment: SDAssignment) {
         guard let idx = allAssignmentsCache.firstIndex(where: { $0.assignmentId == assignment.assignmentId }) else { return }
-        withAnimation(Self.assignmentMutationAnimation) {
+        withAnimation(prefersReducedMotion ? nil : Self.assignmentMutationAnimation) {
             allAssignmentsCache[idx].isArchived = false
             DataCache.shared.removeArchivedAssignmentId(assignment.assignmentId)
             recomputeUpcomingAssignments()
@@ -233,7 +236,7 @@ final class HomeViewModel {
 
     func markAssignmentAsLocallyCompleted(_ assignment: SDAssignment) {
         guard let idx = allAssignmentsCache.firstIndex(where: { $0.assignmentId == assignment.assignmentId }) else { return }
-        withAnimation(Self.assignmentMutationAnimation) {
+        withAnimation(prefersReducedMotion ? nil : Self.assignmentMutationAnimation) {
             allAssignmentsCache[idx].isLocallyCompleted = true
             DataCache.shared.addLocallyCompletedAssignmentId(assignment.assignmentId)
             recomputeUpcomingAssignments()
@@ -242,7 +245,7 @@ final class HomeViewModel {
 
     func undoLocallyCompleted(_ assignment: SDAssignment) {
         guard let idx = allAssignmentsCache.firstIndex(where: { $0.assignmentId == assignment.assignmentId }) else { return }
-        withAnimation(Self.assignmentMutationAnimation) {
+        withAnimation(prefersReducedMotion ? nil : Self.assignmentMutationAnimation) {
             allAssignmentsCache[idx].isLocallyCompleted = false
             DataCache.shared.removeLocallyCompletedAssignmentId(assignment.assignmentId)
             recomputeUpcomingAssignments()

--- a/swift/TigerDuck/Features/Library/Components/LibraryQRCodeView.swift
+++ b/swift/TigerDuck/Features/Library/Components/LibraryQRCodeView.swift
@@ -11,6 +11,8 @@ struct LibraryQRCodeView: View {
     /// 1:1 aspect ratio below.
     private static let qrCodeMaxWidth: CGFloat = 250
 
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 48
+
     var body: some View {
         VStack(spacing: 0) {
             // Title bar
@@ -88,7 +90,7 @@ struct LibraryQRCodeView: View {
             #endif
         } else {
             Image(systemName: "qrcode")
-                .font(.system(size: 48))
+                .font(.system(size: heroIconSize))
                 .foregroundStyle(Color.textSecondary)
                 .frame(maxWidth: .infinity, minHeight: 200)
         }

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -21,6 +21,8 @@ struct LibraryView: View {
     @State private var savedBrightness: CGFloat?
     #endif
 
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 56
+
     var body: some View {
         if embedded {
             content
@@ -245,7 +247,7 @@ struct LibraryView: View {
     private var loginPrompt: some View {
         VStack(spacing: TigerDuckTheme.Spacing.lg) {
             Image(systemName: "qrcode")
-                .font(.system(size: 56))
+                .font(.system(size: heroIconSize))
                 .foregroundStyle(Color.accentPrimary)
 
             Text(String(localized: "library_login_qr_prompt"))

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -17,6 +17,8 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
     @ViewBuilder let content: () -> Content
     @ViewBuilder let actions: () -> Actions
 
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 64
+
     var body: some View {
         VStack(spacing: TigerDuckTheme.Spacing.lg) {
             iconView
@@ -71,7 +73,7 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
         switch iconAnimation {
         case .pulse:
             Image(systemName: icon)
-                .font(.system(size: 64))
+                .font(.system(size: heroIconSize))
                 .foregroundStyle(accentColor)
                 .symbolEffect(.pulse)
         case .layerFlash:
@@ -80,7 +82,7 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
             // pulse both layers).
             ZStack {
                 Image(systemName: "shield.fill")
-                    .font(.system(size: 64))
+                    .font(.system(size: heroIconSize))
                     .foregroundStyle(accentColor)
                 Image(systemName: "lock.fill")
                     .font(.system(size: 32, weight: .semibold))

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -17,6 +17,7 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
     @ViewBuilder let content: () -> Content
     @ViewBuilder let actions: () -> Actions
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 64
 
     var body: some View {
@@ -75,7 +76,7 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
             Image(systemName: icon)
                 .font(.system(size: heroIconSize))
                 .foregroundStyle(accentColor)
-                .symbolEffect(.pulse)
+                .symbolEffect(.pulse, isActive: !reduceMotion)
         case .layerFlash:
             // Compose the shield and lock as separate images so only the
             // lock animates (the built-in lock.shield.fill effect would
@@ -87,7 +88,7 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
                 Image(systemName: "lock.fill")
                     .font(.system(size: 32, weight: .semibold))
                     .foregroundStyle(.white)
-                    .symbolEffect(.pulse, options: .repeating.speed(0.35))
+                    .symbolEffect(.pulse, options: .repeating.speed(0.35), isActive: !reduceMotion)
                     .offset(y: -4)
             }
         }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -85,10 +85,10 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
                     .font(.system(size: heroIconSize))
                     .foregroundStyle(accentColor)
                 Image(systemName: "lock.fill")
-                    .font(.system(size: 32, weight: .semibold))
+                    .font(.system(size: heroIconSize * 0.5, weight: .semibold))
                     .foregroundStyle(.white)
                     .symbolEffect(.pulse, options: .repeating.speed(0.35))
-                    .offset(y: -4)
+                    .offset(y: -heroIconSize / 16)
             }
         }
     }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -3,6 +3,7 @@ import UserNotifications
 
 struct OnboardingView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var currentPage = 0
     @State private var studentId = ""
     @State private var password = ""
@@ -84,7 +85,7 @@ struct OnboardingView: View {
             actions: {
                 VStack(spacing: TigerDuckTheme.Spacing.md) {
                     Button(String(localized: "action_next")) {
-                        withAnimation { currentPage = Page.privacy.rawValue }
+                        withAnimation(reduceMotion ? nil : .default) { currentPage = Page.privacy.rawValue }
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
@@ -127,7 +128,7 @@ struct OnboardingView: View {
                         .opacity(agreedPrivacy && agreedDeletion ? 0 : 1)
 
                     Button(String(localized: "action_next")) {
-                        withAnimation { currentPage = Page.watchOS.rawValue }
+                        withAnimation(reduceMotion ? nil : .default) { currentPage = Page.watchOS.rawValue }
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
@@ -172,7 +173,7 @@ struct OnboardingView: View {
             accentColor: .red
         ) {
             Button(String(localized: "action_next")) {
-                withAnimation { currentPage = Page.login.rawValue }
+                withAnimation(reduceMotion ? nil : .default) { currentPage = Page.login.rawValue }
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
@@ -249,7 +250,7 @@ struct OnboardingView: View {
             actions: {
                 VStack(spacing: TigerDuckTheme.Spacing.md) {
                     Button(String(localized: "onboarding_skip_for_now")) {
-                        withAnimation { currentPage = Page.notifications.rawValue }
+                        withAnimation(reduceMotion ? nil : .default) { currentPage = Page.notifications.rawValue }
                     }
                     .foregroundStyle(Color.textSecondary)
 
@@ -284,7 +285,7 @@ struct OnboardingView: View {
             let success = await appState.authService.login(
                 studentId: trimmedId, password: trimmedPwd
             )
-            if success { withAnimation { currentPage = Page.notifications.rawValue } }
+            if success { withAnimation(reduceMotion ? nil : .default) { currentPage = Page.notifications.rawValue } }
         }
     }
 
@@ -316,7 +317,7 @@ struct OnboardingView: View {
             actions: {
                 VStack(spacing: TigerDuckTheme.Spacing.md) {
                     Button(String(localized: "onboarding_skip_for_now")) {
-                        withAnimation { currentPage = Page.ready.rawValue }
+                        withAnimation(reduceMotion ? nil : .default) { currentPage = Page.ready.rawValue }
                     }
                     .foregroundStyle(Color.textSecondary)
 
@@ -328,7 +329,7 @@ struct OnboardingView: View {
                     // in `.notDetermined` with no registration path.
                     if notificationStatus != .notDetermined {
                         Button(String(localized: "action_next")) {
-                            withAnimation { currentPage = Page.ready.rawValue }
+                            withAnimation(reduceMotion ? nil : .default) { currentPage = Page.ready.rawValue }
                         }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.large)

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -149,7 +149,7 @@ struct OnboardingView: View {
                     .font(.title2)
                     .symbolRenderingMode(.hierarchical)
                     .foregroundStyle(isOn.wrappedValue ? Color.accentPrimary : Color.textSecondary)
-                    .contentTransition(.symbolEffect(.replace))
+                    .contentTransition(reduceMotion ? .identity : .symbolEffect(.replace))
             }
             .buttonStyle(.plain)
             .sensoryFeedback(.selection, trigger: isOn.wrappedValue)

--- a/swift/TigerDuck/Features/Score/Components/CreditSummaryBento.swift
+++ b/swift/TigerDuck/Features/Score/Components/CreditSummaryBento.swift
@@ -40,7 +40,9 @@ struct CreditSummaryBento: View {
 
             HStack(alignment: .lastTextBaseline, spacing: 4) {
                 Text("\(breakdown.total)")
-                    .font(.system(size: 34, weight: .bold, design: .rounded))
+                    .font(.system(.largeTitle, design: .rounded).weight(.bold).monospacedDigit())
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
                     .foregroundStyle(accent)
                 Text(String(localized: "course_detail_credits_label"))
                     .font(TigerDuckTheme.Typography.caption2)

--- a/swift/TigerDuck/Features/Score/Components/RankingsTrendCard.swift
+++ b/swift/TigerDuck/Features/Score/Components/RankingsTrendCard.swift
@@ -78,6 +78,13 @@ struct RankingsTrendCard: View {
                     )
                     .foregroundStyle(Color(hex: 0x4ECDC4))
                     .symbolSize(isSelected(ranking.term) ? 160 : 64)
+                    .accessibilityLabel(
+                        Text(String(
+                            format: String(localized: "a11y_rankings_trend_point"),
+                            ranking.term as CVarArg,
+                            value.formatted(.number.precision(.fractionLength(2))) as CVarArg
+                        ))
+                    )
                 }
             }
 
@@ -124,6 +131,9 @@ struct RankingsTrendCard: View {
             }
         }
         .frame(height: 160)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(Text(String(localized: "a11y_rankings_trend_chart")))
+        .accessibilityValue(Text(currentSelectionDescription))
     }
 
     @ViewBuilder
@@ -193,6 +203,18 @@ struct RankingsTrendCard: View {
 
     private func isSelected(_ term: String) -> Bool {
         selectedTerm == term
+    }
+
+    private var currentSelectionDescription: String {
+        guard let selected = resolvedSelection,
+              let value = gpa(for: selected) else {
+            return String(localized: "a11y_rankings_trend_no_selection")
+        }
+        return String(
+            format: String(localized: "a11y_rankings_trend_point"),
+            selected.term as CVarArg,
+            value.formatted(.number.precision(.fractionLength(2))) as CVarArg
+        )
     }
 
     // MARK: - Helpers

--- a/swift/TigerDuck/Features/Score/Components/ScoreCourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/Score/Components/ScoreCourseDetailSheet.swift
@@ -59,7 +59,9 @@ struct ScoreCourseDetailSheet: View {
             }
             Spacer()
             Text(gradeDisplay)
-                .font(.system(size: 32, weight: .bold, design: .rounded))
+                .font(.system(.largeTitle, design: .rounded).weight(.bold).monospacedDigit())
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
                 .foregroundStyle(gradeColor)
         }
         .padding(TigerDuckTheme.Spacing.md)

--- a/swift/TigerDuck/Features/Score/Components/ScoreCourseRow.swift
+++ b/swift/TigerDuck/Features/Score/Components/ScoreCourseRow.swift
@@ -75,7 +75,9 @@ private struct GradeChip: View {
                     .font(.caption2)
             }
             Text(descriptor.label)
-                .font(.system(size: 18, weight: .bold, design: .rounded))
+                .font(.system(.title3, design: .rounded).weight(.bold).monospacedDigit())
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
         }
         .foregroundStyle(descriptor.color)
         .padding(.horizontal, 10)

--- a/swift/TigerDuck/Features/Settings/Components/TabEditorView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/TabEditorView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TabEditorView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var tabs: [AppFeature] = []
     @State private var draggingTab: AppFeature?
     @State private var tabDragLocation: CGPoint = .zero
@@ -35,7 +36,7 @@ struct TabEditorView: View {
                             HStack(spacing: TigerDuckTheme.Spacing.md) {
                                 ForEach(tabs, id: \.self) { feature in
                                     TabPreviewItem(feature: feature, isDragging: draggingTab == feature) {
-                                        withAnimation(.smoothSpring) {
+                                        withAnimation(reduceMotion ? nil : .smoothSpring) {
                                             tabs.removeAll { $0 == feature }
                                         }
                                     }
@@ -64,7 +65,7 @@ struct TabEditorView: View {
                                                 reorderTabsIfNeeded(at: value.location)
                                             }
                                             .onEnded { _ in
-                                                withAnimation(.smoothSpring) {
+                                                withAnimation(reduceMotion ? nil : .smoothSpring) {
                                                     draggingTab = nil
                                                 }
                                             }
@@ -125,7 +126,7 @@ struct TabEditorView: View {
                             ) {
                                 ForEach(availableFeatures) { feature in
                                     Button {
-                                        withAnimation(.smoothSpring) {
+                                        withAnimation(reduceMotion ? nil : .smoothSpring) {
                                             tabs.append(feature)
                                         }
                                     } label: {
@@ -152,7 +153,7 @@ struct TabEditorView: View {
                     }
 
                     Button(String(localized: "tab_editor_reset_default")) {
-                        withAnimation(.smoothSpring) {
+                        withAnimation(reduceMotion ? nil : .smoothSpring) {
                             tabs = AppFeature.defaultTabs
                         }
                     }

--- a/swift/TigerDuck/Features/Settings/SettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/SettingsView.swift
@@ -5,6 +5,7 @@ import UserNotifications
 struct SettingsView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openURL) private var openURL
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var notifyAssignments = true
     @State private var notifyAnnouncements = true
     @State private var notifyFreeLunch = true
@@ -52,7 +53,7 @@ struct SettingsView: View {
                     HStack(spacing: 12) {
                         ForEach(AppState.themeColors, id: \.hex) { theme in
                             Button {
-                                withAnimation(.smoothSpring) {
+                                withAnimation(reduceMotion ? nil : .smoothSpring) {
                                     appState.accentColorHex = theme.hex
                                 }
                             } label: {
@@ -283,8 +284,10 @@ struct SettingsView: View {
                 )
                 .onAppear {
                     warningFlash = false
-                    withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
-                        warningFlash = true
+                    if !reduceMotion {
+                        withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                            warningFlash = true
+                        }
                     }
                     triggerWarningVibration()
                 }
@@ -439,6 +442,7 @@ private struct LibraryWarningOverlay: View {
     let onCancel: () -> Void
     let onConfirm: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var countdown = 5
     @State private var confirmEnabled = false
 
@@ -509,7 +513,7 @@ private struct LibraryWarningOverlay: View {
                 try? await Task.sleep(for: .seconds(1))
                 countdown = i
             }
-            withAnimation(.easeInOut(duration: 0.3)) {
+            withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.3)) {
                 confirmEnabled = true
             }
         }

--- a/swift/TigerDuck/Services/API/Library/LibraryService.swift
+++ b/swift/TigerDuck/Services/API/Library/LibraryService.swift
@@ -161,7 +161,7 @@ enum LibraryService {
                 throw error
             }
 
-            await saveCredentials(username: username, password: password)
+            saveCredentials(username: username, password: password)
             saveToken(loginData.token, expirationMs: loginData.expirationTimeStamp)
             return loginData.token
         } catch {

--- a/swift/TigerDuck/Services/API/Library/LibraryService.swift
+++ b/swift/TigerDuck/Services/API/Library/LibraryService.swift
@@ -161,7 +161,7 @@ enum LibraryService {
                 throw error
             }
 
-            saveCredentials(username: username, password: password)
+            await saveCredentials(username: username, password: password)
             saveToken(loginData.token, expirationMs: loginData.expirationTimeStamp)
             return loginData.token
         } catch {

--- a/swift/TigerDuck/SharedUI/EmptyStateView.swift
+++ b/swift/TigerDuck/SharedUI/EmptyStateView.swift
@@ -5,10 +5,12 @@ struct EmptyStateView: View {
     let title: String
     var message: String? = nil
 
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 48
+
     var body: some View {
         VStack(spacing: TigerDuckTheme.Spacing.md) {
             Image(systemName: icon)
-                .font(.system(size: 48))
+                .font(.system(size: heroIconSize))
                 .foregroundStyle(Color.textSecondary)
             Text(title)
                 .font(TigerDuckTheme.Typography.headline)

--- a/swift/TigerDuck/SharedUI/LoadingShimmer.swift
+++ b/swift/TigerDuck/SharedUI/LoadingShimmer.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct LoadingShimmer: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var phase: CGFloat = -1
 
     var body: some View {
@@ -23,6 +24,7 @@ struct LoadingShimmer: View {
                 }
                 .clipped()
                 .onAppear {
+                    guard !reduceMotion else { return }
                     withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
                         phase = 1
                     }

--- a/swift/TigerDuck/SharedUI/LoadingShimmer.swift
+++ b/swift/TigerDuck/SharedUI/LoadingShimmer.swift
@@ -23,12 +23,22 @@ struct LoadingShimmer: View {
                         .offset(x: phase * proxy.size.width)
                 }
                 .clipped()
-                .onAppear {
-                    guard !reduceMotion else { return }
-                    withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
-                        phase = 1
-                    }
-                }
+                .onAppear { syncShimmer() }
+                // Reduce Motion can be switched on while the shimmer is still
+                // mounted — re-sync so an in-flight sweep stops.
+                .onChange(of: reduceMotion) { _, _ in syncShimmer() }
+        }
+    }
+
+    private func syncShimmer() {
+        guard !reduceMotion else {
+            // Reissue a non-repeating animation so the running
+            // `repeatForever` sweep settles instead of looping forever.
+            withAnimation(.linear(duration: 0)) { phase = -1 }
+            return
+        }
+        withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
+            phase = 1
         }
     }
 }

--- a/swift/TigerDuck/SharedUI/LoginRequiredView.swift
+++ b/swift/TigerDuck/SharedUI/LoginRequiredView.swift
@@ -21,6 +21,8 @@ struct LoginRequiredView: View {
     let onPrimary: () -> Void
     var onSecondary: (() -> Void)? = nil
 
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconSize: CGFloat = 48
+
     var body: some View {
         switch layout {
         case .page:
@@ -33,7 +35,7 @@ struct LoginRequiredView: View {
     private var pageBody: some View {
         VStack(spacing: TigerDuckTheme.Spacing.lg) {
             Image(systemName: "lock.shield")
-                .font(.system(size: 48))
+                .font(.system(size: heroIconSize))
                 .foregroundStyle(Color.accentPrimary)
             Text(title)
                 .font(TigerDuckTheme.Typography.title)

--- a/swift/TigerDuck/SharedUI/NetworkStatusOverlay.swift
+++ b/swift/TigerDuck/SharedUI/NetworkStatusOverlay.swift
@@ -31,6 +31,10 @@ struct NetworkStatusOverlay: View {
             }
         }
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: loadingState)
+        // Drive the fade off `visible` here rather than inside the delayed
+        // task: this modifier re-reads `reduceMotion` at render time, so a
+        // toggle made during the two-second delay is always respected.
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.5), value: visible)
         .onChange(of: loadingState) { _, newValue in
             hideTask?.cancel()
             if newValue == .loaded {
@@ -38,9 +42,7 @@ struct NetworkStatusOverlay: View {
                 hideTask = Task { @MainActor in
                     try? await Task.sleep(for: .seconds(2))
                     guard !Task.isCancelled else { return }
-                    withAnimation(reduceMotion ? nil : .easeOut(duration: 0.5)) {
-                        visible = false
-                    }
+                    visible = false
                 }
             } else {
                 visible = false

--- a/swift/TigerDuck/SharedUI/NetworkStatusOverlay.swift
+++ b/swift/TigerDuck/SharedUI/NetworkStatusOverlay.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct NetworkStatusOverlay: View {
     var loadingState: LoadingState
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var visible = false
     @State private var hideTask: Task<Void, Never>?
 
@@ -29,7 +30,7 @@ struct NetworkStatusOverlay: View {
                 EmptyView()
             }
         }
-        .animation(.easeInOut(duration: 0.3), value: loadingState)
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: loadingState)
         .onChange(of: loadingState) { _, newValue in
             hideTask?.cancel()
             if newValue == .loaded {
@@ -37,7 +38,7 @@ struct NetworkStatusOverlay: View {
                 hideTask = Task { @MainActor in
                     try? await Task.sleep(for: .seconds(2))
                     guard !Task.isCancelled else { return }
-                    withAnimation(.easeOut(duration: 0.5)) {
+                    withAnimation(reduceMotion ? nil : .easeOut(duration: 0.5)) {
                         visible = false
                     }
                 }


### PR DESCRIPTION
Forward-merge to correct a stacked-PR merge-order slip: #141
(voiceover-labels → dev) merged ~12s before #142 (dynamic-type-fonts →
voiceover-labels), so the Dynamic Type work landed on
\`feat/voiceover-labels\` but never reached \`dev\`.

\`feat/voiceover-labels\` is now exactly \`dev\` + the \`feat/dynamic-type-fonts\`
commits; this PR carries them forward. No new code — recovery merge only.