### PR TITLE
feat(library): flip phone face-down to open Library QR

### DIFF
--- a/swift/Shared/Sensors/FlipDetector.swift
+++ b/swift/Shared/Sensors/FlipDetector.swift
@@ -28,6 +28,12 @@ final class FlipDetector {
     /// before a transition is committed.
     static let debounceInterval: TimeInterval = 0.4
 
+    /// Maximum time between consecutive sensor events before we treat them
+    /// as a discontinuity (device sleep, sensor restart) and reset the
+    /// debounce window. Normal cadence is ~33ms (30Hz); a full second
+    /// without an event means something paused the stream.
+    static let maxEventGap: TimeInterval = 1.0
+
     enum Phase { case unknown, upright, faceDown }
 
     /// Immutable state for the debounce machine.
@@ -38,6 +44,9 @@ final class FlipDetector {
         /// boot) of the first event in the current window. `nil` before the
         /// first event is delivered.
         var windowStart: TimeInterval?
+        /// Timestamp of the most recent event. Used to detect discontinuities
+        /// (sleep / sensor restart) where the gap exceeds `maxEventGap`.
+        var lastTimestamp: TimeInterval?
         /// `true` iff this transition fired the `onFaceDown` callback;
         /// callers consume and reset this on each step.
         var didFire: Bool
@@ -46,6 +55,7 @@ final class FlipDetector {
             phase: .unknown,
             pendingFaceDown: false,
             windowStart: nil,
+            lastTimestamp: nil,
             didFire: false
         )
     }
@@ -58,26 +68,46 @@ final class FlipDetector {
         return q
     }()
     private let onFaceDown: () -> Void
+    /// All access serialized through `stateLock` — `handle()` runs on the
+    /// sensor `queue` while `start()`/`stop()` run on the main thread.
+    private let stateLock = NSLock()
     private var state = State.initial
+    /// Guarded by `stateLock`. Flipped false in `stop()` BEFORE the state
+    /// reset so any in-flight `handle(...)` already past its early-return
+    /// can't fire `onFaceDown` for an event the user has just cancelled.
+    private var isActive = false
 
     init(onFaceDown: @escaping () -> Void) {
         self.onFaceDown = onFaceDown
     }
 
-    /// `true` iff this device exposes a device-motion sensor we can register
-    /// against. Settings reads this to decide whether the toggle is shown.
-    static var isSupported: Bool {
-        CMMotionManager().isDeviceMotionAvailable
+    deinit {
+        // CMMotionManager retains its update closure until
+        // stopDeviceMotionUpdates is called — relying on `onDisappear` alone
+        // leaves a window where ARC tears the detector down without
+        // releasing the hardware. Call directly on the manager (avoids
+        // touching `stateLock` from deinit which would violate Swift's
+        // exclusivity rules in -O builds).
+        if motionManager.isDeviceMotionActive {
+            motionManager.stopDeviceMotionUpdates()
+        }
     }
+
+    /// `true` iff this device exposes a device-motion sensor we can register
+    /// against. `let` (not `var`) because Apple's CoreMotion docs warn against
+    /// instantiating multiple `CMMotionManager`s — caching the result here
+    /// means hot paths like `OtherSettingsView.body` and the modifier's
+    /// `shouldBeActive` don't churn the motion subsystem.
+    static let isSupported: Bool = CMMotionManager().isDeviceMotionAvailable
 
     /// Idempotent. No-op if already active or if the device lacks the sensor.
     func start() {
         guard !motionManager.isDeviceMotionActive else { return }
         guard motionManager.isDeviceMotionAvailable else { return }
-        // Reset the state machine each time we (re-)register so a sensor
-        // event from a previous session can't leak into the new debounce
-        // window.
+        stateLock.lock()
         state = .initial
+        isActive = true
+        stateLock.unlock()
         motionManager.deviceMotionUpdateInterval = 1.0 / 30.0
         motionManager.startDeviceMotionUpdates(to: queue) { [weak self] motion, _ in
             guard let self, let motion else { return }
@@ -88,14 +118,26 @@ final class FlipDetector {
     /// Idempotent.
     func stop() {
         guard motionManager.isDeviceMotionActive else { return }
-        motionManager.stopDeviceMotionUpdates()
+        // Flip the active flag BEFORE stopping the manager so any callback
+        // already executing past its lock acquisition will see isActive
+        // = false and skip the fire.
+        stateLock.lock()
+        isActive = false
         state = .initial
+        stateLock.unlock()
+        motionManager.stopDeviceMotionUpdates()
     }
 
     private func handle(gravityZ: Double, timestamp: TimeInterval) {
         let faceDown = Self.isFaceDown(gravityZ: gravityZ)
-        state = Self.nextState(current: state, isFaceDown: faceDown, timestamp: timestamp)
-        if state.didFire {
+        let didFire: Bool = {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            guard isActive else { return false }
+            state = Self.nextState(current: state, isFaceDown: faceDown, timestamp: timestamp)
+            return state.didFire
+        }()
+        if didFire {
             DispatchQueue.main.async { [weak self] in self?.onFaceDown() }
         }
     }
@@ -112,13 +154,25 @@ final class FlipDetector {
     /// at least `debounceInterval`. `didFire` is `true` only on the specific
     /// transition Upright → FaceDown; all other transitions (including the
     /// cold-start Unknown → FaceDown) leave `didFire = false`.
+    ///
+    /// A gap > `maxEventGap` between consecutive events is treated as a
+    /// discontinuity (device sleep, sensor restart) and resets the window so
+    /// the next debounce restarts from zero — without this, a sleep gap of
+    /// minutes can make a single post-wake event instantly satisfy
+    /// `elapsed >= debounceInterval` and fire on the very first read.
     static func nextState(
         current: State,
         isFaceDown: Bool,
         timestamp: TimeInterval
     ) -> State {
         var next = current
-        if next.windowStart == nil || isFaceDown != next.pendingFaceDown {
+        next.lastTimestamp = timestamp
+        let discontinuity: Bool = {
+            guard let last = current.lastTimestamp else { return false }
+            let gap = timestamp - last
+            return gap > maxEventGap || gap < 0
+        }()
+        if next.windowStart == nil || isFaceDown != next.pendingFaceDown || discontinuity {
             next.pendingFaceDown = isFaceDown
             next.windowStart = timestamp
             next.didFire = false

--- a/swift/Shared/Sensors/FlipDetector.swift
+++ b/swift/Shared/Sensors/FlipDetector.swift
@@ -1,0 +1,142 @@
+#if os(iOS)
+import CoreMotion
+import Foundation
+
+/// Detects a sustained "phone face-down" gesture using CoreMotion's device-
+/// motion stream. Pure helpers (`isFaceDown`, `nextState`) carry the math
+/// and the debounce machine; the rest is `CMMotionManager` glue.
+///
+/// Emits exactly one `onFaceDown` callback per Upright → FaceDown transition;
+/// flickers under the debounce window are filtered out. The cold-start
+/// `Unknown` phase ensures opening the app while the phone is already
+/// face-down does NOT auto-fire.
+///
+/// Phone-only — `CMMotionManager` is iOS-only and the gesture is only wired
+/// up under `UIDevice.current.userInterfaceIdiom == .phone`. This mirrors the
+/// Android port (`FlipDetector.kt`), modulo the coordinate flip: Android uses
+/// `R[8] <= -0.85` on the world-frame screen-normal Z; iOS gravity in the
+/// device frame points to +Z when the screen faces the ground, so the same
+/// "within ~32° of perfectly inverted" window is `gravity.z >= 0.85`.
+final class FlipDetector {
+
+    /// `gravity.z >= faceDownThreshold` captures both "screen facing the
+    /// ground" and "within ~32 degrees of flat" in one comparison. Tighter
+    /// (more positive) = fewer false positives but harder to trigger.
+    static let faceDownThreshold: Double = 0.85
+
+    /// Debounce window — the predicate must hold for at least this long
+    /// before a transition is committed.
+    static let debounceInterval: TimeInterval = 0.4
+
+    enum Phase { case unknown, upright, faceDown }
+
+    /// Immutable state for the debounce machine.
+    struct State: Equatable {
+        var phase: Phase
+        var pendingFaceDown: Bool
+        /// Timestamp (CoreMotion `motion.timestamp`, monotonic seconds since
+        /// boot) of the first event in the current window. `nil` before the
+        /// first event is delivered.
+        var windowStart: TimeInterval?
+        /// `true` iff this transition fired the `onFaceDown` callback;
+        /// callers consume and reset this on each step.
+        var didFire: Bool
+
+        static let initial = State(
+            phase: .unknown,
+            pendingFaceDown: false,
+            windowStart: nil,
+            didFire: false
+        )
+    }
+
+    private let motionManager = CMMotionManager()
+    private let queue: OperationQueue = {
+        let q = OperationQueue()
+        q.name = "org.ntust.app.TigerDuck.FlipDetector"
+        q.maxConcurrentOperationCount = 1
+        return q
+    }()
+    private let onFaceDown: () -> Void
+    private var state = State.initial
+
+    init(onFaceDown: @escaping () -> Void) {
+        self.onFaceDown = onFaceDown
+    }
+
+    /// `true` iff this device exposes a device-motion sensor we can register
+    /// against. Settings reads this to decide whether the toggle is shown.
+    static var isSupported: Bool {
+        CMMotionManager().isDeviceMotionAvailable
+    }
+
+    /// Idempotent. No-op if already active or if the device lacks the sensor.
+    func start() {
+        guard !motionManager.isDeviceMotionActive else { return }
+        guard motionManager.isDeviceMotionAvailable else { return }
+        // Reset the state machine each time we (re-)register so a sensor
+        // event from a previous session can't leak into the new debounce
+        // window.
+        state = .initial
+        motionManager.deviceMotionUpdateInterval = 1.0 / 30.0
+        motionManager.startDeviceMotionUpdates(to: queue) { [weak self] motion, _ in
+            guard let self, let motion else { return }
+            self.handle(gravityZ: motion.gravity.z, timestamp: motion.timestamp)
+        }
+    }
+
+    /// Idempotent.
+    func stop() {
+        guard motionManager.isDeviceMotionActive else { return }
+        motionManager.stopDeviceMotionUpdates()
+        state = .initial
+    }
+
+    private func handle(gravityZ: Double, timestamp: TimeInterval) {
+        let faceDown = Self.isFaceDown(gravityZ: gravityZ)
+        state = Self.nextState(current: state, isFaceDown: faceDown, timestamp: timestamp)
+        if state.didFire {
+            DispatchQueue.main.async { [weak self] in self?.onFaceDown() }
+        }
+    }
+
+    // MARK: - Pure logic (no CoreMotion dependency)
+
+    static func isFaceDown(gravityZ: Double) -> Bool {
+        gravityZ >= faceDownThreshold
+    }
+
+    /// Advance the debounce machine by one sensor event.
+    ///
+    /// The committed `phase` only transitions when the predicate has held for
+    /// at least `debounceInterval`. `didFire` is `true` only on the specific
+    /// transition Upright → FaceDown; all other transitions (including the
+    /// cold-start Unknown → FaceDown) leave `didFire = false`.
+    static func nextState(
+        current: State,
+        isFaceDown: Bool,
+        timestamp: TimeInterval
+    ) -> State {
+        var next = current
+        if next.windowStart == nil || isFaceDown != next.pendingFaceDown {
+            next.pendingFaceDown = isFaceDown
+            next.windowStart = timestamp
+            next.didFire = false
+            return next
+        }
+        let elapsed = timestamp - (next.windowStart ?? timestamp)
+        if elapsed < debounceInterval {
+            next.didFire = false
+            return next
+        }
+        let target: Phase = isFaceDown ? .faceDown : .upright
+        if target == next.phase {
+            next.didFire = false
+            return next
+        }
+        next.didFire = (next.phase == .upright && target == .faceDown)
+        next.phase = target
+        return next
+    }
+}
+#endif

--- a/swift/TigerDuck/App/AppConstants.swift
+++ b/swift/TigerDuck/App/AppConstants.swift
@@ -100,6 +100,7 @@ nonisolated enum AppConstants {
         static let macConfiguredTabs = "macConfiguredTabs"
         static let invertSliderDirection = "invertSliderDirection"
         static let libraryFeatureEnabled = "libraryFeatureEnabled"
+        static let flipToLibraryEnabled = "flipToLibraryEnabled"
         static let homeSectionLayout = "homeSectionLayout"
         static let visualPreset = "visualPreset"
 

--- a/swift/TigerDuck/App/AppDefaults.swift
+++ b/swift/TigerDuck/App/AppDefaults.swift
@@ -54,6 +54,13 @@ nonisolated extension Defaults.Keys {
         AppConstants.UserDefaultsKeys.libraryFeatureEnabled,
         default: false
     )
+    /// Default ON: the gesture is harmless when the parent library feature
+    /// is off (which is itself default-off), and the first-trigger prompt
+    /// gives users an explicit choice on their first accidental flip.
+    static let flipToLibraryEnabled = Key<Bool>(
+        AppConstants.UserDefaultsKeys.flipToLibraryEnabled,
+        default: true
+    )
     static let homeSectionLayoutData = Key<Data?>(
         AppConstants.UserDefaultsKeys.homeSectionLayout
     )

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -383,6 +383,13 @@ final class AppState {
         didSet { Defaults[.libraryFeatureEnabled] = libraryFeatureEnabled }
     }
 
+    /// Whether the "flip phone face-down to open Library QR" gesture is armed.
+    /// iPhone-only at the read site; macOS still persists the bool via
+    /// `Defaults` since the property lives on the cross-platform `AppState`.
+    var flipToLibraryEnabled: Bool = Defaults[.flipToLibraryEnabled] {
+        didSet { Defaults[.flipToLibraryEnabled] = flipToLibraryEnabled }
+    }
+
     /// User-selected visual preset controlling presentation-layer decisions
     /// (card surfaces, accent usage, slider color prominence, etc). This is
     /// a pure UI concern — changes MUST NOT trigger Live Activity refreshes,

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -233,6 +233,13 @@ final class AppState {
     /// "enable first" alert. Not persisted — lives only within the process.
     var pendingLibraryEnablePrompt = false
 
+    /// Transient deep-link into the More tab's NavigationStack. Set when a
+    /// feature needs to be opened but isn't pinned as a top-level tab (e.g.
+    /// flip-to-Library when the user hasn't added the Library tab to their
+    /// tab bar). `MoreView` observes this, appends the feature to its local
+    /// navigationPath, and clears the flag. Not persisted.
+    var pendingMoreDeepLink: AppFeature?
+
     func openFromWidget(_ destination: WidgetDestination) {
         pendingWidgetDestination = destination
     }

--- a/swift/TigerDuck/App/FlipToLibraryCoordinator.swift
+++ b/swift/TigerDuck/App/FlipToLibraryCoordinator.swift
@@ -125,9 +125,20 @@ private struct FlipToLibraryModifier: ViewModifier {
 }
 
 extension View {
-    /// Install the flip-to-library sensor lifecycle on this view. iPhone only.
+    /// Install the flip-to-library sensor lifecycle on this view. iPhone
+    /// only — on iPad the modifier is intentionally never attached, so no
+    /// scene-phase / preference observers fire and no `FlipDetector` is
+    /// ever instantiated. This matches the hidden Settings row in
+    /// `OtherSettingsView`: on iPad the feature does not exist at all.
+    /// The inner `shouldBeActive` guard keeps the iPhone-side belt for
+    /// `FlipDetector.isSupported` and runtime state.
+    @ViewBuilder
     func flipToLibraryAttached() -> some View {
-        modifier(FlipToLibraryModifier())
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            modifier(FlipToLibraryModifier())
+        } else {
+            self
+        }
     }
 }
 #endif

--- a/swift/TigerDuck/App/FlipToLibraryCoordinator.swift
+++ b/swift/TigerDuck/App/FlipToLibraryCoordinator.swift
@@ -18,7 +18,15 @@ private struct FlipToLibraryModifier: ViewModifier {
             .onAppear { reconcile() }
             .onChange(of: appState.flipToLibraryEnabled) { _, _ in reconcile() }
             .onChange(of: appState.libraryFeatureEnabled) { _, _ in reconcile() }
-            .onChange(of: scenePhase) { _, _ in reconcile() }
+            .onChange(of: scenePhase) { _, new in
+                // Only tear down on .background — .inactive happens for
+                // transient interruptions (Control Center pull, banner) and
+                // tearing down on those would wipe in-progress debounce
+                // state and churn CoreMotion several times per minute.
+                if new == .background || new == .active {
+                    reconcile()
+                }
+            }
             .onDisappear {
                 detector?.stop()
                 detector = nil
@@ -30,26 +38,39 @@ private struct FlipToLibraryModifier: ViewModifier {
             && FlipDetector.isSupported
             && appState.flipToLibraryEnabled
             && appState.libraryFeatureEnabled
-            && scenePhase == .active
+            && scenePhase != .background
     }
 
     private func reconcile() {
         if shouldBeActive {
             if detector == nil {
-                detector = FlipDetector { handleFaceDown() }
+                // Capture appState explicitly rather than relying on the
+                // modifier struct's @Environment wrapper inside an escaping
+                // closure (Apple's guidance: snapshot env values into local
+                // bindings before passing into long-lived closures).
+                let appState = self.appState
+                detector = FlipDetector { handleFaceDown(appState: appState) }
             }
             detector?.start()
         } else {
             detector?.stop()
+            detector = nil
         }
     }
 
-    private func handleFaceDown() {
+    private func handleFaceDown(appState: AppState) {
         // Fire-time guards: settings can flip while a sensor event was in
         // flight, and the library session can come and go independently of
         // the registration gate.
         guard appState.libraryFeatureEnabled,
               appState.flipToLibraryEnabled else { return }
+
+        // Don't fight an already-open root-level sheet. The first-trigger
+        // host attaches to MainTabView while the NTUST login host attaches
+        // to ContentView; presenting our sheet over login would land in
+        // SwiftUI's undefined sheet-stacking territory. Navigation is also
+        // unhelpful while a modal is up.
+        guard !appState.isShowingNTUSTLoginSheet else { return }
 
         // First-trigger UX: the toggle defaults to ON so the user discovers
         // the feature on their first accidental flip. The prompt explains

--- a/swift/TigerDuck/App/FlipToLibraryCoordinator.swift
+++ b/swift/TigerDuck/App/FlipToLibraryCoordinator.swift
@@ -65,12 +65,20 @@ private struct FlipToLibraryModifier: ViewModifier {
         guard appState.libraryFeatureEnabled,
               appState.flipToLibraryEnabled else { return }
 
-        // Don't fight an already-open root-level sheet. The first-trigger
-        // host attaches to MainTabView while the NTUST login host attaches
-        // to ContentView; presenting our sheet over login would land in
-        // SwiftUI's undefined sheet-stacking territory. Navigation is also
-        // unhelpful while a modal is up.
-        guard !appState.isShowingNTUSTLoginSheet else { return }
+        // Don't fight any already-open modal. The first-trigger prompt is
+        // a root-level sheet, and presenting it over another sheet (NTUST
+        // login, Settings flows, tab editor, in-app browser, feedback,
+        // course pickers, etc.) lands in SwiftUI's undefined
+        // sheet-stacking territory — SwiftUI may reject or defer the
+        // presentation, leaving the prompt invisible while `pending` is
+        // already set. Navigation is also unhelpful while a modal covers
+        // the TabView: a steady-state flip would switch tabs behind the
+        // modal so the user has to dismiss the sheet to find the QR.
+        //
+        // Sheets are not centrally tracked (most use local `@State` in
+        // their owning view), so query UIKit's presentation chain — every
+        // SwiftUI sheet is a UIKit modal underneath.
+        guard !Self.isAnyModalPresented() else { return }
 
         // First-trigger UX: the toggle defaults to ON so the user discovers
         // the feature on their first accidental flip. The prompt explains
@@ -99,6 +107,20 @@ private struct FlipToLibraryModifier: ViewModifier {
         // already handles the unauth case gracefully).
         appState.openFromWidget(.library)
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+    }
+
+    /// True when the foreground-active window has anything modally
+    /// presented above its root. Walks the presentation chain because the
+    /// topmost modal is the one that would conflict — sheets-over-sheets
+    /// are rare in this app but the walk is cheap.
+    private static func isAnyModalPresented() -> Bool {
+        let scene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }
+        guard let window = scene?.windows.first(where: \.isKeyWindow) ?? scene?.windows.first,
+              let root = window.rootViewController
+        else { return false }
+        return root.presentedViewController != nil
     }
 }
 

--- a/swift/TigerDuck/App/FlipToLibraryCoordinator.swift
+++ b/swift/TigerDuck/App/FlipToLibraryCoordinator.swift
@@ -1,0 +1,90 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// Wires `FlipDetector` into the app, gated by user opt-in, the parent
+/// library feature toggle, scene phase, and idiom. On a successful face-down
+/// gesture, routes through the existing widget-destination drain so tab
+/// switching (and the "library disabled" fall-through) stays in one place.
+///
+/// Attach to the root tab view via `.flipToLibraryAttached()`.
+private struct FlipToLibraryModifier: ViewModifier {
+    @Environment(AppState.self) private var appState
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var detector: FlipDetector?
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { reconcile() }
+            .onChange(of: appState.flipToLibraryEnabled) { _, _ in reconcile() }
+            .onChange(of: appState.libraryFeatureEnabled) { _, _ in reconcile() }
+            .onChange(of: scenePhase) { _, _ in reconcile() }
+            .onDisappear {
+                detector?.stop()
+                detector = nil
+            }
+    }
+
+    private var shouldBeActive: Bool {
+        UIDevice.current.userInterfaceIdiom == .phone
+            && FlipDetector.isSupported
+            && appState.flipToLibraryEnabled
+            && appState.libraryFeatureEnabled
+            && scenePhase == .active
+    }
+
+    private func reconcile() {
+        if shouldBeActive {
+            if detector == nil {
+                detector = FlipDetector { handleFaceDown() }
+            }
+            detector?.start()
+        } else {
+            detector?.stop()
+        }
+    }
+
+    private func handleFaceDown() {
+        // Fire-time guards: settings can flip while a sensor event was in
+        // flight, and the library session can come and go independently of
+        // the registration gate.
+        guard appState.libraryFeatureEnabled,
+              appState.flipToLibraryEnabled else { return }
+
+        // First-trigger UX: the toggle defaults to ON so the user discovers
+        // the feature on their first accidental flip. The prompt explains
+        // what just happened and lets them keep or disable it — no
+        // navigation happens on this first event so the user is not
+        // jump-scared into an unfamiliar tab.
+        if !FirstTriggerPromptCenter.shared.hasSeen(.flipToLibrary) {
+            FirstTriggerPromptCenter.shared.requestIfFirstTime(.flipToLibrary) {
+                FirstTriggerPromptContent(
+                    title: String(localized: "first_trigger_flip_to_library_title"),
+                    message: String(localized: "first_trigger_flip_to_library_message"),
+                    animation: .phoneFlip,
+                    acceptLabel: String(localized: "first_trigger_flip_to_library_keep"),
+                    declineLabel: String(localized: "first_trigger_flip_to_library_turn_off"),
+                    onAccept: { /* leave toggle on, no nav this time */ },
+                    onDecline: { appState.flipToLibraryEnabled = false }
+                )
+            }
+            return
+        }
+
+        // Steady-state: navigate. Library session is not a registration gate
+        // — when logged out, the existing `openFromWidget(.library)` drain
+        // surfaces the login flow inside the Library tab, which is the
+        // correct UX (Android silently no-ops, but the iOS Library view
+        // already handles the unauth case gracefully).
+        appState.openFromWidget(.library)
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+    }
+}
+
+extension View {
+    /// Install the flip-to-library sensor lifecycle on this view. iPhone only.
+    func flipToLibraryAttached() -> some View {
+        modifier(FlipToLibraryModifier())
+    }
+}
+#endif

--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -109,13 +109,17 @@ struct MainTabView: View {
             // defaults pin only Home/Class/Calendar, and the Settings enable
             // path only auto-adds Library when there is room). Selecting a
             // value that no `Tab` matches would leave the `TabView` in a
-            // broken state, so route to More — library lives under that
-            // category and the user is one tap away.
+            // broken state, so route to More and ask MoreView to push the
+            // Library destination onto its NavigationStack — that's the
+            // only path that actually surfaces the QR. Just switching to
+            // More would leave the user on the category list and the
+            // flip would silently fail to open Library.
             if appState.libraryFeatureEnabled {
                 if visibleTabs.contains(.library) {
                     selectedTab = .library
                 } else {
                     selectedTab = .more
+                    appState.pendingMoreDeepLink = .library
                 }
             } else {
                 selectedTab = .more

--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -104,8 +104,19 @@ struct MainTabView: View {
             // Library has a feature-disabled flag; if disabled, send the user
             // to the More tab and raise an "enable first" alert there, mirroring
             // the Android library-shortcut behavior.
+            //
+            // Library can also be enabled-but-not-pinned-as-a-tab (fresh
+            // defaults pin only Home/Class/Calendar, and the Settings enable
+            // path only auto-adds Library when there is room). Selecting a
+            // value that no `Tab` matches would leave the `TabView` in a
+            // broken state, so route to More — library lives under that
+            // category and the user is one tap away.
             if appState.libraryFeatureEnabled {
-                selectedTab = .library
+                if visibleTabs.contains(.library) {
+                    selectedTab = .library
+                } else {
+                    selectedTab = .more
+                }
             } else {
                 selectedTab = .more
                 appState.pendingLibraryEnablePrompt = true

--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -85,6 +85,10 @@ struct MainTabView: View {
                 showTimezoneAlert = true
             }
         }
+        #if os(iOS)
+        .flipToLibraryAttached()
+        .firstTriggerPromptHost()
+        #endif
     }
 
     private func evaluateTimezoneAlert() {

--- a/swift/TigerDuck/Features/More/MoreView.swift
+++ b/swift/TigerDuck/Features/More/MoreView.swift
@@ -76,6 +76,17 @@ struct MoreView: View {
                 moreDestination(for: feature)
             }
         }
+        // Consume deep-links from callers that can't reach this view's
+        // local navigationPath directly (e.g. the flip-to-Library
+        // coordinator routing here when Library is enabled but not pinned
+        // as a top-level tab). `initial: true` covers cold-launch /
+        // tab-switch ordering where the flag is already set by the time
+        // the body re-renders.
+        .onChange(of: appState.pendingMoreDeepLink, initial: true) { _, new in
+            guard let new else { return }
+            navigationPath.append(new)
+            appState.pendingMoreDeepLink = nil
+        }
     }
 
     @ViewBuilder

--- a/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
 
 /// Sub-page collecting the "miscellaneous" settings that used to live as a
 /// run of header-less Sections at the bottom of `SettingsView`'s
@@ -27,6 +30,25 @@ struct OtherSettingsView: View {
             Section {
                 Toggle(String(localized: "settings_invert_slider_direction"), isOn: $appState.invertSliderDirection)
             }
+            #if os(iOS)
+            // Flip-to-Library: only meaningful when the library feature is
+            // on (the gesture routes to the Library tab) and only available
+            // on iPhone (iPad use case is unclear and the issue scope says
+            // "phone only"). Mirrors the Android equivalent in
+            // `Settings → 圖書館 → 翻轉開啟圖書館 QR`.
+            if appState.libraryFeatureEnabled
+                && UIDevice.current.userInterfaceIdiom == .phone
+                && FlipDetector.isSupported {
+                Section {
+                    Toggle(
+                        String(localized: "settings_flip_to_library_title"),
+                        isOn: $appState.flipToLibraryEnabled
+                    )
+                } footer: {
+                    Text(String(localized: "settings_flip_to_library_summary"))
+                }
+            }
+            #endif
             Section {
                 Button {
                     showReassignColorsConfirm = true

--- a/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
@@ -40,14 +40,17 @@ struct OtherSettingsView: View {
             // The row is rendered (not hidden) even when library is off so
             // the user can see the preference exists and inspect its state
             // before enabling library — hiding it caused users who turned
-            // library off-then-on to be silently re-armed.
+            // library off-then-on to be silently re-armed. The toggle is
+            // also kept enabled in that state so the user can opt out
+            // before flipping the library feature back on; the gesture is
+            // gated at fire time by `libraryFeatureEnabled` in the
+            // coordinator either way.
             if UIDevice.current.userInterfaceIdiom == .phone && FlipDetector.isSupported {
                 Section {
                     Toggle(
                         String(localized: "settings_flip_to_library_title"),
                         isOn: $appState.flipToLibraryEnabled
                     )
-                    .disabled(!appState.libraryFeatureEnabled)
                 } footer: {
                     Text(String(localized: "settings_flip_to_library_summary"))
                 }

--- a/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
@@ -36,14 +36,18 @@ struct OtherSettingsView: View {
             // on iPhone (iPad use case is unclear and the issue scope says
             // "phone only"). Mirrors the Android equivalent in
             // `Settings → 圖書館 → 翻轉開啟圖書館 QR`.
-            if appState.libraryFeatureEnabled
-                && UIDevice.current.userInterfaceIdiom == .phone
-                && FlipDetector.isSupported {
+            //
+            // The row is rendered (not hidden) even when library is off so
+            // the user can see the preference exists and inspect its state
+            // before enabling library — hiding it caused users who turned
+            // library off-then-on to be silently re-armed.
+            if UIDevice.current.userInterfaceIdiom == .phone && FlipDetector.isSupported {
                 Section {
                     Toggle(
                         String(localized: "settings_flip_to_library_title"),
                         isOn: $appState.flipToLibraryEnabled
                     )
+                    .disabled(!appState.libraryFeatureEnabled)
                 } footer: {
                     Text(String(localized: "settings_flip_to_library_summary"))
                 }

--- a/swift/TigerDuck/Shared/FirstTriggerPrompt.swift
+++ b/swift/TigerDuck/Shared/FirstTriggerPrompt.swift
@@ -79,18 +79,30 @@ final class FirstTriggerPromptCenter {
         pending = Pending(key: key, content: build())
     }
 
-    /// Called by the sheet's buttons. Marks the prompt seen (regardless of
-    /// accept/decline) so it never auto-pops again, fires the corresponding
-    /// closure, and clears `pending` so the sheet dismisses.
+    /// Called by the sheet's buttons. Clears `pending` (dismissing the
+    /// sheet) BEFORE invoking the user's closure so that any synchronous
+    /// SwiftUI work the closure triggers — e.g. mutating `AppState` which
+    /// fans out to `onChange` observers — runs against an already-cleared
+    /// presentation state. The seen flag is written by the sheet's own
+    /// `.onAppear` (see `markSeen(_:)`), not here, so a system-driven
+    /// dismissal between presentation and the user's tap doesn't leave the
+    /// prompt in a "seen but not chosen" limbo.
     func finish(accept: Bool) {
         guard let p = pending else { return }
-        UserDefaults.standard.set(true, forKey: Self.storageKey(p.key))
+        pending = nil
         if accept {
             p.content.onAccept()
         } else {
             p.content.onDecline()
         }
-        pending = nil
+    }
+
+    /// Mark a prompt seen the moment the user actually sees the sheet (via
+    /// `.onAppear` on the sheet content). If the sheet never presents
+    /// because something dismissed `pending` first, this never runs and
+    /// the prompt remains eligible to fire again next time.
+    func markSeen(_ key: FirstTriggerPromptKey) {
+        UserDefaults.standard.set(true, forKey: Self.storageKey(key))
     }
 
     private static func storageKey(_ key: FirstTriggerPromptKey) -> String {
@@ -101,6 +113,7 @@ final class FirstTriggerPromptCenter {
 // MARK: - Sheet
 
 private struct FirstTriggerPromptSheet: View {
+    let promptKey: FirstTriggerPromptKey
     let content: FirstTriggerPromptContent
     @Environment(\.dismiss) private var dismiss
 
@@ -146,6 +159,13 @@ private struct FirstTriggerPromptSheet: View {
         .padding(.horizontal, 24)
         .padding(.vertical, 40)
         .onAppear {
+            // Record "seen" the moment the sheet actually appears so a
+            // system-driven dismissal (parent identity change, focus
+            // steal) can't strand the user in a re-show loop, and so a
+            // sheet that never presents (queued behind another modal)
+            // remains eligible for retry.
+            FirstTriggerPromptCenter.shared.markSeen(promptKey)
+
             // Heavy impact on sheet appearance so the prompt is felt as well
             // as seen — every first-trigger prompt is an unexpected interrupt
             // and the haptic anchors it to the gesture that caused it.
@@ -204,13 +224,16 @@ private struct FirstTriggerPromptHost: ViewModifier {
     func body(content: Content) -> some View {
         @Bindable var center = center
         return content.sheet(item: $center.pending) { pending in
-            FirstTriggerPromptSheet(content: pending.content)
+            FirstTriggerPromptSheet(promptKey: pending.key, content: pending.content)
                 // `.medium` clips the animation + 2-button stack on standard
                 // phones. Tall fraction gives the prompt room to breathe
                 // without forcing a full-screen sheet (which would feel
                 // disproportionate for an opt-in question).
+                //
+                // No drag indicator: the user MUST tap Keep or Turn off
+                // (interactiveDismissDisabled) so a visible grab handle
+                // would advertise a gesture that does nothing.
                 .presentationDetents([.fraction(0.7)])
-                .presentationDragIndicator(.visible)
                 .interactiveDismissDisabled()
         }
     }

--- a/swift/TigerDuck/Shared/FirstTriggerPrompt.swift
+++ b/swift/TigerDuck/Shared/FirstTriggerPrompt.swift
@@ -1,0 +1,225 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+// MARK: - Identifier
+
+/// Strongly-typed identifier for every one-shot "first time you did X, want
+/// us to keep doing it?" prompt in the app. Adding a new prompt = add a case.
+///
+/// The `rawValue` is appended to a fixed `firstTriggerPromptSeen.` prefix and
+/// stored in `UserDefaults`, so renaming a case is a one-way migration: the
+/// new key reverts to "unseen" for upgrading users. Pick names that read well
+/// in user-facing analytics ("flipToLibrary"), not implementation details.
+enum FirstTriggerPromptKey: String {
+    case flipToLibrary
+}
+
+// MARK: - Content model
+
+/// A single "first trigger" prompt's content. Constructed lazily by the
+/// caller via `FirstTriggerPromptCenter.requestIfFirstTime(_:build:)` so the
+/// closures (and the strings they pull from localization) are not evaluated
+/// when the prompt has already been seen.
+struct FirstTriggerPromptContent {
+    let title: String
+    let message: String
+    let animation: FirstTriggerAnimation
+    let acceptLabel: String
+    let declineLabel: String
+    let onAccept: () -> Void
+    let onDecline: () -> Void
+}
+
+/// Animation variants available for the prompt's hero illustration. Add cases
+/// as new features adopt the prompt — each case gets a small SwiftUI sub-view
+/// inside `FirstTriggerAnimationView`.
+enum FirstTriggerAnimation {
+    case phoneFlip
+}
+
+// MARK: - Center (state holder)
+
+/// Process-wide queue of pending first-trigger prompts. The root view binds a
+/// `.sheet(item:)` to `pending` via `.firstTriggerPromptHost()`. At most one
+/// prompt is visible at a time; rapid `requestIfFirstTime(...)` calls past
+/// the first are dropped silently.
+///
+/// Persistence is plain `UserDefaults` (not the `Defaults` library) because
+/// keys are constructed dynamically from the enum's `rawValue` and the set of
+/// known keys grows organically as features are added.
+@Observable
+final class FirstTriggerPromptCenter {
+    static let shared = FirstTriggerPromptCenter()
+
+    /// Wraps the content with an Identifiable shell so SwiftUI's
+    /// `.sheet(item:)` can drive present/dismiss directly off this property.
+    struct Pending: Identifiable {
+        let id = UUID()
+        let key: FirstTriggerPromptKey
+        let content: FirstTriggerPromptContent
+    }
+
+    var pending: Pending?
+
+    private init() {}
+
+    func hasSeen(_ key: FirstTriggerPromptKey) -> Bool {
+        UserDefaults.standard.bool(forKey: Self.storageKey(key))
+    }
+
+    /// Show the prompt iff it hasn't been seen and nothing else is currently
+    /// pending. `build` is invoked only when the prompt will actually be
+    /// shown — cheap to call from a hot path (e.g. a sensor callback).
+    func requestIfFirstTime(
+        _ key: FirstTriggerPromptKey,
+        build: () -> FirstTriggerPromptContent
+    ) {
+        guard pending == nil, !hasSeen(key) else { return }
+        pending = Pending(key: key, content: build())
+    }
+
+    /// Called by the sheet's buttons. Marks the prompt seen (regardless of
+    /// accept/decline) so it never auto-pops again, fires the corresponding
+    /// closure, and clears `pending` so the sheet dismisses.
+    func finish(accept: Bool) {
+        guard let p = pending else { return }
+        UserDefaults.standard.set(true, forKey: Self.storageKey(p.key))
+        if accept {
+            p.content.onAccept()
+        } else {
+            p.content.onDecline()
+        }
+        pending = nil
+    }
+
+    private static func storageKey(_ key: FirstTriggerPromptKey) -> String {
+        "firstTriggerPromptSeen.\(key.rawValue)"
+    }
+}
+
+// MARK: - Sheet
+
+private struct FirstTriggerPromptSheet: View {
+    let content: FirstTriggerPromptContent
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 24) {
+            FirstTriggerAnimationView(animation: content.animation)
+                .frame(height: 140)
+
+            Text(content.title)
+                .font(.title2.bold())
+                .multilineTextAlignment(.center)
+
+            Text(content.message)
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 0)
+
+            VStack(spacing: 10) {
+                Button {
+                    FirstTriggerPromptCenter.shared.finish(accept: true)
+                } label: {
+                    Text(content.acceptLabel)
+                        .font(.body.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button {
+                    FirstTriggerPromptCenter.shared.finish(accept: false)
+                } label: {
+                    Text(content.declineLabel)
+                        .font(.body.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 40)
+        .onAppear {
+            // Heavy impact on sheet appearance so the prompt is felt as well
+            // as seen — every first-trigger prompt is an unexpected interrupt
+            // and the haptic anchors it to the gesture that caused it.
+            UIImpactFeedbackGenerator(style: .heavy).impactOccurred(intensity: 1.0)
+        }
+    }
+}
+
+// MARK: - Animation
+
+private struct FirstTriggerAnimationView: View {
+    let animation: FirstTriggerAnimation
+    @State private var flipped = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// SF Symbol switches between iPhone and iPad glyph based on idiom so the
+    /// same reusable prompt looks right on either device when future features
+    /// adopt this animation. Flip-to-Library itself is iPhone-only, but the
+    /// prompt system is feature-agnostic.
+    private var deviceSymbol: String {
+        UIDevice.current.userInterfaceIdiom == .pad ? "ipad.gen2" : "iphone.gen3"
+    }
+
+    var body: some View {
+        switch animation {
+        case .phoneFlip:
+            Image(systemName: deviceSymbol)
+                .font(.system(size: 96, weight: .regular))
+                .foregroundStyle(.tint)
+                // Rotate around the device's long edge (Y axis in portrait):
+                // the phone "tips over sideways" the way you'd naturally flip
+                // it to lay it face-down on a table.
+                .rotation3DEffect(
+                    .degrees(flipped ? 180 : 0),
+                    axis: (x: 0, y: 1, z: 0),
+                    perspective: 0.4
+                )
+                .onAppear {
+                    guard !reduceMotion else { return }
+                    withAnimation(
+                        .easeInOut(duration: 1.6).repeatForever(autoreverses: true)
+                    ) {
+                        flipped = true
+                    }
+                }
+                .accessibilityLabel(Text(String(localized: "first_trigger_phone_flip_accessibility")))
+        }
+    }
+}
+
+// MARK: - Host modifier
+
+private struct FirstTriggerPromptHost: ViewModifier {
+    @State private var center = FirstTriggerPromptCenter.shared
+
+    func body(content: Content) -> some View {
+        @Bindable var center = center
+        return content.sheet(item: $center.pending) { pending in
+            FirstTriggerPromptSheet(content: pending.content)
+                // `.medium` clips the animation + 2-button stack on standard
+                // phones. Tall fraction gives the prompt room to breathe
+                // without forcing a full-screen sheet (which would feel
+                // disproportionate for an opt-in question).
+                .presentationDetents([.fraction(0.7)])
+                .presentationDragIndicator(.visible)
+                .interactiveDismissDisabled()
+        }
+    }
+}
+
+extension View {
+    /// Install the first-trigger prompt sheet host. Apply once near the root.
+    func firstTriggerPromptHost() -> some View {
+        modifier(FirstTriggerPromptHost())
+    }
+}
+#endif

--- a/swift/TigerDuck/Shared/FirstTriggerPrompt.swift
+++ b/swift/TigerDuck/Shared/FirstTriggerPrompt.swift
@@ -79,16 +79,21 @@ final class FirstTriggerPromptCenter {
         pending = Pending(key: key, content: build())
     }
 
-    /// Called by the sheet's buttons. Clears `pending` (dismissing the
-    /// sheet) BEFORE invoking the user's closure so that any synchronous
-    /// SwiftUI work the closure triggers — e.g. mutating `AppState` which
-    /// fans out to `onChange` observers — runs against an already-cleared
-    /// presentation state. The seen flag is written by the sheet's own
-    /// `.onAppear` (see `markSeen(_:)`), not here, so a system-driven
-    /// dismissal between presentation and the user's tap doesn't leave the
-    /// prompt in a "seen but not chosen" limbo.
+    /// Called by the sheet's buttons. Marks the prompt seen and clears
+    /// `pending` (dismissing the sheet) BEFORE invoking the user's closure
+    /// so that any synchronous SwiftUI work the closure triggers — e.g.
+    /// mutating `AppState` which fans out to `onChange` observers — runs
+    /// against an already-cleared presentation state.
+    ///
+    /// The seen flag is written here, not on `.onAppear`, so that a sheet
+    /// dismissed by anything other than a Keep/Turn-off tap (app backgrounded,
+    /// root view recreated, another presentation steals focus) does NOT count
+    /// as the user having made a choice. Re-showing on a later flip is the
+    /// correct behavior — silently treating "seen" as "agreed to keep it on"
+    /// would arm the gesture without consent.
     func finish(accept: Bool) {
         guard let p = pending else { return }
+        markSeen(p.key)
         pending = nil
         if accept {
             p.content.onAccept()
@@ -97,10 +102,6 @@ final class FirstTriggerPromptCenter {
         }
     }
 
-    /// Mark a prompt seen the moment the user actually sees the sheet (via
-    /// `.onAppear` on the sheet content). If the sheet never presents
-    /// because something dismissed `pending` first, this never runs and
-    /// the prompt remains eligible to fire again next time.
     func markSeen(_ key: FirstTriggerPromptKey) {
         UserDefaults.standard.set(true, forKey: Self.storageKey(key))
     }
@@ -159,16 +160,12 @@ private struct FirstTriggerPromptSheet: View {
         .padding(.horizontal, 24)
         .padding(.vertical, 40)
         .onAppear {
-            // Record "seen" the moment the sheet actually appears so a
-            // system-driven dismissal (parent identity change, focus
-            // steal) can't strand the user in a re-show loop, and so a
-            // sheet that never presents (queued behind another modal)
-            // remains eligible for retry.
-            FirstTriggerPromptCenter.shared.markSeen(promptKey)
-
             // Heavy impact on sheet appearance so the prompt is felt as well
             // as seen — every first-trigger prompt is an unexpected interrupt
             // and the haptic anchors it to the gesture that caused it.
+            //
+            // The "seen" flag is recorded in `finish(accept:)` on a Keep or
+            // Turn-off tap, not here — see that method's comment.
             UIImpactFeedbackGenerator(style: .heavy).impactOccurred(intensity: 1.0)
         }
     }

--- a/swift/TigerDuck/Shared/FirstTriggerPrompt.swift
+++ b/swift/TigerDuck/Shared/FirstTriggerPrompt.swift
@@ -220,7 +220,23 @@ private struct FirstTriggerPromptHost: ViewModifier {
 
     func body(content: Content) -> some View {
         @Bindable var center = center
-        return content.sheet(item: $center.pending) { pending in
+        return content.sheet(
+            item: $center.pending,
+            onDismiss: {
+                // Defensive cleanup: if the sheet went away by any path
+                // other than a Keep/Turn-off tap (`finish(_:)` marks seen
+                // before clearing `pending`), the seen flag is still
+                // false. Clear the stranded `pending` so the next flip
+                // can re-enter `requestIfFirstTime` and surface the
+                // prompt again — otherwise the user is stuck with
+                // `pending != nil`, default-true `flipToLibraryEnabled`,
+                // and no way to make a choice until process restart.
+                if let stranded = center.pending,
+                   !center.hasSeen(stranded.key) {
+                    center.pending = nil
+                }
+            }
+        ) { pending in
             FirstTriggerPromptSheet(promptKey: pending.key, content: pending.content)
                 // `.medium` clips the animation + 2-button stack on standard
                 // phones. Tall fraction gives the prompt room to breathe

--- a/swift/TigerDuckTests/FlipDetectorTests.swift
+++ b/swift/TigerDuckTests/FlipDetectorTests.swift
@@ -1,0 +1,199 @@
+#if os(iOS)
+import Foundation
+import Testing
+@testable import TigerDuck
+
+/// Tests for `FlipDetector`'s pure debounce machine. The CoreMotion glue
+/// (`start` / `stop`) is intentionally not exercised — `nextState` is the
+/// piece with non-trivial branching, and the file header documents it as
+/// designed to be unit-testable.
+struct FlipDetectorTests {
+
+    private static let debounce = FlipDetector.debounceInterval
+    private static let pastDebounce = debounce + 0.05
+
+    // MARK: - isFaceDown
+
+    @Test
+    func isFaceDown_atAndAboveThreshold_isTrue() {
+        #expect(FlipDetector.isFaceDown(gravityZ: FlipDetector.faceDownThreshold))
+        #expect(FlipDetector.isFaceDown(gravityZ: 0.99))
+        #expect(FlipDetector.isFaceDown(gravityZ: 1.0))
+    }
+
+    @Test
+    func isFaceDown_belowThreshold_isFalse() {
+        #expect(!FlipDetector.isFaceDown(gravityZ: FlipDetector.faceDownThreshold - 0.0001))
+        #expect(!FlipDetector.isFaceDown(gravityZ: 0.0))
+        #expect(!FlipDetector.isFaceDown(gravityZ: -1.0))
+    }
+
+    // MARK: - nextState — cold start (Unknown phase)
+
+    /// Documented invariant: opening the app with the phone already face-down
+    /// must NOT auto-fire. The first event anchors the window; once the
+    /// debounce has elapsed, we commit to `.faceDown` but `didFire` stays
+    /// false because the previous phase was `.unknown`, not `.upright`.
+    @Test
+    func coldStart_phoneAlreadyFaceDown_doesNotFire() {
+        var s = FlipDetector.State.initial
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 0)
+        #expect(!s.didFire)
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: Self.pastDebounce)
+        #expect(s.phase == .faceDown)
+        #expect(!s.didFire, "Unknown → FaceDown must never fire onFaceDown")
+    }
+
+    @Test
+    func coldStart_phoneUpright_doesNotFire() {
+        var s = FlipDetector.State.initial
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 0)
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: Self.pastDebounce)
+        #expect(s.phase == .upright)
+        #expect(!s.didFire)
+    }
+
+    // MARK: - nextState — the actual flip
+
+    /// Upright → FaceDown (held past debounce) is the ONE transition that
+    /// fires. This is the whole point of the detector.
+    @Test
+    func upright_thenFaceDown_pastDebounce_fires() {
+        var s = FlipDetector.State.initial
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 0)
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: Self.pastDebounce)
+        #expect(s.phase == .upright)
+
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 1.0)
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 1.0 + Self.pastDebounce)
+        #expect(s.phase == .faceDown)
+        #expect(s.didFire)
+    }
+
+    // MARK: - nextState — debounce filters flicker
+
+    @Test
+    func flicker_underDebounce_doesNotFire() {
+        var s = FlipDetector.State.initial
+        // Establish upright phase.
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 0)
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: Self.pastDebounce)
+        #expect(s.phase == .upright)
+
+        // Brief face-down spike (0.1s) — predicate flips back before debounce.
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 1.0)
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 1.1)
+        #expect(!s.didFire)
+        #expect(s.phase == .upright, "phase must not have committed mid-flicker")
+
+        // Back to upright, also brief.
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 1.2)
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 1.3)
+        #expect(!s.didFire)
+        #expect(s.phase == .upright)
+    }
+
+    // MARK: - nextState — second flip after returning upright
+
+    @Test
+    func faceDown_thenUpright_thenFaceDown_firesTwice() {
+        var s = FlipDetector.State.initial
+        // Cold start upright.
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 0)
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: Self.pastDebounce)
+        #expect(s.phase == .upright)
+
+        // First flip down — fires.
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 1.0)
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 1.0 + Self.pastDebounce)
+        #expect(s.didFire)
+
+        // Return upright — no fire.
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 2.0)
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 2.0 + Self.pastDebounce)
+        #expect(s.phase == .upright)
+        #expect(!s.didFire)
+
+        // Second flip down — fires again.
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 3.0)
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 3.0 + Self.pastDebounce)
+        #expect(s.didFire)
+    }
+
+    // MARK: - nextState — discontinuity / wake-from-sleep
+
+    /// If consecutive events arrive with a gap greater than `maxEventGap`,
+    /// treat the new event as a fresh window — otherwise a long sleep would
+    /// make `timestamp - windowStart` instantly exceed `debounceInterval`
+    /// and fire on the very first post-wake read.
+    @Test
+    func wakeFromSleep_largeGap_resetsWindow() {
+        var s = FlipDetector.State.initial
+        // Establish upright.
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 0)
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: Self.pastDebounce)
+        #expect(s.phase == .upright)
+
+        // Long sleep gap — single face-down event arrives much later.
+        let postSleep = 100.0
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: postSleep)
+        #expect(!s.didFire, "single post-wake event must not instantly fire")
+        #expect(s.phase == .upright, "phase must not have committed off a single event")
+
+        // Sustaining face-down past debounce after the discontinuity fires
+        // normally — the debounce restarts from `postSleep`, not from the
+        // pre-sleep window.
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: postSleep + Self.pastDebounce)
+        #expect(s.didFire)
+        #expect(s.phase == .faceDown)
+    }
+
+    @Test
+    func backwardsTimestamp_resetsWindow() {
+        var s = FlipDetector.State.initial
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 10.0)
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 10.0 + Self.pastDebounce)
+        #expect(s.phase == .upright)
+
+        // Negative delta — treated as discontinuity.
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 5.0)
+        #expect(!s.didFire)
+        #expect(s.phase == .upright)
+    }
+
+    // MARK: - nextState — identical timestamps
+
+    @Test
+    func identicalTimestamps_noFire() {
+        var s = FlipDetector.State.initial
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 0)
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: Self.pastDebounce)
+        #expect(s.phase == .upright)
+
+        // Repeat the same event twice — zero elapsed, must not fire.
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 1.0)
+        let twin = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 1.0)
+        #expect(!twin.didFire)
+        #expect(twin.phase == .upright)
+    }
+
+    // MARK: - nextState — already in target phase
+
+    @Test
+    func sustainedFaceDown_firesExactlyOnce() {
+        var s = FlipDetector.State.initial
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: 0)
+        s = FlipDetector.nextState(current: s, isFaceDown: false, timestamp: Self.pastDebounce)
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 1.0)
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 1.0 + Self.pastDebounce)
+        #expect(s.didFire)
+
+        // Subsequent sustained face-down events past the original window
+        // must not re-fire — already committed to .faceDown.
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 1.0 + Self.pastDebounce + 0.05)
+        #expect(!s.didFire)
+        s = FlipDetector.nextState(current: s, isFaceDown: true, timestamp: 1.0 + Self.pastDebounce + 0.10)
+        #expect(!s.didFire)
+    }
+}
+#endif


