### PR TITLE
fix(i18n + ux): Live Activity localization + 3 small UX fixes

### DIFF
--- a/swift/TigerDuck/Features/ClassTable/ClassTableView.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableView.swift
@@ -109,6 +109,33 @@ struct ClassTableView: View {
                     }
                 )
                 .presentationDetents([.medium, .large])
+                // The conflict alert lives on the sheet's content, not the
+                // parent — when it lived on the parent, iOS dismissed the
+                // sheet to present the alert (only one presentation at a
+                // time per host view). Anchoring it here lets the alert
+                // surface above the search results without exiting search
+                // (#152).
+                .alert(
+                    String(localized: "class_table_conflict_add_failed_title"),
+                    isPresented: Binding(
+                        get: { viewModel.tripleConflictError != nil },
+                        set: { if !$0 { viewModel.tripleConflictError = nil } }
+                    ),
+                    presenting: viewModel.tripleConflictError
+                ) { _ in
+                    Button(String(localized: "action_confirm"), role: .cancel) {
+                        viewModel.tripleConflictError = nil
+                    }
+                } message: { err in
+                    Text(String(
+                        format: String(localized: "class_table_conflict_add_failed_message"),
+                        err.newCourseName,
+                        "\(err.weekday)",
+                        err.periodId,
+                        err.existingA.displayName,
+                        err.existingB.displayName
+                    ))
+                }
             }
             .alert(String(localized: "class_table_rename_title"), isPresented: $viewModel.showRenameAlert) {
                 TextField(String(localized: "class_table_course_name"), text: $viewModel.renameText)
@@ -141,27 +168,6 @@ struct ClassTableView: View {
                     onPick: { viewModel.pickFromConflict($0) }
                 )
                 .presentationDetents([.medium])
-            }
-            .alert(
-                String(localized: "class_table_conflict_add_failed_title"),
-                isPresented: Binding(
-                    get: { viewModel.tripleConflictError != nil },
-                    set: { if !$0 { viewModel.tripleConflictError = nil } }
-                ),
-                presenting: viewModel.tripleConflictError
-            ) { _ in
-                Button(String(localized: "action_confirm"), role: .cancel) {
-                    viewModel.tripleConflictError = nil
-                }
-            } message: { err in
-                Text(String(
-                    format: String(localized: "class_table_conflict_add_failed_message"),
-                    err.newCourseName,
-                    "\(err.weekday)",
-                    err.periodId,
-                    err.existingA.displayName,
-                    err.existingB.displayName
-                ))
             }
     }
 

--- a/swift/TigerDuck/Features/ClassTable/Components/AddCourseSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/AddCourseSheet.swift
@@ -117,6 +117,13 @@ struct AddCourseSheet: View {
                 }
             }
         }
+        // The Form's `.background(Color.backgroundPrimary)` only paints the
+        // scrollable area — at the .medium detent the nav bar at the top
+        // and the bottom safe-area inset fall back to the sheet's default
+        // translucent backing and visibly show the underlying class table
+        // bleeding through. `.presentationBackground` paints the entire
+        // sheet container so the popup reads as one solid panel.
+        .presentationBackground(Color.backgroundPrimary)
     }
 
     // MARK: - macOS body

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -23,11 +23,24 @@ struct OnboardingView: View {
         case welcome, privacy, watchOS, login, notifications, ready
     }
 
