### PR TITLE
feat(settings): course-name font size slider (closes #145)

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -54,6 +54,29 @@ device locale/timezone and would normally suggest pinning to
 timezone-preference plumbing; pre-pinning now would just have to be
 ripped out and would conflict with that work.
 
+## Course-name font scale is iOS/iPadOS only
+
+**Rule:** Do not flag `MacClassTableView` (`swift/TigerDuck/Platform/Mac/MacClassTableView.swift`)
+or `MacSettingsScene` (`swift/TigerDuck/Platform/Mac/MacSettingsScene.swift`)
+for "ignoring `courseCardFontScale`" or "missing a font-size control".
+The Mac app intentionally omits the per-app course-name font scale —
+both the Mac class table (which keeps `.callout.weight(.semibold)`) and
+any Mac-native widgets render at the fixed baseline.
+
+**Why:** The scale is an iOS/iPadOS accommodation for the compressed
+class-table cells on a phone screen. Mac surfaces are sized for a
+desktop window and a per-app text-size override is redundant — users
+who want larger text use the system-wide "Larger Text" accessibility
+setting instead. Adding the slider on Mac would also force a second
+source of truth for what is currently a one-platform preference.
+
+**How to apply:** If you see `MacClassTableView` rendering course names
+without reading `AppState.courseCardFontScale`, or `MacSettingsScene`
+lacking a slider for it, skip the comment. The same applies to any
+future Mac-native widget extension. The doc comment on
+`CourseCardFontScale` (in `swift/TigerDuck/Shared/CourseCardFontScale.swift`)
+spells out the exclusion.
+
 ## Greptile review
 
 **Rule:** For every review, please update confidence score as well as giving the suggestions (if any).

--- a/swift/TigerDuck.xcodeproj/project.pbxproj
+++ b/swift/TigerDuck.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 				Clock/AppClock.swift,
 				Clock/ClockOverride.swift,
 				Shared/ClassTableLayout.swift,
+				Shared/CourseCardFontScale.swift,
 				Widgets/WidgetSnapshot.swift,
 			);
 			target = B244D74E2FB87B580040D6FA /* TigerDuckWidgetsExtension */;
@@ -1020,6 +1021,7 @@
 					AppConstants.swift,
 					AppDefaults.swift,
 					AppState.swift,
+					CourseCardFontScale.swift,
 					BrowserPreference.swift,
 					MoodleOpenTarget.swift,
 					LanguageManager.swift,
@@ -1198,6 +1200,7 @@
 					AppConstants.swift,
 					AppDefaults.swift,
 					AppState.swift,
+					CourseCardFontScale.swift,
 					BrowserPreference.swift,
 					MoodleOpenTarget.swift,
 					LanguageManager.swift,