### PR DESCRIPTION
Closes #151.

Adds an iPhone-only gesture: flipping the phone face-down opens the Library QR. Mirrors the Android equivalent in `Settings → 圖書館 → 翻轉開啟圖書館 QR`.

## Summary
- `FlipDetector` (CoreMotion-backed, ~32° face-down window, 0.4s debounce, cold-start Unknown phase blocks auto-fire) with pure `nextState` helpers
- `FlipToLibraryCoordinator` (`.flipToLibraryAttached()` modifier) gates the sensor on idiom, sensor availability, the library feature toggle, and scene phase; routes through the existing `openFromWidget(.library)` drain
- Reusable first-trigger prompt sheet host (`FirstTriggerPromptCenter` + `.firstTriggerPromptHost()`) — opt-in design: the toggle defaults on, and the first accidental flip surfaces an explainer with Keep / Turn off, no navigation on that first event
- Settings row under Settings → Other (iPhone-only when sensor is supported)
- Localization for prompt + settings strings across all locales

## Code review fixes (second commit)
After running an extra-high-effort code review against `dev`, addressed 13 of 15 findings:
- **FlipDetector**: lock-guarded state between sensor queue and main, `static let isSupported` (no more CMMotionManager churn), wake-from-sleep discontinuity reset via `lastTimestamp` + `maxEventGap`, `deinit { stop }`
- **Coordinator**: tear down only on `.background` (not transient `.inactive`), explicit `appState` capture into the detector closure, `guard !isShowingNTUSTLoginSheet` to avoid sheet-stacking
- **Prompt sheet**: mark-seen on `.onAppear` (not in `finish()`) so system dismissals can't strand the user; `pending = nil` before invoking the closure; dropped the misleading drag indicator paired with `interactiveDismissDisabled`
- **Settings**: toggle always rendered on supported phones, disabled when library is off (no longer vanishes / silently re-arms)
- **Tests**: added `FlipDetectorTests` covering 9 `nextState` scenarios

Two findings intentionally deferred:
- `configuredTabs` filtering hides the Library tab while feature is on → pre-existing widget bug, needs a product decision on auto-restore vs. fallback
- `flipToLibraryEnabled = true` default for upgrading users → the first-trigger prompt IS the deliberate consent surface per the design comment; changing it would defeat the pattern

## Test plan
- [ ] Fresh-install fast path: enable library → flip phone face-down → first-trigger sheet appears → tap Keep → flip again → Library tab opens
- [ ] First-trigger Decline: flip → tap Turn off → toggle in Settings → Other now off, gesture inert
- [ ] Settings row visible when library is off (disabled state); enabling library re-enables the toggle
- [ ] Control Center pull while gesture is mid-flight does NOT reset debounce (detector survives `.inactive`)
- [ ] Lock device, leave face-down for a minute, unlock face-down: no auto-fire on the first post-wake event
- [ ] Backgrounding the app: detector stops; foregrounding re-arms
- [ ] iPad: settings row hidden, no detector registered
- [ ] NTUST login sheet up + flip phone: no prompt sheet collision, no nav while login is presented