+    /// iPad has no Apple Watch pairing affordance — there's no Watch app to
+    /// install from the iPad, so the slide is pure noise there (#146). Keep
+    /// it for iPhone (the canonical pairing host) and for any non-iOS host.
+    private var showsWatchPage: Bool {
+        #if os(iOS)
+        UIDevice.current.userInterfaceIdiom != .pad
+        #else
+        true
+        #endif
+    }
+
     var body: some View {
         TabView(selection: $currentPage) {
             welcomePage.tag(Page.welcome.rawValue)
             privacyPage.tag(Page.privacy.rawValue)
-            watchOSPage.tag(Page.watchOS.rawValue)
+            if showsWatchPage {
+                watchOSPage.tag(Page.watchOS.rawValue)
+            }
             loginPage.tag(Page.login.rawValue)
             notificationsPage.tag(Page.notifications.rawValue)
             readyPage.tag(Page.ready.rawValue)
@@ -128,7 +141,9 @@ struct OnboardingView: View {
                         .opacity(agreedPrivacy && agreedDeletion ? 0 : 1)
 
                     Button(String(localized: "action_next")) {
-                        withAnimation(reduceMotion ? nil : .default) { currentPage = Page.watchOS.rawValue }
+                        // Skip the watchOS slide on iPad — see `showsWatchPage`.
+                        let nextPage = showsWatchPage ? Page.watchOS.rawValue : Page.login.rawValue
+                        withAnimation(reduceMotion ? nil : .default) { currentPage = nextPage }
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)

--- a/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
@@ -173,6 +173,32 @@ struct MacClassTableView: View {
                 onAdd: { addUserCourse($0) },
                 onRemove: { removeUserAddedCourse(courseNo: $0) }
             )
+            // Conflict alert lives on the sheet's content (#152): on iPhone
+            // hosting an alert on the parent forces SwiftUI to dismiss the
+            // sheet to present it. macOS doesn't have the same dismissal,
+            // but keeping both platforms anchored to the sheet keeps the
+            // alert visually attached to the search results either way.
+            .alert(
+                String(localized: "class_table_conflict_add_failed_title"),
+                isPresented: Binding(
+                    get: { tripleConflictError != nil },
+                    set: { if !$0 { tripleConflictError = nil } }
+                ),
+                presenting: tripleConflictError
+            ) { _ in
+                Button(String(localized: "action_confirm"), role: .cancel) {
+                    tripleConflictError = nil
+                }
+            } message: { err in
+                Text(String(
+                    format: String(localized: "class_table_conflict_add_failed_message"),
+                    err.newCourseName,
+                    "\(err.weekday)",
+                    err.periodId,
+                    err.existingA.displayName,
+                    err.existingB.displayName
+                ))
+            }
         }
         .sheet(item: $courseToRecolor) { course in
             CourseColorPickerSheet(
@@ -184,27 +210,6 @@ struct MacClassTableView: View {
                 }
             )
             .frame(minWidth: 360, minHeight: 480)
-        }
-        .alert(
-            String(localized: "class_table_conflict_add_failed_title"),
-            isPresented: Binding(
-                get: { tripleConflictError != nil },
-                set: { if !$0 { tripleConflictError = nil } }
-            ),
-            presenting: tripleConflictError
-        ) { _ in
-            Button(String(localized: "action_confirm"), role: .cancel) {
-                tripleConflictError = nil
-            }
-        } message: { err in
-            Text(String(
-                format: String(localized: "class_table_conflict_add_failed_message"),
-                err.newCourseName,
-                "\(err.weekday)",
-                err.periodId,
-                err.existingA.displayName,
-                err.existingB.displayName
-            ))
         }
         .alert(String(localized: "class_table_rename_title"), isPresented: $showRenameAlert) {
             TextField(String(localized: "class_table_course_name"), text: $renameText)

--- a/swift/TigerDuck/Platform/Mac/MacWidgetCards.swift
+++ b/swift/TigerDuck/Platform/Mac/MacWidgetCards.swift
@@ -136,6 +136,18 @@ private struct NextClassWidgetCard: View {
                 let color = TigerDuckTheme.courseColor(for: primary.course.courseNo)
                 VStack(alignment: .leading, spacing: 6) {
                     HStack {
+                        // Render the chosen slot's bounds, not the day's
+                        // first-to-last span — the countdown above counts
+                        // down to `primary.start`, so a split same-day
+                        // course (e.g. P3-P4 + P7-P8) would otherwise show
+                        // a gap-spanning time that doesn't match the timer.
+                        // Lives on the leading edge so the eye lands on the
+                        // time first, with the live badge (when present) as
+                        // a trailing accent.
+                        Text("\(primary.start.timeString) - \(primary.end.timeString)")
+                            .font(.title3.monospacedDigit().weight(.semibold))
+                            .foregroundStyle(color)
+                        Spacer()
                         // Only show a badge when the class is actively in
                         // session — the "next up" caption used to duplicate
                         // the card title (#136) and the white-on-course-color
@@ -150,15 +162,6 @@ private struct NextClassWidgetCard: View {
                                 .padding(.vertical, 2)
                                 .background(Capsule().fill(color))
                         }
-                        Spacer()
-                        // Render the chosen slot's bounds, not the day's
-                        // first-to-last span — the countdown above counts
-                        // down to `primary.start`, so a split same-day
-                        // course (e.g. P3-P4 + P7-P8) would otherwise show
-                        // a gap-spanning time that doesn't match the timer.
-                        Text("\(primary.start.timeString) - \(primary.end.timeString)")
-                            .font(.title3.monospacedDigit().weight(.semibold))
-                            .foregroundStyle(color)
                     }
                     if target.slots.count >= 2 {
                         // 衝堂: list every overlapping course on its own line so

--- a/swift/TigerDuckLiveActivity/TigerDuckLiveActivityLiveActivity.swift
+++ b/swift/TigerDuckLiveActivity/TigerDuckLiveActivityLiveActivity.swift
@@ -258,9 +258,9 @@ private func iconName(for scenario: LiveActivityScenarioKind) -> String {
 
 private func statusLabel(for scenario: LiveActivityScenarioKind) -> String {
     switch scenario {
-    case .inClass: return "上課"
-    case .classPreparing: return "即將上課"
-    case .assignmentUrgent: return "作業"
+    case .inClass: return String(localized: "live_activity_status_in_class_short")
+    case .classPreparing: return String(localized: "live_activity_status_class_preparing")
+    case .assignmentUrgent: return String(localized: "live_activity_status_assignment_short")
     }
 }
 

--- a/swift/TigerDuckLiveActivity/ar.lproj
+++ b/swift/TigerDuckLiveActivity/ar.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/ar.lproj

--- a/swift/TigerDuckLiveActivity/bg.lproj
+++ b/swift/TigerDuckLiveActivity/bg.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/bg.lproj

--- a/swift/TigerDuckLiveActivity/bn.lproj
+++ b/swift/TigerDuckLiveActivity/bn.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/bn.lproj

--- a/swift/TigerDuckLiveActivity/ca.lproj
+++ b/swift/TigerDuckLiveActivity/ca.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/ca.lproj

--- a/swift/TigerDuckLiveActivity/cs.lproj
+++ b/swift/TigerDuckLiveActivity/cs.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/cs.lproj

--- a/swift/TigerDuckLiveActivity/da.lproj
+++ b/swift/TigerDuckLiveActivity/da.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/da.lproj

--- a/swift/TigerDuckLiveActivity/de.lproj
+++ b/swift/TigerDuckLiveActivity/de.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/de.lproj

--- a/swift/TigerDuckLiveActivity/el.lproj
+++ b/swift/TigerDuckLiveActivity/el.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/el.lproj

--- a/swift/TigerDuckLiveActivity/en-AU.lproj
+++ b/swift/TigerDuckLiveActivity/en-AU.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/en-AU.lproj

--- a/swift/TigerDuckLiveActivity/en-CA.lproj
+++ b/swift/TigerDuckLiveActivity/en-CA.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/en-CA.lproj

--- a/swift/TigerDuckLiveActivity/en-GB.lproj
+++ b/swift/TigerDuckLiveActivity/en-GB.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/en-GB.lproj

--- a/swift/TigerDuckLiveActivity/en-IN.lproj
+++ b/swift/TigerDuckLiveActivity/en-IN.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/en-IN.lproj

--- a/swift/TigerDuckLiveActivity/en.lproj
+++ b/swift/TigerDuckLiveActivity/en.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/en.lproj

--- a/swift/TigerDuckLiveActivity/es-MX.lproj
+++ b/swift/TigerDuckLiveActivity/es-MX.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/es-MX.lproj

--- a/swift/TigerDuckLiveActivity/es.lproj
+++ b/swift/TigerDuckLiveActivity/es.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/es.lproj

--- a/swift/TigerDuckLiveActivity/et.lproj
+++ b/swift/TigerDuckLiveActivity/et.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/et.lproj

--- a/swift/TigerDuckLiveActivity/fa.lproj
+++ b/swift/TigerDuckLiveActivity/fa.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/fa.lproj

--- a/swift/TigerDuckLiveActivity/fi.lproj
+++ b/swift/TigerDuckLiveActivity/fi.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/fi.lproj

--- a/swift/TigerDuckLiveActivity/fil.lproj
+++ b/swift/TigerDuckLiveActivity/fil.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/fil.lproj

--- a/swift/TigerDuckLiveActivity/fr-CA.lproj
+++ b/swift/TigerDuckLiveActivity/fr-CA.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/fr-CA.lproj

--- a/swift/TigerDuckLiveActivity/fr.lproj
+++ b/swift/TigerDuckLiveActivity/fr.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/fr.lproj

--- a/swift/TigerDuckLiveActivity/gu.lproj
+++ b/swift/TigerDuckLiveActivity/gu.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/gu.lproj

--- a/swift/TigerDuckLiveActivity/he.lproj
+++ b/swift/TigerDuckLiveActivity/he.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/he.lproj

--- a/swift/TigerDuckLiveActivity/hi.lproj
+++ b/swift/TigerDuckLiveActivity/hi.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/hi.lproj

--- a/swift/TigerDuckLiveActivity/hr.lproj
+++ b/swift/TigerDuckLiveActivity/hr.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/hr.lproj

--- a/swift/TigerDuckLiveActivity/hu.lproj
+++ b/swift/TigerDuckLiveActivity/hu.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/hu.lproj

--- a/swift/TigerDuckLiveActivity/id.lproj
+++ b/swift/TigerDuckLiveActivity/id.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/id.lproj

--- a/swift/TigerDuckLiveActivity/is.lproj
+++ b/swift/TigerDuckLiveActivity/is.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/is.lproj

--- a/swift/TigerDuckLiveActivity/it.lproj
+++ b/swift/TigerDuckLiveActivity/it.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/it.lproj

--- a/swift/TigerDuckLiveActivity/ja.lproj
+++ b/swift/TigerDuckLiveActivity/ja.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/ja.lproj

--- a/swift/TigerDuckLiveActivity/kk.lproj
+++ b/swift/TigerDuckLiveActivity/kk.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/kk.lproj

--- a/swift/TigerDuckLiveActivity/kn.lproj
+++ b/swift/TigerDuckLiveActivity/kn.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/kn.lproj

--- a/swift/TigerDuckLiveActivity/ko.lproj
+++ b/swift/TigerDuckLiveActivity/ko.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/ko.lproj

--- a/swift/TigerDuckLiveActivity/lt.lproj
+++ b/swift/TigerDuckLiveActivity/lt.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/lt.lproj

--- a/swift/TigerDuckLiveActivity/lv.lproj
+++ b/swift/TigerDuckLiveActivity/lv.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/lv.lproj

--- a/swift/TigerDuckLiveActivity/ml.lproj
+++ b/swift/TigerDuckLiveActivity/ml.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/ml.lproj

--- a/swift/TigerDuckLiveActivity/mr.lproj
+++ b/swift/TigerDuckLiveActivity/mr.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/mr.lproj

--- a/swift/TigerDuckLiveActivity/ms.lproj
+++ b/swift/TigerDuckLiveActivity/ms.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/ms.lproj

--- a/swift/TigerDuckLiveActivity/nb.lproj
+++ b/swift/TigerDuckLiveActivity/nb.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/nb.lproj

--- a/swift/TigerDuckLiveActivity/nl.lproj
+++ b/swift/TigerDuckLiveActivity/nl.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/nl.lproj

--- a/swift/TigerDuckLiveActivity/no.lproj
+++ b/swift/TigerDuckLiveActivity/no.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/no.lproj

--- a/swift/TigerDuckLiveActivity/pa.lproj
+++ b/swift/TigerDuckLiveActivity/pa.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/pa.lproj

--- a/swift/TigerDuckLiveActivity/pl.lproj
+++ b/swift/TigerDuckLiveActivity/pl.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/pl.lproj

--- a/swift/TigerDuckLiveActivity/pt-BR.lproj
+++ b/swift/TigerDuckLiveActivity/pt-BR.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/pt-BR.lproj

--- a/swift/TigerDuckLiveActivity/pt-PT.lproj
+++ b/swift/TigerDuckLiveActivity/pt-PT.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/pt-PT.lproj

--- a/swift/TigerDuckLiveActivity/pt.lproj
+++ b/swift/TigerDuckLiveActivity/pt.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/pt.lproj

--- a/swift/TigerDuckLiveActivity/ro.lproj
+++ b/swift/TigerDuckLiveActivity/ro.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/ro.lproj

--- a/swift/TigerDuckLiveActivity/ru.lproj
+++ b/swift/TigerDuckLiveActivity/ru.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/ru.lproj

--- a/swift/TigerDuckLiveActivity/sk.lproj
+++ b/swift/TigerDuckLiveActivity/sk.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/sk.lproj

--- a/swift/TigerDuckLiveActivity/sl.lproj
+++ b/swift/TigerDuckLiveActivity/sl.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/sl.lproj

--- a/swift/TigerDuckLiveActivity/sr.lproj
+++ b/swift/TigerDuckLiveActivity/sr.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/sr.lproj

--- a/swift/TigerDuckLiveActivity/sv.lproj
+++ b/swift/TigerDuckLiveActivity/sv.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/sv.lproj

--- a/swift/TigerDuckLiveActivity/ta.lproj
+++ b/swift/TigerDuckLiveActivity/ta.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/ta.lproj

--- a/swift/TigerDuckLiveActivity/te.lproj
+++ b/swift/TigerDuckLiveActivity/te.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/te.lproj

--- a/swift/TigerDuckLiveActivity/th.lproj
+++ b/swift/TigerDuckLiveActivity/th.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/th.lproj

--- a/swift/TigerDuckLiveActivity/tr.lproj
+++ b/swift/TigerDuckLiveActivity/tr.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/tr.lproj

--- a/swift/TigerDuckLiveActivity/uk.lproj
+++ b/swift/TigerDuckLiveActivity/uk.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/uk.lproj

--- a/swift/TigerDuckLiveActivity/ur.lproj
+++ b/swift/TigerDuckLiveActivity/ur.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/ur.lproj

--- a/swift/TigerDuckLiveActivity/vi.lproj
+++ b/swift/TigerDuckLiveActivity/vi.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/vi.lproj

--- a/swift/TigerDuckLiveActivity/yue-HK.lproj
+++ b/swift/TigerDuckLiveActivity/yue-HK.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/yue-HK.lproj

--- a/swift/TigerDuckLiveActivity/zh-CN.lproj
+++ b/swift/TigerDuckLiveActivity/zh-CN.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/zh-CN.lproj

--- a/swift/TigerDuckLiveActivity/zh-HK.lproj
+++ b/swift/TigerDuckLiveActivity/zh-HK.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/zh-HK.lproj

--- a/swift/TigerDuckLiveActivity/zh-Hans.lproj
+++ b/swift/TigerDuckLiveActivity/zh-Hans.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/zh-Hans.lproj

--- a/swift/TigerDuckLiveActivity/zh-Hant.lproj
+++ b/swift/TigerDuckLiveActivity/zh-Hant.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/zh-Hant.lproj

--- a/swift/TigerDuckLiveActivity/zh-MO.lproj
+++ b/swift/TigerDuckLiveActivity/zh-MO.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/zh-MO.lproj

--- a/swift/TigerDuckLiveActivity/zh-SG.lproj
+++ b/swift/TigerDuckLiveActivity/zh-SG.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/zh-SG.lproj

--- a/swift/TigerDuckLiveActivity/zh-TW.lproj
+++ b/swift/TigerDuckLiveActivity/zh-TW.lproj
@@ -1,0 +1,1 @@
+../../localization/generated/apple/zh-TW.lproj

--- a/tools/localization/sync_localizations.py
+++ b/tools/localization/sync_localizations.py
@@ -47,6 +47,7 @@ TARGET_DIRS = [
     ROOT / "swift" / "TigerDuck",
     ROOT / "swift" / "TigerDuckWatch Watch App",
     ROOT / "swift" / "TigerDuckWatchWidget",
+    ROOT / "swift" / "TigerDuckLiveActivity",
 ]
 
 # Widget extension's resources live one level deeper, so it uses a separate


### PR DESCRIPTION
## Summary

- **#147** — Localize Live Activity status labels. `statusLabel(for:)` in `TigerDuckLiveActivityLiveActivity.swift` now resolves the three scenario strings via `String(localized:)`. The keys already existed in `localization/source`; this PR wires per-language `.lproj` symlinks (67 locales) into the `TigerDuckLiveActivity.appex` so the bundle actually resolves them, mirroring the existing TigerDuckWatchWidget pattern. `tools/localization/sync_localizations.py` adds the extension's root to `TARGET_DIRS`.
- **Mac NextClass card** — Swapped HStack child order in `NextClassWidgetCard` so the class time renders on the leading edge with the live badge as a trailing accent, matching the user request.
- **#152** — Conflict alert was dismissing the AddCourseSheet because iOS only allows one presentation per host view at a time. Moved `.alert(...)` from `ClassTableView`'s body into the `.sheet { AddCourseSheet(...) }` closure so the alert surfaces above the search results without exiting search. Same alert content/binding, just re-anchored.
- **#146** — Hide the Apple Watch onboarding page on iPad via a `showsWatchPage` helper (`UIDevice.current.userInterfaceIdiom != .pad`). TabView page is conditional and the privacy page's Next button skips straight to Login when the watch page is omitted. macOS unaffected (always-true branch).

## Test plan

- [x] iOS build: `xcodebuild -scheme TigerDuck -destination 'generic/platform=iOS' build` → SUCCEEDED
- [x] macOS build: `xcodebuild -scheme TigerDuck -destination 'platform=macOS,arch=arm64' build` → SUCCEEDED
- [ ] On a Live Activity in zh-Hant locale, verify the three status labels render translated (in-class / preparing / assignment).
- [ ] On the Mac home page, confirm the 下一堂課 card shows the time on the left and the live badge (when in-session) on the right.
- [ ] On iPhone, open AddCourseSheet, trigger a triple-conflict — alert should appear over the sheet without dismissing the search results.
- [ ] On iPad, walk the onboarding flow — the Apple Watch page should be skipped (privacy → login). On iPhone the watch page should still appear.

Closes #147, #152, #146.