--- a/swift/TigerDuck/App/AppConstants.swift
+++ b/swift/TigerDuck/App/AppConstants.swift
@@ -101,6 +101,12 @@ nonisolated enum AppConstants {
         static let invertSliderDirection = "invertSliderDirection"
         static let libraryFeatureEnabled = "libraryFeatureEnabled"
         static let flipToLibraryEnabled = "flipToLibraryEnabled"
+        /// Multiplier (0.8…1.6) applied to the course-name font in the
+        /// class table and widget course-name labels. Stored in the App
+        /// Group `UserDefaults` suite (NOT `.standard`) so the widget
+        /// extension reads the same value — see `CourseCardFontScaleStore`.
+        /// Listed here for discoverability; the literal lives on the store.
+        static let courseCardFontScale = "courseCardFontScale"
         static let homeSectionLayout = "homeSectionLayout"
         static let visualPreset = "visualPreset"
 

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 import SwiftData
 import Defaults
+#if canImport(WidgetKit)
+import WidgetKit
+#endif
 
 @Observable
 final class AppState {
@@ -395,6 +398,37 @@ final class AppState {
     /// `Defaults` since the property lives on the cross-platform `AppState`.
     var flipToLibraryEnabled: Bool = Defaults[.flipToLibraryEnabled] {
         didSet { Defaults[.flipToLibraryEnabled] = flipToLibraryEnabled }
+    }
+
+    /// User-selected multiplier applied to the course-name font in the
+    /// class table (`TimetableGridView`) and the course-name labels
+    /// inside home-screen widgets. 1.0 = pre-feature baseline.
+    ///
+    /// Persisted through ``CourseCardFontScaleStore`` (App Group
+    /// `UserDefaults`) rather than the `Defaults` library because the
+    /// widget extension also reads this key — keeping it in the same
+    /// suite avoids a second source-of-truth for the widget side.
+    var courseCardFontScale: Double = CourseCardFontScaleStore().read() {
+        didSet {
+            // Compare on the normalized (snapped) values so the slider's
+            // every-frame writes during a drag don't all trigger a
+            // widget reload — only when the user crossed a step boundary
+            // do we persist + reload. The store always writes the
+            // normalized value, so downstream readers (widgets,
+            // TimetableGridView) see snapped sizes regardless of the
+            // raw in-memory binding state.
+            let newSnapped = CourseCardFontScale.normalize(courseCardFontScale)
+            let oldSnapped = CourseCardFontScale.normalize(oldValue)
+            guard newSnapped != oldSnapped else { return }
+            CourseCardFontScaleStore().write(newSnapped)
+            #if canImport(WidgetKit)
+            // Widgets render in a separate process; reload all timelines
+            // so the next render of each widget reads the new scale from
+            // the App Group store. Snapshot data is unchanged, so we
+            // skip the WidgetSnapshotWriter regenerate pipeline.
+            WidgetCenter.shared.reloadAllTimelines()
+            #endif
+        }
     }
 
     /// User-selected visual preset controlling presentation-layer decisions

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -1,12 +1,17 @@
 import SwiftUI
 import SwiftData
 import Defaults
-#if canImport(WidgetKit)
-import WidgetKit
-#endif
 
 @Observable
 final class AppState {
+    /// Debounced reload channel for widgets when course-name font scale
+    /// changes. The slider's stepped binding fires didSet on every step
+    /// crossing during a drag (up to 16 across the 0.8–1.6 range), so
+    /// routing through the coordinator collapses a fast drag into a
+    /// single 300ms-debounced WidgetKit reload instead of saturating
+    /// the per-app reload budget.
+    private let widgetReloadCoordinator = WidgetReloadCoordinator()
+
     var hasCompletedOnboarding = Defaults[.hasCompletedOnboarding]
 
     /// App-level presenter flag for the NTUST login sheet. Owned by
@@ -421,13 +426,15 @@ final class AppState {
             let oldSnapped = CourseCardFontScale.normalize(oldValue)
             guard newSnapped != oldSnapped else { return }
             CourseCardFontScaleStore().write(newSnapped)
-            #if canImport(WidgetKit)
-            // Widgets render in a separate process; reload all timelines
-            // so the next render of each widget reads the new scale from
-            // the App Group store. Snapshot data is unchanged, so we
-            // skip the WidgetSnapshotWriter regenerate pipeline.
-            WidgetCenter.shared.reloadAllTimelines()
-            #endif
+            // Widgets render in a separate process; ask the coordinator
+            // for a debounced reload so a fast slider drag collapses
+            // into a single timeline refresh instead of one-per-step.
+            // Snapshot data is unchanged, so we skip the
+            // WidgetSnapshotWriter regenerate pipeline.
+            let coordinator = widgetReloadCoordinator
+            Task { @MainActor in
+                coordinator.requestReload()
+            }
         }
     }
 

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -21,6 +21,7 @@ private func weekdayDisplayName(_ weekday: Int) -> String {
 
 struct TimetableGridView: View {
     let viewModel: ClassTableViewModel
+    @Environment(AppState.self) private var appState
 
     private let cellHeight: CGFloat = 52
     private let rowSpacing: CGFloat = 3
@@ -29,7 +30,18 @@ struct TimetableGridView: View {
     private let periodWidth: CGFloat = 12
     @ScaledMetric(relativeTo: .caption2) private var badgeIconSize: CGFloat = 8
 
-    @ScaledMetric(relativeTo: .caption2) private var courseNameSize: CGFloat = 8
+    @ScaledMetric(relativeTo: .caption2) private var courseNameBaseSize: CGFloat = 8
+
+    /// User multiplier from Settings → Font size. Multiplied into the
+    /// Dynamic-Type-scaled base so the cell respects both the system
+    /// Dynamic Type preference and the user's per-app override. Reads
+    /// from `AppState` (not the store directly) so SwiftUI tracks the
+    /// `@Observable` dependency and re-renders the grid the instant the
+    /// slider moves — without that hop the cells stayed at the old size
+    /// until the app was relaunched.
+    private var courseNameSize: CGFloat {
+        courseNameBaseSize * CGFloat(appState.courseCardFontScale)
+    }
 
     private static let allWeekdayLabels = AppConstants.Periods.weekdays + AppConstants.Periods.weekendDays
 
@@ -175,8 +187,16 @@ private struct ConflictClusterView: View {
     let periodId: String
 
     @Environment(\.accessibilityDifferentiateWithoutColor) private var diffWithoutColor
+    @Environment(AppState.self) private var appState
     @ScaledMetric(relativeTo: .caption2) private var badgeIconSize: CGFloat = 8
-    @ScaledMetric(relativeTo: .caption2) private var courseNameSize: CGFloat = 8
+    @ScaledMetric(relativeTo: .caption2) private var courseNameBaseSize: CGFloat = 8
+
+    /// Same convention as `TimetableGridView.courseNameSize` — see there
+    /// for the rationale, including why we read through `AppState`
+    /// rather than `CourseCardFontScaleStore` directly.
+    private var courseNameSize: CGFloat {
+        courseNameBaseSize * CGFloat(appState.courseCardFontScale)
+    }
 
     private var courseA: SDCourse { segments[0].course }
     private var spanA: Int { segments[0].span }

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -39,8 +39,15 @@ struct TimetableGridView: View {
     /// `@Observable` dependency and re-renders the grid the instant the
     /// slider moves — without that hop the cells stayed at the old size
     /// until the app was relaunched.
+    ///
+    /// We normalize the raw in-memory value here so the live timetable
+    /// stays consistent with the App-Group-persisted value the widgets
+    /// read. The Slider's `step:` snaps interactively, but any non-Slider
+    /// writer (debug menu, migration, tests) could land us at a
+    /// non-stepped raw value — normalizing at the read site keeps all
+    /// three surfaces (timetable / Settings readout / widget) in sync.
     private var courseNameSize: CGFloat {
-        courseNameBaseSize * CGFloat(appState.courseCardFontScale)
+        courseNameBaseSize * CGFloat(CourseCardFontScale.normalize(appState.courseCardFontScale))
     }
 
     private static let allWeekdayLabels = AppConstants.Periods.weekdays + AppConstants.Periods.weekendDays
@@ -193,9 +200,10 @@ private struct ConflictClusterView: View {
 
     /// Same convention as `TimetableGridView.courseNameSize` — see there
     /// for the rationale, including why we read through `AppState`
-    /// rather than `CourseCardFontScaleStore` directly.
+    /// rather than `CourseCardFontScaleStore` directly, and why we
+    /// normalize at the read site.
     private var courseNameSize: CGFloat {
-        courseNameBaseSize * CGFloat(appState.courseCardFontScale)
+        courseNameBaseSize * CGFloat(CourseCardFontScale.normalize(appState.courseCardFontScale))
     }
 
     private var courseA: SDCourse { segments[0].course }

--- a/swift/TigerDuck/Features/Settings/Components/FontSizeSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/FontSizeSettingsView.swift
@@ -1,0 +1,203 @@
+import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
+
+/// Sub-page for picking the course-name font scale used in the class
+/// table and home-screen widgets. The selection flows through
+/// `AppState.courseCardFontScale` → `CourseCardFontScaleStore`
+/// (App Group `UserDefaults`) and is applied at the specific course-name
+/// `Text` views in `TimetableGridView` plus the widget course-name labels.
+/// Widgets read the same value on their next render after `AppState`'s
+/// `didSet` triggers `WidgetCenter.reloadAllTimelines()`.
+///
+/// Layout: a `Preview` section at the top renders a mock class-table
+/// cluster so the user can see the effect on the actual UI surface, and
+/// a `Slider` section below drives the scale. The mock includes one
+/// "solo" cell and a two-course conflict cluster so the live preview
+/// covers both rendering modes the user will see in the real timetable.
+struct FontSizeSettingsView: View {
+    @Environment(AppState.self) private var appState
+    #if os(iOS)
+    /// Matches the `TimeSliderViewModel` pattern — keep one generator
+    /// alive for the lifetime of the view so `prepare()` actually warms
+    /// the haptic engine; a fresh-per-call generator skips priming and
+    /// the first selection feels delayed.
+    @State private var hapticGenerator = UISelectionFeedbackGenerator()
+    #endif
+    /// Tracks the most recent snapped scale we've fired a haptic for, so
+    /// the slider's high-frequency `onChange` callbacks only buzz when
+    /// the value crosses a step boundary instead of on every drag tick.
+    @State private var lastHapticScale: Double = -1
+
+    var body: some View {
+        @Bindable var appState = appState
+        List {
+            Section {
+                ClassCardPreview(scale: appState.courseCardFontScale)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+            } header: {
+                Text(String(localized: "settings_font_size_preview_section"))
+            } footer: {
+                Text(String(localized: "settings_font_size_preview_footer"))
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        // Tap to nudge by one step, hold the slider to
+                        // drag freely. The two "A" anchors mirror the
+                        // iOS Settings → Display & Text Size pattern.
+                        Text("A")
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
+                        Slider(
+                            value: $appState.courseCardFontScale,
+                            in: CourseCardFontScale.minimum...CourseCardFontScale.maximum,
+                            step: CourseCardFontScale.step
+                        )
+                        Text("A")
+                            .font(.system(size: 24, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    HStack {
+                        Spacer()
+                        Text(scaleLabel(appState.courseCardFontScale))
+                            .font(.callout.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                    }
+                }
+                .padding(.vertical, 4)
+                #if os(iOS)
+                // Slider with `step:` fires onChange on every snapped
+                // tick. Gate the haptic on the normalized value so a
+                // drag from 1.00× to 1.30× produces six discrete buzzes
+                // (one per 0.05× boundary) and not one per render frame.
+                // Mirrors the `TimeSliderViewModel` selectionChanged()
+                // cadence the user already knows from Home.
+                .onChange(of: appState.courseCardFontScale) { _, newValue in
+                    let snapped = CourseCardFontScale.normalize(newValue)
+                    guard snapped != lastHapticScale else { return }
+                    lastHapticScale = snapped
+                    hapticGenerator.selectionChanged()
+                    // Re-prime for the next tick so the kernel keeps the
+                    // engine warm — `selectionChanged()` invalidates the
+                    // primed state.
+                    hapticGenerator.prepare()
+                }
+                .onAppear {
+                    // Warm the engine up front so the first drag doesn't
+                    // eat the priming latency.
+                    hapticGenerator.prepare()
+                    lastHapticScale = CourseCardFontScale.normalize(appState.courseCardFontScale)
+                }
+                #endif
+
+                Button {
+                    appState.courseCardFontScale = CourseCardFontScale.default
+                } label: {
+                    Text(String(localized: "settings_font_size_reset_button"))
+                        .foregroundStyle(.primary)
+                }
+                .disabled(
+                    CourseCardFontScale.normalize(appState.courseCardFontScale)
+                        == CourseCardFontScale.default
+                )
+            } header: {
+                Text(String(localized: "settings_font_size_picker_section"))
+            }
+        }
+        .navigationTitle(String(localized: "settings_font_size_title"))
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+
+    /// Format: `1.20×`. Uses `String(format:)` rather than a
+    /// `NumberFormatter` because the trailing `×` matches the iOS
+    /// Accessibility text-size readout style and we want consistent
+    /// width across digits via `.monospacedDigit()`.
+    private func scaleLabel(_ scale: Double) -> String {
+        String(format: "%.2f×", CourseCardFontScale.normalize(scale))
+    }
+}
+
+/// Mock class-table preview that mirrors `TimetableGridView`'s solo-cell
+/// and 2-course conflict-cluster geometry at a small scale, so the user
+/// sees the slider's effect against the same visual surface they're
+/// adjusting for. Strings are localizable mock course names — they
+/// should read as realistic course titles in every locale, not stand
+/// in as English-only placeholders.
+private struct ClassCardPreview: View {
+    let scale: Double
+
+    private let cellHeight: CGFloat = 52
+    private let rowSpacing: CGFloat = 3
+    private let cornerRadius: CGFloat = 8
+    @ScaledMetric(relativeTo: .caption2) private var courseNameBaseSize: CGFloat = 8
+
+    private var courseFontSize: CGFloat {
+        courseNameBaseSize * CGFloat(CourseCardFontScale.normalize(scale))
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: rowSpacing) {
+            soloCell
+                .frame(maxWidth: .infinity)
+                .frame(height: cellHeight)
+
+            conflictCluster
+                .frame(maxWidth: .infinity)
+                .frame(height: cellHeight * 2 + rowSpacing)
+        }
+        .padding(.horizontal, 4)
+    }
+
+    private var soloCell: some View {
+        RoundedRectangle(cornerRadius: cornerRadius)
+            .fill(Color.accentColor.opacity(0.35))
+            .overlay {
+                Text(String(localized: "settings_font_size_preview_course_name"))
+                    .font(.system(size: courseFontSize, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.7)
+                    .multilineTextAlignment(.center)
+                    .padding(2)
+            }
+    }
+
+    /// Stacked two-cell stand-in for a conflict cluster. The real
+    /// renderer interlocks two L shapes; mocking that here would drag in
+    /// `ConflictLShape` for a preview. A simple two-row stack is enough
+    /// to communicate "course names in adjacent cells stay readable
+    /// after rescaling".
+    private var conflictCluster: some View {
+        VStack(spacing: rowSpacing) {
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(Color.green.opacity(0.4))
+                .overlay {
+                    Text(String(localized: "settings_font_size_preview_course_name_alt_1"))
+                        .font(.system(size: courseFontSize, weight: .medium))
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.7)
+                        .multilineTextAlignment(.center)
+                        .padding(2)
+                }
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(Color.orange.opacity(0.4))
+                .overlay {
+                    Text(String(localized: "settings_font_size_preview_course_name_alt_2"))
+                        .font(.system(size: courseFontSize, weight: .medium))
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.7)
+                        .multilineTextAlignment(.center)
+                        .padding(2)
+                }
+        }
+    }
+}

--- a/swift/TigerDuck/Features/Settings/Components/FontSizeSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/FontSizeSettingsView.swift
@@ -28,7 +28,10 @@ struct FontSizeSettingsView: View {
     /// Tracks the most recent snapped scale we've fired a haptic for, so
     /// the slider's high-frequency `onChange` callbacks only buzz when
     /// the value crosses a step boundary instead of on every drag tick.
-    @State private var lastHapticScale: Double = -1
+    /// `nil` is the "no baseline yet" state — the first observation
+    /// silently records the baseline so a layout-pass tick before
+    /// `onAppear` can never fire a spurious haptic.
+    @State private var lastHapticScale: Double?
 
     var body: some View {
         @Bindable var appState = appState
@@ -79,8 +82,10 @@ struct FontSizeSettingsView: View {
                 // cadence the user already knows from Home.
                 .onChange(of: appState.courseCardFontScale) { _, newValue in
                     let snapped = CourseCardFontScale.normalize(newValue)
-                    guard snapped != lastHapticScale else { return }
-                    lastHapticScale = snapped
+                    defer { lastHapticScale = snapped }
+                    // First observation establishes the baseline
+                    // silently — only subsequent boundary crossings buzz.
+                    guard let last = lastHapticScale, snapped != last else { return }
                     hapticGenerator.selectionChanged()
                     // Re-prime for the next tick so the kernel keeps the
                     // engine warm — `selectionChanged()` invalidates the
@@ -91,7 +96,9 @@ struct FontSizeSettingsView: View {
                     // Warm the engine up front so the first drag doesn't
                     // eat the priming latency.
                     hapticGenerator.prepare()
-                    lastHapticScale = CourseCardFontScale.normalize(appState.courseCardFontScale)
+                    if lastHapticScale == nil {
+                        lastHapticScale = CourseCardFontScale.normalize(appState.courseCardFontScale)
+                    }
                 }
                 #endif
 
@@ -115,12 +122,13 @@ struct FontSizeSettingsView: View {
         #endif
     }
 
-    /// Format: `1.20×`. Uses `String(format:)` rather than a
-    /// `NumberFormatter` because the trailing `×` matches the iOS
-    /// Accessibility text-size readout style and we want consistent
-    /// width across digits via `.monospacedDigit()`.
+    /// Format: `1.20×` (en) / `1,20×` (de/fr/...). Uses
+    /// `.formatted(.number...)` so the decimal separator follows
+    /// `Locale.current`. `.monospacedDigit()` is applied at the call
+    /// site for stable column width during drags.
     private func scaleLabel(_ scale: Double) -> String {
-        String(format: "%.2f×", CourseCardFontScale.normalize(scale))
+        let normalized = CourseCardFontScale.normalize(scale)
+        return normalized.formatted(.number.precision(.fractionLength(2))) + "×"
     }
 }
 

--- a/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
@@ -30,6 +30,24 @@ struct OtherSettingsView: View {
             Section {
                 Toggle(String(localized: "settings_invert_slider_direction"), isOn: $appState.invertSliderDirection)
             }
+            Section {
+                NavigationLink {
+                    FontSizeSettingsView()
+                } label: {
+                    HStack {
+                        Text(String(localized: "settings_font_size_title"))
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        Text(String(format: "%.2f×",
+                                    CourseCardFontScale.normalize(appState.courseCardFontScale)))
+                            .font(.body.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            } footer: {
+                Text(String(localized: "settings_font_size_summary"))
+            }
             #if os(iOS)
             // Flip-to-Library: only meaningful when the library feature is
             // on (the gesture routes to the Library tab) and only available

--- a/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
@@ -38,8 +38,12 @@ struct OtherSettingsView: View {
                         Text(String(localized: "settings_font_size_title"))
                             .foregroundStyle(.primary)
                         Spacer()
-                        Text(String(format: "%.2f×",
-                                    CourseCardFontScale.normalize(appState.courseCardFontScale)))
+                        // Locale-aware decimal separator: en "1.20×",
+                        // de/fr/es/it "1,20×". `String(format:)` would
+                        // be POSIX-only and break the non-period locales.
+                        Text(CourseCardFontScale
+                            .normalize(appState.courseCardFontScale)
+                            .formatted(.number.precision(.fractionLength(2))) + "×")
                             .font(.body.monospacedDigit())
                             .foregroundStyle(.secondary)
                             .lineLimit(1)

--- a/swift/TigerDuck/Shared/CourseCardFontScale.swift
+++ b/swift/TigerDuck/Shared/CourseCardFontScale.swift
@@ -4,15 +4,23 @@ import SwiftUI
 
 /// Multiplier applied to the course-name font size in the class table
 /// (`TimetableGridView`) and the course-name labels inside the iOS /
-/// iPadOS / macOS home-screen widgets (Next Class, Today, Week). 1.0 =
-/// the baseline size every cell would render at without the user
-/// override.
+/// iPadOS home-screen widgets (Next Class, Today, Week). 1.0 = the
+/// baseline size every cell would render at without the user override.
 ///
-/// Scope: the watchOS widgets use a separate App Group
-/// (`group.org.ntust.app.TigerDuck.watch`) and are NOT wired up to this
-/// scale — Watch font sizing is governed by Apple's complication ramps
-/// and a sync channel would need to be added before the user-facing
-/// toggle could honor Watch surfaces.
+/// Scope — Mac is intentionally excluded: `MacClassTableView` keeps its
+/// fixed `.callout.weight(.semibold)` baseline and `MacSettingsScene`
+/// exposes no slider, so this scale is a no-op for the Mac app and any
+/// Mac-native widgets. The Mac surfaces are sized for a desktop window
+/// and a per-app text-size override is redundant there — users who
+/// want larger text use the system-wide "Larger Text" accessibility
+/// setting instead. See `.greptile/rules.md` ("Course-name font scale
+/// is iOS/iPadOS only").
+///
+/// Scope — Watch is also excluded: the watchOS widgets use a separate
+/// App Group (`group.org.ntust.app.TigerDuck.watch`) and are NOT wired
+/// up to this scale. Watch font sizing is governed by Apple's
+/// complication ramps and a sync channel would need to be added before
+/// the user-facing toggle could honor Watch surfaces.
 ///
 /// Persisted via ``CourseCardFontScaleStore`` in the App Group
 /// `UserDefaults` suite so the widget extension can read the same value

--- a/swift/TigerDuck/Shared/CourseCardFontScale.swift
+++ b/swift/TigerDuck/Shared/CourseCardFontScale.swift
@@ -1,16 +1,25 @@
 import Foundation
+import os
 import SwiftUI
 
 /// Multiplier applied to the course-name font size in the class table
-/// (`TimetableGridView`) and the course-name labels inside the home-screen
-/// widgets (Next Class, Today, Week). 1.0 = the baseline size every cell
-/// would render at without the user override.
+/// (`TimetableGridView`) and the course-name labels inside the iOS /
+/// iPadOS / macOS home-screen widgets (Next Class, Today, Week). 1.0 =
+/// the baseline size every cell would render at without the user
+/// override.
+///
+/// Scope: the watchOS widgets use a separate App Group
+/// (`group.org.ntust.app.TigerDuck.watch`) and are NOT wired up to this
+/// scale — Watch font sizing is governed by Apple's complication ramps
+/// and a sync channel would need to be added before the user-facing
+/// toggle could honor Watch surfaces.
 ///
 /// Persisted via ``CourseCardFontScaleStore`` in the App Group
 /// `UserDefaults` suite so the widget extension can read the same value
-/// the main app writes. Changing the value in the main app triggers
-/// `WidgetCenter.shared.reloadAllTimelines()` so widgets pick it up on
-/// their next render.
+/// the main app writes. Changing the value in the main app triggers a
+/// debounced widget timeline reload (see `AppState.courseCardFontScale`
+/// and `WidgetReloadCoordinator`) so widgets pick it up on their next
+/// render.
 ///
 /// The scale is intentionally narrow (0.8…1.6×): below 0.8 the names
 /// become unreadable inside the timetable cells, above 1.6× they overflow
@@ -43,16 +52,31 @@ enum CourseCardFontScale {
 
 /// App-group-backed reader/writer for the course-card font scale. Used
 /// by both the main app (read + write) and the widget extension
-/// (read-only at view body render time). Falls back to `.standard` if
-/// the App Group suite is missing so a provisioning hiccup degrades
-/// gracefully instead of crashing.
+/// (read-only at view body render time).
+///
+/// In DEBUG we crash hard if the suite is unavailable so an empty
+/// `com.apple.security.application-groups` regression cannot ship
+/// silently — same protocol as `WidgetSnapshotStore`. In release we
+/// still fall back to `.standard` with a loud error so a user with a
+/// provisioning hiccup still launches, but the divergence is no longer
+/// invisible (main app vs. widget extension would otherwise persist to
+/// different process-local stores).
 nonisolated final class CourseCardFontScaleStore {
     static let storageKey = "courseCardFontScale"
 
     private let defaults: UserDefaults
+    private let logger = Logger(subsystem: "org.ntust.app.TigerDuck", category: "FontScale")
 
     init(appGroupIdentifier: String = "group.org.ntust.app.TigerDuck") {
-        self.defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
+        if let suite = UserDefaults(suiteName: appGroupIdentifier) {
+            self.defaults = suite
+        } else {
+            assertionFailure(
+                "App Group suite '\(appGroupIdentifier)' unavailable — verify `com.apple.security.application-groups` is populated in BOTH the TigerDuck app AND TigerDuckWidgets extension entitlements and that the App Group capability is enabled on each target."
+            )
+            self.defaults = .standard
+            logger.error("App Group suite '\(appGroupIdentifier, privacy: .public)' unavailable — course-name font scale will diverge between main app and widget process")
+        }
     }
 
     /// Read the user's scale, falling back to `1.0` when unset. Always

--- a/swift/TigerDuck/Shared/CourseCardFontScale.swift
+++ b/swift/TigerDuck/Shared/CourseCardFontScale.swift
@@ -1,0 +1,77 @@
+import Foundation
+import SwiftUI
+
+/// Multiplier applied to the course-name font size in the class table
+/// (`TimetableGridView`) and the course-name labels inside the home-screen
+/// widgets (Next Class, Today, Week). 1.0 = the baseline size every cell
+/// would render at without the user override.
+///
+/// Persisted via ``CourseCardFontScaleStore`` in the App Group
+/// `UserDefaults` suite so the widget extension can read the same value
+/// the main app writes. Changing the value in the main app triggers
+/// `WidgetCenter.shared.reloadAllTimelines()` so widgets pick it up on
+/// their next render.
+///
+/// The scale is intentionally narrow (0.8…1.6×): below 0.8 the names
+/// become unreadable inside the timetable cells, above 1.6× they overflow
+/// the cell before `minimumScaleFactor` rescues them — at which point the
+/// user is fighting the layout, not customizing it.
+enum CourseCardFontScale {
+    /// Inclusive bounds the slider operates over. Out-of-range stored
+    /// values are clamped on read so a manually-edited UserDefaults value
+    /// can never escape this range.
+    static let minimum: Double = 0.8
+    static let maximum: Double = 1.6
+    /// Slider snaps to 0.05× ticks so the displayed `1.20×` value is
+    /// reproducible — a continuous CGFloat would let the user land on
+    /// 1.196… which reads as 1.20× but compares unequal across launches.
+    static let step: Double = 0.05
+    /// Baseline: no scaling, matches the pre-feature rendering exactly.
+    static let `default`: Double = 1.0
+
+    /// Clamp + snap to the nearest `step` so the slider can persist its
+    /// continuous CGFloat as a clean stepped value.
+    static func normalize(_ value: Double) -> Double {
+        let clamped = min(max(value, minimum), maximum)
+        let stepped = (clamped / step).rounded() * step
+        // Re-clamp after rounding in case the snap pushed past a bound
+        // (only theoretically possible if `step` doesn't divide the
+        // range cleanly, but defensive against future tuning).
+        return min(max(stepped, minimum), maximum)
+    }
+}
+
+/// App-group-backed reader/writer for the course-card font scale. Used
+/// by both the main app (read + write) and the widget extension
+/// (read-only at view body render time). Falls back to `.standard` if
+/// the App Group suite is missing so a provisioning hiccup degrades
+/// gracefully instead of crashing.
+nonisolated final class CourseCardFontScaleStore {
+    static let storageKey = "courseCardFontScale"
+
+    private let defaults: UserDefaults
+
+    init(appGroupIdentifier: String = "group.org.ntust.app.TigerDuck") {
+        self.defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
+    }
+
+    /// Read the user's scale, falling back to `1.0` when unset. Always
+    /// returns a normalized value so callers can use it directly without
+    /// re-normalizing at every render site.
+    func read() -> Double {
+        // `double(forKey:)` returns `0.0` when the key is missing, which
+        // is a valid storage value but indistinguishable from "unset".
+        // Use `object(forKey:)` first to detect the unset case explicitly
+        // so a never-set user gets the actual default (1.0) instead of a
+        // clamped 0.8.
+        guard defaults.object(forKey: Self.storageKey) != nil else {
+            return CourseCardFontScale.default
+        }
+        let raw = defaults.double(forKey: Self.storageKey)
+        return CourseCardFontScale.normalize(raw)
+    }
+
+    func write(_ scale: Double) {
+        defaults.set(CourseCardFontScale.normalize(scale), forKey: Self.storageKey)
+    }
+}

--- a/swift/TigerDuckWidgets/Views/NextClassView.swift
+++ b/swift/TigerDuckWidgets/Views/NextClassView.swift
@@ -6,6 +6,19 @@ struct NextClassView: View {
     let palette: WidgetPalette
     let family: WidgetFamily
 
+    /// User-chosen multiplier for course-name font, read from the App
+    /// Group at struct init. The main app reloads widget timelines after
+    /// changing the value, so the next render picks up a fresh struct
+    /// with the new scale.
+    private let userScale: CGFloat = CGFloat(CourseCardFontScaleStore().read())
+
+    /// Default Dynamic Type point sizes for the system fonts we replaced
+    /// to multiply in `userScale`. Hard-coding the baselines keeps the
+    /// font matching system `.subheadline` / `.title3` at scale 1.0 while
+    /// letting us multiply by the user override.
+    private static let subheadlineBase: CGFloat = 15
+    private static let title3Base: CGFloat = 20
+
     var body: some View {
         switch derived {
         case .signInRequired:
@@ -63,7 +76,7 @@ struct NextClassView: View {
                 }
             }
             Text(info.course.displayName)
-                .font(.subheadline.weight(.bold))
+                .font(.system(size: Self.subheadlineBase * userScale, weight: .bold))
                 .foregroundStyle(palette.onSurface)
                 .lineLimit(1)
             Text(String.localizedStringWithFormat(
@@ -83,7 +96,7 @@ struct NextClassView: View {
                 .background(palette.highlight, in: RoundedRectangle(cornerRadius: 8))
                 .foregroundStyle(.white)
             Text(info.course.displayName)
-                .font(.title3.weight(.bold))
+                .font(.system(size: Self.title3Base * userScale, weight: .bold))
                 .foregroundStyle(palette.onSurface)
                 .lineLimit(2)
             Text("\(info.startTime)–\(info.endTime)  \(info.periodRange)")
@@ -114,7 +127,10 @@ struct NextClassView: View {
                     .foregroundStyle(palette.onSurfaceVariant)
             }
             Text(info.course.displayName)
-                .font(isCompact ? .subheadline.weight(.bold) : .title3.weight(.bold))
+                .font(.system(
+                    size: (isCompact ? Self.subheadlineBase : Self.title3Base) * userScale,
+                    weight: .bold
+                ))
                 .foregroundStyle(palette.onSurface)
                 .lineLimit(2)
             Text(info.startTime)

--- a/swift/TigerDuckWidgets/Views/NextClassView.swift
+++ b/swift/TigerDuckWidgets/Views/NextClassView.swift
@@ -12,12 +12,16 @@ struct NextClassView: View {
     /// with the new scale.
     private let userScale: CGFloat = CGFloat(CourseCardFontScaleStore().read())
 
-    /// Default Dynamic Type point sizes for the system fonts we replaced
-    /// to multiply in `userScale`. Hard-coding the baselines keeps the
-    /// font matching system `.subheadline` / `.title3` at scale 1.0 while
-    /// letting us multiply by the user override.
-    private static let subheadlineBase: CGFloat = 15
-    private static let title3Base: CGFloat = 20
+    /// Dynamic-Type-anchored baselines for the system fonts we replaced
+    /// to multiply in `userScale`. `@ScaledMetric(relativeTo:)` makes
+    /// the default Dynamic Type point size grow/shrink with the user's
+    /// system text-size preference — so the surrounding `.subheadline`
+    /// /  `.caption` / `.title3` labels (still semantic) and these
+    /// course-name labels keep moving together as the user changes
+    /// Display & Text Size. Without this, the course name would be a
+    /// hard 15pt / 20pt / 12pt while neighbors continued to scale.
+    @ScaledMetric(relativeTo: .subheadline) private var subheadlineBase: CGFloat = 15
+    @ScaledMetric(relativeTo: .title3) private var title3Base: CGFloat = 20
 
     var body: some View {
         switch derived {
@@ -76,9 +80,10 @@ struct NextClassView: View {
                 }
             }
             Text(info.course.displayName)
-                .font(.system(size: Self.subheadlineBase * userScale, weight: .bold))
+                .font(.system(size: subheadlineBase * userScale, weight: .bold))
                 .foregroundStyle(palette.onSurface)
                 .lineLimit(1)
+                .minimumScaleFactor(0.7)
             Text(String.localizedStringWithFormat(
                 String(localized: "widget_until_time"), info.endTime))
                 .font(.caption)
@@ -96,9 +101,10 @@ struct NextClassView: View {
                 .background(palette.highlight, in: RoundedRectangle(cornerRadius: 8))
                 .foregroundStyle(.white)
             Text(info.course.displayName)
-                .font(.system(size: Self.title3Base * userScale, weight: .bold))
+                .font(.system(size: title3Base * userScale, weight: .bold))
                 .foregroundStyle(palette.onSurface)
                 .lineLimit(2)
+                .minimumScaleFactor(0.7)
             Text("\(info.startTime)–\(info.endTime)  \(info.periodRange)")
                 .font(.caption)
                 .foregroundStyle(palette.onSurfaceVariant)
@@ -128,11 +134,12 @@ struct NextClassView: View {
             }
             Text(info.course.displayName)
                 .font(.system(
-                    size: (isCompact ? Self.subheadlineBase : Self.title3Base) * userScale,
+                    size: (isCompact ? subheadlineBase : title3Base) * userScale,
                     weight: .bold
                 ))
                 .foregroundStyle(palette.onSurface)
                 .lineLimit(2)
+                .minimumScaleFactor(0.7)
             Text(info.startTime)
                 .font(.caption)
                 .foregroundStyle(palette.onSurfaceVariant)

--- a/swift/TigerDuckWidgets/Views/TodayListView.swift
+++ b/swift/TigerDuckWidgets/Views/TodayListView.swift
@@ -7,6 +7,16 @@ struct TodayListView: View {
     let palette: WidgetPalette
     let maxRows: Int
 
+    /// User-chosen multiplier for course-name font, read from the App
+    /// Group at struct init. The main app reloads widget timelines after
+    /// changing the value, so the next render picks up the new scale.
+    private let userScale: CGFloat = CGFloat(CourseCardFontScaleStore().read())
+
+    /// Default Dynamic Type point size for system `.caption`, kept as a
+    /// constant so we can multiply by `userScale` while matching the
+    /// pre-feature visual at scale 1.0.
+    private static let captionBase: CGFloat = 12
+
     var body: some View {
         Group {
             if !snapshot.isLoggedIn {
@@ -109,7 +119,7 @@ struct TodayListView: View {
             .frame(width: 60, alignment: .leading)
             VStack(alignment: .leading, spacing: 1) {
                 Text(course.displayName)
-                    .font(.caption.weight(.medium))
+                    .font(.system(size: Self.captionBase * userScale, weight: .medium))
                     .foregroundStyle(primary)
                     .lineLimit(1)
                 if !course.classroom.isEmpty {

--- a/swift/TigerDuckWidgets/Views/TodayListView.swift
+++ b/swift/TigerDuckWidgets/Views/TodayListView.swift
@@ -12,10 +12,13 @@ struct TodayListView: View {
     /// changing the value, so the next render picks up the new scale.
     private let userScale: CGFloat = CGFloat(CourseCardFontScaleStore().read())
 
-    /// Default Dynamic Type point size for system `.caption`, kept as a
-    /// constant so we can multiply by `userScale` while matching the
-    /// pre-feature visual at scale 1.0.
-    private static let captionBase: CGFloat = 12
+    /// Dynamic-Type-anchored baseline for the system `.caption` font.
+    /// `@ScaledMetric(relativeTo:)` keeps the course-name label moving
+    /// with the user's system text-size preference so the surrounding
+    /// `.caption.weight(.bold)` / `.caption2` row metadata (still
+    /// semantic) doesn't drift away from it under Accessibility text
+    /// sizes.
+    @ScaledMetric(relativeTo: .caption) private var captionBase: CGFloat = 12
 
     var body: some View {
         Group {
@@ -119,9 +122,10 @@ struct TodayListView: View {
             .frame(width: 60, alignment: .leading)
             VStack(alignment: .leading, spacing: 1) {
                 Text(course.displayName)
-                    .font(.system(size: Self.captionBase * userScale, weight: .medium))
+                    .font(.system(size: captionBase * userScale, weight: .medium))
                     .foregroundStyle(primary)
                     .lineLimit(1)
+                    .minimumScaleFactor(0.7)
                 if !course.classroom.isEmpty {
                     Text(course.classroom)
                         .font(.caption2)

--- a/swift/TigerDuckWidgets/Views/WeekGridView.swift
+++ b/swift/TigerDuckWidgets/Views/WeekGridView.swift
@@ -26,6 +26,17 @@ struct WeekGridView: View {
     /// consume this; period/weekday rails stay un-scaled.
     private let userCourseNameScale: CGFloat = CGFloat(CourseCardFontScaleStore().read())
 
+    /// Dynamic-Type-anchored baselines for the course-name labels in
+    /// `courseBlock` (solo) and `conflictHalf` (衝堂). Anchoring to
+    /// `.caption2` lets the user's system Display & Text Size preference
+    /// grow/shrink these labels alongside the surrounding rails, the same
+    /// way the Next Class / Today widgets stack Dynamic Type with the
+    /// per-app `userCourseNameScale`. Without these, the Week widget
+    /// would replace Dynamic Type with the per-app scale instead of
+    /// stacking on top of it.
+    @ScaledMetric(relativeTo: .caption2) private var soloCourseNameBase: CGFloat = 9
+    @ScaledMetric(relativeTo: .caption2) private var conflictCourseNameBase: CGFloat = 8
+
     var body: some View {
         Group {
             if !snapshot.isLoggedIn {
@@ -194,7 +205,7 @@ struct WeekGridView: View {
                     .overlay {
                         VStack(spacing: 1) {
                             Text(course.displayName)
-                                .font(.system(size: 9 * fontScale * userCourseNameScale, weight: .medium))
+                                .font(.system(size: soloCourseNameBase * fontScale * userCourseNameScale, weight: .medium))
                                 .foregroundStyle(palette.onSurface)
                                 .lineLimit(spanCount > 1 ? 3 : 2)
                                 .multilineTextAlignment(.center)
@@ -256,7 +267,7 @@ struct WeekGridView: View {
             }
             .overlay {
                 Text(course.displayName)
-                    .font(.system(size: 8 * fontScale * userCourseNameScale, weight: .medium))
+                    .font(.system(size: conflictCourseNameBase * fontScale * userCourseNameScale, weight: .medium))
                     .foregroundStyle(palette.onSurface)
                     .lineLimit(3)
                     .multilineTextAlignment(.center)

--- a/swift/TigerDuckWidgets/Views/WeekGridView.swift
+++ b/swift/TigerDuckWidgets/Views/WeekGridView.swift
@@ -18,6 +18,14 @@ struct WeekGridView: View {
     private let periodWidth: CGFloat = 12
     private let cornerRadius: CGFloat = 4
 
+    /// User-chosen multiplier for course-name font, read from the App
+    /// Group at struct init. Multiplied into the cell-height-driven
+    /// `fontScale` so the user override stacks on top of the widget's
+    /// own size adaptation (small iPhone widget vs. iPad systemExtraLarge).
+    /// Only the course-name labels in `courseBlock` / `conflictHalf`
+    /// consume this; period/weekday rails stay un-scaled.
+    private let userCourseNameScale: CGFloat = CGFloat(CourseCardFontScaleStore().read())
+
     var body: some View {
         Group {
             if !snapshot.isLoggedIn {
@@ -186,7 +194,7 @@ struct WeekGridView: View {
                     .overlay {
                         VStack(spacing: 1) {
                             Text(course.displayName)
-                                .font(.system(size: 9 * fontScale, weight: .medium))
+                                .font(.system(size: 9 * fontScale * userCourseNameScale, weight: .medium))
                                 .foregroundStyle(palette.onSurface)
                                 .lineLimit(spanCount > 1 ? 3 : 2)
                                 .multilineTextAlignment(.center)
@@ -248,7 +256,7 @@ struct WeekGridView: View {
             }
             .overlay {
                 Text(course.displayName)
-                    .font(.system(size: 8 * fontScale, weight: .medium))
+                    .font(.system(size: 8 * fontScale * userCourseNameScale, weight: .medium))
                     .foregroundStyle(palette.onSurface)
                     .lineLimit(3)
                     .multilineTextAlignment(.center)


### PR DESCRIPTION
## Summary

User-configurable course-name font scale (0.8–1.6×) applied in the class table and home-screen widgets. Persisted in the App Group `UserDefaults` suite so the widget extension reads what the main app writes. Settings → Other → Font size hosts a Slider sub-page with a live in-place preview, a reset button, and stepwise haptics.

Two commits:

- `feat(settings): course-name font size slider (closes #145)` — original feature
- `fix(font-size): address code review findings` — review-driven follow-ups

### Review fixes in the second commit

- **Restored widget Dynamic Type** — `NextClassView` / `TodayListView` were swapping `.subheadline` / `.title3` / `.caption` for `.system(size: const * userScale)`, which is a fixed point size and ignores Accessibility text-size. Now uses `@ScaledMetric(relativeTo:)` baselines so the user override stacks on top of Dynamic Type instead of replacing it.
- **Added `minimumScaleFactor(0.7)`** to widget course-name labels so long names rescale at 1.6× instead of truncating.
- **Debounced widget reloads** — `AppState.didSet` now routes through `WidgetReloadCoordinator` (300 ms) instead of calling `WidgetCenter.shared.reloadAllTimelines()` per step (a full 0.8→1.6 drag was firing ~16 reloads).
- **Locale-aware decimal formatting** — `String(format: "%.2f×", …)` → `.formatted(.number.precision(.fractionLength(2))) + "×"` so `de`/`fr`/`es` users see `1,20×` instead of `1.20×`.
- **App Group fallback hardened** — `CourseCardFontScaleStore.init` now matches `WidgetSnapshotStore`: `assertionFailure` in DEBUG + `Logger.error` in release if the suite is missing, so a future entitlement regression cannot silently desync main app vs. widget.
- **Normalize at the timetable read site** — `TimetableGridView.courseNameSize` now normalizes the raw in-memory scale before multiplying, keeping timetable / widgets / Settings consistent if any future non-Slider writer lands an unsnapped value.
- **Haptic sentinel** — `lastHapticScale: Double = -1` → `Double?`; first observation establishes the baseline silently so a layout-pass tick before `onAppear` can never fire a spurious haptic.
- **Docstring scope** — `CourseCardFontScale` now explicitly calls out that watchOS widgets are out of scope (different App Group, would need a sync channel).

## Test plan

- [ ] Set iOS → Accessibility → Display & Text Size → Larger Text to AX5 and confirm widget course names now scale with it (not stuck at 15/20/12pt).
- [ ] Set German (`de_DE`) locale and confirm slider readout shows `1,20×`, not `1.20×`. Same on the parent row in `OtherSettingsView`.
- [ ] Scrub the slider end-to-end 0.8→1.6 and back; confirm widgets refresh smoothly (debounced) rather than flickering 16 times.
- [ ] Pick 1.6× with a long Chinese course name; confirm widget course-name rescales via `minimumScaleFactor` instead of mid-character truncation.
- [ ] Open Settings → Other → Font size and confirm there is no spurious haptic on first appear.
- [ ] Verify the timetable cells in the class table re-render the instant the slider moves.
- [ ] Tap Reset; confirm slider snaps to 1.0× and the Reset button becomes disabled.