### PR TITLE
feat(updates): in-app update prompt + What's New sheet

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -77,6 +77,33 @@ future Mac-native widget extension. The doc comment on
 `CourseCardFontScale` (in `swift/TigerDuck/Shared/CourseCardFontScale.swift`)
 spells out the exclusion.
 
+## Sinitic-family locales fall back to `zh-TW`, not `en`
+
+**Rule:** Do not flag the locale selector in
+`swift/TigerDuck/Features/Updates/WhatsNewRepository.swift`
+(`localeCandidates(for:)`) for "serving Traditional Chinese to a
+Simplified Chinese reader" or "missing English fallback for non-Hant
+Chinese tags". Every Sinitic-family tag (`zh`, `zh-Hant*`, `zh-Hans*`,
+`yue`, `wuu`, `nan`, `hak`, `lzh`) is intentionally routed to the
+`zh-TW` block before ever reaching `en`. Simplified-script tags
+additionally try a `zh-Hans` block first when one is authored, but
+still fall through to `zh-TW` (not `en`) when it is absent.
+
+**Why:** The maintainer's explicit preference: any Chinese-language
+reader (Mandarin in either script, Cantonese, Wu, Hakka, Min Nan,
+Classical) gets readable Chinese — Traditional being the universal
+in-family fallback — rather than being dropped to English. An earlier
+review iteration suggested the opposite (Simplified → English when no
+`zh-Hans` block exists); that suggestion was rejected on this repo.
+
+**How to apply:** If you see `WhatsNewRepository.localeCandidates(for:)`
+or any other Sinitic-aware selector in this codebase returning a chain
+that ends with `zh-TW` for non-Hant Chinese tags (and only falls back
+to `en` for non-Sinitic languages), do NOT flag it. The Sinitic code
+set (`["zh", "yue", "nan", "hak", "wuu", "lzh"]`) mirrors
+`LanguageManager.chineseLanguageCodes` and is the source of truth for
+which tags get the Traditional fallback.
+
 ## Greptile review
 
 **Rule:** For every review, please update confidence score as well as giving the suggestions (if any).

--- a/swift/TigerDuck/App/AppConstants.swift
+++ b/swift/TigerDuck/App/AppConstants.swift
@@ -136,7 +136,45 @@ nonisolated enum AppConstants {
         static let useEnglishCourseAbbreviation = "useEnglishCourseAbbreviation"
         static let useEnglishClassroomAbbreviation = "useEnglishClassroomAbbreviation"
         static let classroomMandarinDisplay = "classroomMandarinDisplay"
+
+        // MARK: App-update prompt + What's New (iOS only)
+        /// App Store version recorded by the "Skip This Version" action.
+        /// While the iTunes Lookup `version` matches this string the
+        /// prompt is suppressed; a newer version on the store re-arms it.
+        static let skippedUpdateVersion = "skippedUpdateVersion"
+        /// Wall-clock timestamp of the last successful iTunes Lookup. The
+        /// scene-active trigger throttles to once per
+        /// ``AppConstants/updateCheckThrottle`` so rapid foreground
+        /// returns don't hammer Apple's endpoint.
+        static let lastUpdateCheckAt = "lastUpdateCheckAt"
+        /// App Store version most recently surfaced via the prompt sheet.
+        /// Paired with ``lastPromptedUpdateAt`` to implement the
+        /// "don't nag" cooldown ported from Android's
+        /// `UpdatePromptGate.COOLDOWN_MS` — re-prompting for the same
+        /// version inside ``updatePromptCooldown`` is suppressed.
+        static let lastPromptedUpdateVersion = "lastPromptedUpdateVersion"
+        static let lastPromptedUpdateAt = "lastPromptedUpdateAt"
+        /// App version associated with the most recent What's New sheet
+        /// acknowledgement. When the running bundle's
+        /// `CFBundleShortVersionString` is greater AND the running
+        /// version has a registered entry in `whatsnew.json`, the
+        /// sheet auto-presents on launch.
+        static let lastShownWhatsNewVersion = "lastShownWhatsNewVersion"
     }
+
+    /// Minimum interval between automatic update checks. Manual taps on
+    /// "Check for Updates" in Settings bypass this. Kept at 24h so the
+    /// scene-active trigger has no perceptible cost during normal app
+    /// use while still catching a same-day post-launch hotfix on the
+    /// next foreground.
+    static let updateCheckThrottle: TimeInterval = 24 * 60 * 60
+
+    /// "Don't nag" cooldown on a single available version. After the
+    /// prompt is dismissed with "Later" the same version is suppressed
+    /// for this long; a newer version landing on the App Store re-arms
+    /// the prompt immediately regardless. Mirrors the Android port's
+    /// 7-day `UpdatePromptGate.COOLDOWN_MS`.
+    static let updatePromptCooldown: TimeInterval = 7 * 24 * 60 * 60
 
     enum Periods {
         static let defaultVisible = ["1", "2", "3", "4", "6", "7", "8", "9"]

--- a/swift/TigerDuck/App/AppConstants.swift
+++ b/swift/TigerDuck/App/AppConstants.swift
@@ -176,6 +176,14 @@ nonisolated enum AppConstants {
     /// 7-day `UpdatePromptGate.COOLDOWN_MS`.
     static let updatePromptCooldown: TimeInterval = 7 * 24 * 60 * 60
 
+    /// iTunes Lookup storefront for App Store version checks. Pinned to
+    /// the release storefront (Taiwan) so a user traveling abroad or
+    /// behind a VPN through an unsupported region doesn't get
+    /// `resultCount == 0` (which the coordinator then treats as "no
+    /// public record" and masks a real available update). Update if the
+    /// app launches in additional storefronts.
+    static let appStoreLookupStorefront = "tw"
+
     enum Periods {
         static let defaultVisible = ["1", "2", "3", "4", "6", "7", "8", "9"]
         static let extended = ["5", "10", "A", "B", "C", "D"]

--- a/swift/TigerDuck/App/AppDefaults.swift
+++ b/swift/TigerDuck/App/AppDefaults.swift
@@ -158,4 +158,26 @@ nonisolated extension Defaults.Keys {
         AppConstants.UserDefaultsKeys.classroomMandarinDisplay,
         default: "original"
     )
+
+    // MARK: App-update prompt + What's New (iOS only — declared at the
+    // cross-platform `Defaults.Keys` level because the keys themselves
+    // are plain `String?` / `Date?` and the macOS build of `AppState`
+    // does not reference any of these; the iOS-only update coordinator
+    // is the sole reader/writer.
+
+    static let skippedUpdateVersion = Key<String?>(
+        AppConstants.UserDefaultsKeys.skippedUpdateVersion
+    )
+    static let lastUpdateCheckAt = Key<Date?>(
+        AppConstants.UserDefaultsKeys.lastUpdateCheckAt
+    )
+    static let lastPromptedUpdateVersion = Key<String?>(
+        AppConstants.UserDefaultsKeys.lastPromptedUpdateVersion
+    )
+    static let lastPromptedUpdateAt = Key<Date?>(
+        AppConstants.UserDefaultsKeys.lastPromptedUpdateAt
+    )
+    static let lastShownWhatsNewVersion = Key<String?>(
+        AppConstants.UserDefaultsKeys.lastShownWhatsNewVersion
+    )
 }

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -31,6 +31,15 @@ final class AppState {
     let authService = AuthService()
     let sessionManager = NTUSTSessionManager.shared
 
+    #if os(iOS)
+    /// Coordinator owning the iTunes Lookup + What's New plumbing. Lives
+    /// on `AppState` (not as a top-level singleton) so SwiftUI views observe
+    /// changes through the same `@Environment(AppState.self)` they already
+    /// use, and so its sheet-presentation flags reset alongside the rest of
+    /// app state on logout / fresh install paths.
+    let updateNotifyCoordinator = UpdateNotifyCoordinator()
+    #endif
+
     // MARK: - Fresh Install Keychain Cleanup
 
     /// Keychain persists across app uninstall/reinstall on iOS.
@@ -38,6 +47,20 @@ final class AppState {
     /// so the app doesn't start with orphaned credentials from a previous install.
     init() {
         if !Defaults[.appHasBeenInstalled] {
+            #if os(iOS)
+            // Stamp the running version as "already shown" so the
+            // What's New sheet does NOT fire on the very first launch
+            // after install — a freshly downloaded app has no upgrade
+            // history to summarise. Run this BEFORE the Keychain wipe
+            // and independently of its outcome: the seed has nothing
+            // to do with credential cleanup, and gating it on a
+            // successful wipe would let a partial wipe failure
+            // misroute the user into the "no lastShownWhatsNewVersion"
+            // fallback that pops "What's New in vN" on a freshly
+            // downloaded version.
+            updateNotifyCoordinator.seedWhatsNewOnFreshInstall()
+            #endif
+
             // Fresh install — purge any leftover Keychain items.
             let keysToWipe: [String] = [
                 AppConstants.KeychainKeys.studentId,

--- a/swift/TigerDuck/App/FlipToLibraryCoordinator.swift
+++ b/swift/TigerDuck/App/FlipToLibraryCoordinator.swift
@@ -86,17 +86,7 @@ private struct FlipToLibraryModifier: ViewModifier {
         // navigation happens on this first event so the user is not
         // jump-scared into an unfamiliar tab.
         if !FirstTriggerPromptCenter.shared.hasSeen(.flipToLibrary) {
-            FirstTriggerPromptCenter.shared.requestIfFirstTime(.flipToLibrary) {
-                FirstTriggerPromptContent(
-                    title: String(localized: "first_trigger_flip_to_library_title"),
-                    message: String(localized: "first_trigger_flip_to_library_message"),
-                    animation: .phoneFlip,
-                    acceptLabel: String(localized: "first_trigger_flip_to_library_keep"),
-                    declineLabel: String(localized: "first_trigger_flip_to_library_turn_off"),
-                    onAccept: { /* leave toggle on, no nav this time */ },
-                    onDecline: { appState.flipToLibraryEnabled = false }
-                )
-            }
+            FlipToLibraryPromptPresenter.requestFirstTriggerPrompt(appState: appState)
             return
         }
 
@@ -138,6 +128,31 @@ extension View {
             modifier(FlipToLibraryModifier())
         } else {
             self
+        }
+    }
+}
+
+/// Shared builder for the flip-to-library first-trigger prompt content.
+/// Extracted from ``FlipToLibraryModifier`` so the Debug → Triggers page
+/// can replay the same prompt as a real face-down gesture would, without
+/// having to duplicate the localization keys or the callback semantics.
+enum FlipToLibraryPromptPresenter {
+    /// Queue the first-trigger prompt for the flip gesture. No-ops when
+    /// the prompt has already been seen — call
+    /// `FirstTriggerPromptCenter.shared.reset(.flipToLibrary)` first if
+    /// you specifically want to re-test the first-trigger surface
+    /// (debug Triggers page does this).
+    static func requestFirstTriggerPrompt(appState: AppState) {
+        FirstTriggerPromptCenter.shared.requestIfFirstTime(.flipToLibrary) {
+            FirstTriggerPromptContent(
+                title: String(localized: "first_trigger_flip_to_library_title"),
+                message: String(localized: "first_trigger_flip_to_library_message"),
+                animation: .phoneFlip,
+                acceptLabel: String(localized: "first_trigger_flip_to_library_keep"),
+                declineLabel: String(localized: "first_trigger_flip_to_library_turn_off"),
+                onAccept: { /* leave toggle on, no nav this time */ },
+                onDecline: { appState.flipToLibraryEnabled = false }
+            )
         }
     }
 }

--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -61,6 +61,23 @@ struct MainTabView: View {
             // to come from here. Subsequent foreground returns go
             // through the scene-phase observer below.
             evaluateTimezoneAlert()
+            #if os(iOS)
+            // Only check the What's New gate AFTER onboarding completes
+            // (MainTabView is itself gated on that in ContentView), so
+            // a brand-new user finishing onboarding doesn't get
+            // What's New layered on top of their first home screen —
+            // the seed in AppState.init's fresh-install branch already
+            // stamped lastShownWhatsNewVersion in that case.
+            appState.updateNotifyCoordinator.evaluateWhatsNewOnLaunch()
+            // Background update check is gated on `hasCompletedOnboarding`
+            // inside the coordinator, so a brand-new user landing on
+            // MainTabView for the first time gets the first iTunes
+            // Lookup HERE (the `TigerDuckApp.onAppear` kick-off no-oped
+            // while OnboardingView was on screen, which would otherwise
+            // strand `pendingUpdate` behind an un-mounted sheet host).
+            // Throttle absorbs the dupe on subsequent appearances.
+            appState.updateNotifyCoordinator.checkInBackground()
+            #endif
         }
         .onChange(of: appState.pendingWidgetDestination) { _, _ in
             drainPendingWidgetDestination()
@@ -88,6 +105,7 @@ struct MainTabView: View {
         #if os(iOS)
         .flipToLibraryAttached()
         .firstTriggerPromptHost()
+        .updateNotifySheetHost()
         #endif
     }
 

--- a/swift/TigerDuck/Debug/TriggersDebugView.swift
+++ b/swift/TigerDuck/Debug/TriggersDebugView.swift
@@ -1,4 +1,4 @@
-#if DEBUG
+#if DEBUG && os(iOS)
 import SwiftUI
 
 /// Developer-only screen for re-triggering one-shot UI surfaces that are

--- a/swift/TigerDuck/Debug/TriggersDebugView.swift
+++ b/swift/TigerDuck/Debug/TriggersDebugView.swift
@@ -1,0 +1,147 @@
+#if DEBUG
+import SwiftUI
+
+/// Developer-only screen for re-triggering one-shot UI surfaces that are
+/// otherwise hard to retest after they've been dismissed once. Reached
+/// from `Settings → Developer → Triggers`; entry point and this file
+/// are both `#if DEBUG` so Release builds never see either.
+///
+/// Each section maps to a specific surface and uses the smallest hook
+/// that simulates a real fire — clearing a persisted gate, arming a
+/// debug-only flag, or replaying the same closure a real sensor would.
+/// Avoid going around the production code paths: a trigger that takes
+/// a shortcut here can mask real-world bugs in the surface it's
+/// supposed to be testing.
+struct TriggersDebugView: View {
+    @Environment(AppState.self) private var appState
+    @State private var statusMessage: String?
+    /// Tick that refreshes the disabled-button state when the static
+    /// armed-flag flips. The actual task lives on
+    /// ``TriggersDebugArming`` (a MainActor singleton) so it survives
+    /// this view being popped and re-pushed — `@State` is destroyed on
+    /// pop, which is what allowed the same button to spawn a second
+    /// in-flight task when the user navigated away and back.
+    @State private var armedTick = UUID()
+
+    var body: some View {
+        Form {
+            // MARK: - What's New
+            Section {
+                Button("Trigger What's New on next open") {
+                    UserDefaults.standard.removeObject(
+                        forKey: AppConstants.UserDefaultsKeys.lastShownWhatsNewVersion
+                    )
+                    statusMessage = "Cleared lastShownWhatsNewVersion. Cold-launch or scene-active fires the sheet."
+                }
+            } header: {
+                Text("What's New")
+            } footer: {
+                Text("Clears the seen flag so `evaluateWhatsNewOnLaunch()` re-fires the latest registered entry on the next launch / foreground.")
+            }
+
+            // MARK: - Update prompt
+            Section {
+                Button("Trigger Update Available on next open") {
+                    UpdateNotifyCoordinator.armDebugSimulatedUpdate()
+                    statusMessage = "Armed synthetic update prompt. Cold-launch or scene-active fires it once."
+                }
+                if UpdateNotifyCoordinator.isDebugSimulatedUpdateArmed {
+                    Text("Currently armed — relaunch or background/foreground to fire.")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            } header: {
+                Text("Update prompt")
+            } footer: {
+                Text("Skips iTunes Lookup and surfaces a fake `PendingUpdate` (v99.0.0 → apps.apple.com). One-shot per arm.")
+            }
+
+            // MARK: - Flip-to-Library first trigger
+            Section {
+                Button("First library flip after 3 sec") {
+                    triggerFirstLibraryFlip()
+                }
+                .disabled(!canTriggerFlip || TriggersDebugArming.shared.isFlipArmed)
+                if TriggersDebugArming.shared.isFlipArmed {
+                    Text("Flip prompt scheduled. Stay in this tab or navigate to any tab — it'll fire root-level.")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            } header: {
+                Text("Flip to Library")
+            } footer: {
+                if !canTriggerFlip {
+                    Text("Requires both Library and Flip-to-Library to be enabled. Toggle them on in Settings → Other settings first.")
+                } else {
+                    Text("Resets the first-trigger seen flag, waits 3 seconds, then replays the same prompt a real face-down gesture would surface.")
+                }
+            }
+
+            if let statusMessage {
+                Section {
+                    Text(statusMessage)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .navigationTitle("Triggers")
+        // Intentionally NOT cancelling the arming task on disappear: the
+        // 3-second delay exists so navigation away from this page is part
+        // of the test (which tab the prompt overlays is part of what's
+        // being verified). The arming lives on `TriggersDebugArming` so
+        // it survives this view being popped — re-entering the page
+        // shows the disabled-button + "scheduled" footer instead of
+        // letting a second tap spawn a duplicate prompt.
+    }
+
+    private var canTriggerFlip: Bool {
+        appState.libraryFeatureEnabled && appState.flipToLibraryEnabled
+    }
+
+    private func triggerFirstLibraryFlip() {
+        FirstTriggerPromptCenter.shared.reset(.flipToLibrary)
+        statusMessage = "Reset first-trigger flag. Prompt fires in 3 seconds."
+        TriggersDebugArming.shared.armFlipPrompt(appState: appState) { [self] in
+            // Rotate the tick so the body re-evaluates the disabled
+            // state if the view is still mounted when the timer fires.
+            armedTick = UUID()
+        }
+        armedTick = UUID()
+    }
+}
+
+/// MainActor singleton that owns the debug "arm flip prompt" task
+/// beyond a single view's lifetime. `TriggersDebugView`'s `@State` is
+/// destroyed when the user pops the page, which previously let a second
+/// tap on re-entry spawn a duplicate in-flight task. Anchoring the task
+/// here keeps the "scheduled" indication consistent across navigation.
+@MainActor
+final class TriggersDebugArming {
+    static let shared = TriggersDebugArming()
+    private init() {}
+
+    private var flipTask: Task<Void, Never>?
+    var isFlipArmed: Bool { flipTask != nil }
+
+    /// Schedule the flip-to-library first-trigger prompt to fire after
+    /// 3 seconds. No-ops if a previous arm is still in flight.
+    /// `completion` is invoked on the MainActor when the task ends
+    /// (either fired or already-armed-skip) so the caller can refresh
+    /// any view-local state.
+    func armFlipPrompt(appState: AppState, completion: @escaping () -> Void) {
+        guard flipTask == nil else {
+            completion()
+            return
+        }
+        flipTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(3))
+            if !Task.isCancelled {
+                FlipToLibraryPromptPresenter.requestFirstTriggerPrompt(appState: appState)
+            }
+            self?.flipTask = nil
+            completion()
+        }
+    }
+}
+#endif

--- a/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
@@ -62,11 +62,11 @@ struct OtherSettingsView: View {
             // The row is rendered (not hidden) even when library is off so
             // the user can see the preference exists and inspect its state
             // before enabling library — hiding it caused users who turned
-            // library off-then-on to be silently re-armed. The toggle is
-            // also kept enabled in that state so the user can opt out
-            // before flipping the library feature back on; the gesture is
-            // gated at fire time by `libraryFeatureEnabled` in the
-            // coordinator either way.
+            // library off-then-on to be silently re-armed with the default-
+            // true persisted value. The toggle is also kept enabled in that
+            // state so the user can opt out before flipping the library
+            // feature back on; the gesture is gated at fire time by
+            // `libraryFeatureEnabled` in the coordinator either way.
             if UIDevice.current.userInterfaceIdiom == .phone && FlipDetector.isSupported {
                 Section {
                     Toggle(

--- a/swift/TigerDuck/Features/Settings/SettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/SettingsView.swift
@@ -237,9 +237,11 @@ struct SettingsView: View {
                 NavigationLink("API endpoint") {
                     DebugEndpointView()
                 }
+                #if os(iOS)
                 NavigationLink("Triggers") {
                     TriggersDebugView()
                 }
+                #endif
                 // Bypass `.screenCaptureProtected(...)` system-wide for
                 // demo recordings / layout debugging. Backed by
                 // `@AppStorage` so toggling immediately re-evaluates

--- a/swift/TigerDuck/Features/Settings/SettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/SettingsView.swift
@@ -22,6 +22,22 @@ struct SettingsView: View {
     @State private var hapticPlayer: CHHapticPatternPlayer?
     @State private var notificationsAuthorized: Bool = true
     @State private var showOfficialWebsite = false
+    #if os(iOS)
+    /// Drives the "you're up to date" / "couldn't reach the App Store"
+    /// feedback alert that fires after the manual Check for Updates row.
+    /// Only true when the coordinator emitted a result that isn't already
+    /// surfaced through the auto-presented update sheet — an `.offered`
+    /// result is shown via that sheet path, not this alert.
+    @State private var showManualUpdateCheckResultAlert = false
+    /// Item for the Settings → What's New row, allowing repeat
+    /// presentation of the latest release notes independent of the
+    /// auto-launch gate's seen-state. Driven by `.sheet(item:)` rather
+    /// than `.sheet(isPresented:)` so the entry is captured at present
+    /// time — a stale `latestWhatsNew == nil` between the row tap and
+    /// the sheet body evaluation cannot leak an empty sheet onto
+    /// screen.
+    @State private var manualWhatsNewItem: WhatsNewRepository.ResolvedWhatsNew?
+    #endif
     @Environment(\.scenePhase) private var scenePhase
 
     #if DEBUG
@@ -186,6 +202,10 @@ struct SettingsView: View {
             // MARK: - About
             Section(String(localized: "settings_section_about")) {
                 LabeledContent(String(localized: "settings_version"), value: appVersion)
+                #if os(iOS)
+                checkForUpdatesRow
+                whatsNewRow
+                #endif
                 Button {
                     if appState.browserPreference == .inApp {
                         showOfficialWebsite = true
@@ -216,6 +236,9 @@ struct SettingsView: View {
                 }
                 NavigationLink("API endpoint") {
                     DebugEndpointView()
+                }
+                NavigationLink("Triggers") {
+                    TriggersDebugView()
                 }
                 // Bypass `.screenCaptureProtected(...)` system-wide for
                 // demo recordings / layout debugging. Backed by
@@ -318,7 +341,62 @@ struct SettingsView: View {
             libraryWarningTask?.cancel()
             libraryWarningTask = nil
         }
+        #if os(iOS)
+        // Manual-check-result alert — covers the "you're up to date" and
+        // "couldn't reach the App Store" outcomes. The .offered case is
+        // handled by `.updateNotifySheetHost()` instead, so the row's
+        // Task explicitly suppresses this alert in that branch.
+        .alert(
+            manualCheckResultAlertTitle,
+            isPresented: $showManualUpdateCheckResultAlert,
+            actions: {
+                Button(String(localized: "action_got_it"), role: .cancel) {
+                    appState.updateNotifyCoordinator.lastManualCheckResult = nil
+                }
+            },
+            message: {
+                Text(manualCheckResultAlertMessage)
+            }
+        )
+        .sheet(item: $manualWhatsNewItem) { entry in
+            WhatsNewSheetView(entry: entry) {
+                // Manual open does NOT advance
+                // `lastShownWhatsNewVersion` — the Settings entry is a
+                // re-visit surface, and stamping the seen marker here
+                // would silently suppress the next auto-prompt after
+                // viewing release notes again.
+                manualWhatsNewItem = nil
+            }
+            .presentationDetents([.fraction(0.85), .large])
+        }
+        #endif
     }
+
+    #if os(iOS)
+    /// Title for the manual update-check result alert. Mirrors iOS App
+    /// Store style: "You're Up to Date" vs "Update Check Failed".
+    private var manualCheckResultAlertTitle: String {
+        switch appState.updateNotifyCoordinator.lastManualCheckResult {
+        case .upToDate: return String(localized: "update_up_to_date_title")
+        case .failed: return String(localized: "update_check_failed_title")
+        case .offered, nil: return ""
+        }
+    }
+
+    private var manualCheckResultAlertMessage: String {
+        switch appState.updateNotifyCoordinator.lastManualCheckResult {
+        case .upToDate:
+            return String(format: NSLocalizedString(
+                "update_up_to_date_message",
+                comment: ""
+            ), AppConstants.appName)
+        case .failed:
+            return String(localized: "update_check_failed_message")
+        case .offered, nil:
+            return ""
+        }
+    }
+    #endif
 
     private var libraryToggleBinding: Binding<Bool> {
         Binding(
@@ -365,6 +443,68 @@ struct SettingsView: View {
             // Silently fail on devices without haptic support
         }
     }
+
+    #if os(iOS)
+    /// "Check for Updates" row. Tapping forces an iTunes Lookup ignoring
+    /// the 24h throttle. When the lookup succeeds and an update is
+    /// available the existing `.updateNotifySheetHost()` modifier surfaces
+    /// the regular prompt sheet — this row only handles the "already up
+    /// to date" and "couldn't reach the App Store" feedback paths.
+    @ViewBuilder
+    private var checkForUpdatesRow: some View {
+        Button {
+            Task {
+                await appState.updateNotifyCoordinator.checkManually()
+                // Only raise the local alert when the coordinator decided
+                // not to drive the auto-sheet (.upToDate / .failed). An
+                // `.offered` result hands off to the sheet host so a
+                // duplicate alert here would stack on top of the sheet.
+                let result = appState.updateNotifyCoordinator.lastManualCheckResult
+                if case .offered = result { return }
+                if result != nil { showManualUpdateCheckResultAlert = true }
+            }
+        } label: {
+            HStack {
+                Text(String(localized: "settings_check_for_updates"))
+                    .foregroundStyle(.primary)
+                Spacer()
+                if appState.updateNotifyCoordinator.isCheckingForUpdate {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+        }
+        .disabled(appState.updateNotifyCoordinator.isCheckingForUpdate)
+    }
+
+    /// "What's New" entry — always opens the latest entry registered
+    /// in `whatsnew.json`, independent of the
+    /// `lastShownWhatsNewVersion` gate. Hidden when the asset has no
+    /// entries for the resolved locale (e.g. during early bring-up of
+    /// a release where the JSON hasn't been filled in yet).
+    @ViewBuilder
+    private var whatsNewRow: some View {
+        if appState.updateNotifyCoordinator.hasWhatsNewContent {
+            Button {
+                // Capture the entry at tap time and pass it directly to
+                // `.sheet(item:)` — avoids the empty-sheet edge case
+                // where the row was visible on the latest render but
+                // `latestWhatsNew` evaluates to nil inside the sheet
+                // body (e.g. language change between render and tap).
+                manualWhatsNewItem = appState.updateNotifyCoordinator.latestWhatsNew
+            } label: {
+                HStack {
+                    Text(String(localized: "settings_whats_new"))
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+    #endif
 
     private var ntustAccountRow: some View {
         accountRow(

--- a/swift/TigerDuck/Features/Updates/UpdateNotifyCoordinator.swift
+++ b/swift/TigerDuck/Features/Updates/UpdateNotifyCoordinator.swift
@@ -1,0 +1,516 @@
+#if os(iOS)
+import Foundation
+import Defaults
+import UIKit
+
+/// Owns the "newer build on App Store?" check and the sheet-presentation
+/// flags it feeds. Lives as a child of ``AppState`` so SwiftUI views can
+/// observe `pendingUpdate` / `pendingWhatsNew` through the same
+/// `@Environment(AppState.self)` they already use for everything else.
+///
+/// **Why iOS-only**: the Mac App Store surfaces its own Updates tab,
+/// and the iTunes Lookup endpoint indexes iOS App Store records only —
+/// running this on Mac would either silently no-op or deep-link into
+/// the iPhone App Store from inside a Mac binary, both of which are
+/// worse than no prompt.
+///
+/// **Cross-platform alignment**: the gating constants mirror Android's
+/// `UpdatePromptGate.COOLDOWN_MS` (7 days, same available version after
+/// "Later") and the What's New content schema mirrors Android's
+/// `assets/whatsnew.json` so the same release notes render on both
+/// platforms.
+@MainActor
+@Observable
+final class UpdateNotifyCoordinator {
+    /// Latest discovered App-Store-vs-installed mismatch. Set when a
+    /// check finds `latest > current` AND that version is not in
+    /// `Defaults[.skippedUpdateVersion]` AND the same-version cooldown
+    /// has elapsed. Views observe this to drive the update sheet;
+    /// `handleUpdatePromptAction` clears it on accept / later / skip.
+    var pendingUpdate: PendingUpdate?
+
+    /// What's New entry to present on the next eligible launch. Set by
+    /// ``evaluateWhatsNewOnLaunch()`` when the installed version moved
+    /// past `lastShownWhatsNewVersion` and an entry is registered for
+    /// the running version in `whatsnew.json`.
+    var pendingWhatsNew: WhatsNewRepository.ResolvedWhatsNew?
+
+    /// True while a manual "Check for Updates" tap is in flight. Surface
+    /// in Settings so the row can show a spinner instead of a button.
+    var isCheckingForUpdate = false
+
+    /// Result of the most recent *manual* check (Settings tap). Lets the
+    /// Settings row surface "you're up to date" / "couldn't reach the
+    /// App Store" feedback without driving the full update sheet.
+    /// Cleared each time a new manual check starts.
+    var lastManualCheckResult: ManualCheckResult?
+
+    struct PendingUpdate: Equatable {
+        let latestVersion: String
+        let appStoreURL: URL
+    }
+
+    enum ManualCheckResult: Equatable {
+        case upToDate
+        case offered(PendingUpdate)
+        case failed
+    }
+
+    private let bundleId: String
+    private let session: URLSession
+    private let repository: WhatsNewRepository
+    /// Coalesces concurrent calls — a manual "Check now" tap that lands
+    /// while the scene-active background check is mid-flight reuses the
+    /// in-flight task rather than firing a duplicate iTunes Lookup hit.
+    private var inFlight: Task<LookupResult, Never>?
+
+    private typealias Lookup = AppStoreUpdateService.Lookup
+
+    /// Internal tri-state mirroring the service's distinction between
+    /// "Apple replied with no record" (legit pre-launch — DO stamp the
+    /// throttle, do NOT surface a failure alert) and "couldn't reach
+    /// Apple" (retry next foreground, surface failure on manual taps).
+    /// Collapsing both into a single `nil` was the original bug.
+    private enum LookupResult: Equatable {
+        case found(Lookup)
+        case noRecord
+        case failed
+    }
+
+    /// Nonisolated so `AppState` (a non-`@MainActor` `@Observable`) can
+    /// construct this in its stored-property initializer without a
+    /// concurrency hop. The init only assigns `let` properties — no
+    /// MainActor-isolated state is touched.
+    nonisolated init(
+        bundleId: String = Bundle.main.bundleIdentifier ?? "org.ntust.app.TigerDuck",
+        session: URLSession = .shared,
+        repository: WhatsNewRepository? = nil
+    ) {
+        self.bundleId = bundleId
+        self.session = session
+        self.repository = repository ?? WhatsNewRepository()
+    }
+
+    // MARK: - What's New
+
+    /// Resolved language tag passed to the What's New repository. Reads
+    /// the in-app override first (`AppLanguage`-keyed setting), then
+    /// falls back to the device locale. Wrapping this lets the manual
+    /// "Open What's New" Settings entry and the launch-time auto-open
+    /// stay in lockstep.
+    private var resolvedLanguageTag: String {
+        let stored = Defaults[.appLanguage]
+        if stored.lowercased() != "system" { return stored }
+        return Locale.current.identifier
+    }
+
+    /// True iff at least one entry is registered in `whatsnew.json` for
+    /// the current locale resolution. Drives the Settings → What's New
+    /// row's visibility.
+    var hasWhatsNewContent: Bool {
+        repository.hasAnyContent(languageTag: resolvedLanguageTag)
+    }
+
+    /// Latest authored entry for the current locale, independent of
+    /// `lastShownWhatsNewVersion`. Backs the Settings → What's New
+    /// entry point, which is allowed to re-present the same content.
+    var latestWhatsNew: WhatsNewRepository.ResolvedWhatsNew? {
+        repository.latestEntry(languageTag: resolvedLanguageTag)
+    }
+
+    /// Call once during app launch, after onboarding has completed, to
+    /// decide whether to surface the What's New sheet. The decision rule
+    /// mirrors Android's `WhatsNewGate.shouldShow`:
+    ///
+    /// 1. `lastShownWhatsNewVersion` is set (a brand-new install seeded
+    ///    it during fresh-install handling, so this branch fails for
+    ///    first-launch users — they haven't missed anything).
+    /// 2. The running version is strictly greater than the last seen
+    ///    version.
+    /// 3. `whatsnew.json` has a usable entry for the running version
+    ///    in the resolved locale.
+    func evaluateWhatsNewOnLaunch() {
+        guard let lastShownRaw = Defaults[.lastShownWhatsNewVersion],
+              let lastShown = AppVersion(lastShownRaw)
+        else {
+            // Fresh installs that completed the seed land here with a
+            // valid `lastShownRaw`; only path that legitimately lacks
+            // one is "upgrade from a version that predated this
+            // feature". Surface What's New in that case too.
+            return surfaceLatestIfAvailable()
+        }
+        guard lastShown < AppVersion.current else { return }
+        let current = bundleVersionString
+        if let entry = repository.entry(forVersion: current, languageTag: resolvedLanguageTag) {
+            present(entry)
+        }
+        // No registered entry for the running version → silent skip
+        // (matches Android: a bug-fix release with no JSON entry should
+        // NOT pop a dialog).
+    }
+
+    /// Fallback path for users upgrading from a pre-feature version
+    /// (no `lastShownWhatsNewVersion` set). Only surface the latest
+    /// entry when its version actually matches the running bundle —
+    /// otherwise a release that forgot to add a `whatsnew.json` entry
+    /// would pop the *previous* version's sheet ("What's new in 1.7.0"
+    /// to a 1.8.0 user), which is worse than no prompt.
+    private func surfaceLatestIfAvailable() {
+        guard let entry = latestWhatsNew,
+              entry.version == bundleVersionString
+        else { return }
+        present(entry)
+    }
+
+    /// Set `pendingWhatsNew` AND advance the seen marker in the same
+    /// pass. Stamping eagerly (rather than only on dismiss) makes
+    /// `evaluateWhatsNewOnLaunch()` idempotent across the repeated
+    /// `MainTabView.onAppear` firings caused by `ContentView`'s
+    /// `.id(rootLanguageId)` rebuild on every language change — without
+    /// this, a remount before the user has tapped Continue would
+    /// re-present the sheet on every language toggle in the same
+    /// session. The `acknowledgeWhatsNew()` call from the sheet's
+    /// dismiss path is then an idempotent re-write of the same key.
+    private func present(_ entry: WhatsNewRepository.ResolvedWhatsNew) {
+        pendingWhatsNew = entry
+        Defaults[.lastShownWhatsNewVersion] = bundleVersionString
+    }
+
+    /// Sticky write that advances `lastShownWhatsNewVersion` to the
+    /// running bundle version — called by the sheet's Continue button
+    /// and by the swipe-to-dismiss path in `UpdateNotifySheetHost`.
+    /// Persisting the installed marketing string (not the entry's
+    /// `version`) means a fresh install at v1.7.0 with no registered
+    /// entry still seeds the key, so the next release with an entry
+    /// triggers the prompt.
+    func acknowledgeWhatsNew() {
+        Defaults[.lastShownWhatsNewVersion] = bundleVersionString
+        pendingWhatsNew = nil
+    }
+
+    /// Fresh-install seed: stamp the running bundle version so the
+    /// launch-time gate treats it as already seen and skips the auto
+    /// prompt. Called once from AppState's first-install branch —
+    /// without this seed, `lastShownWhatsNewVersion == nil` after a
+    /// brand-new install would fall through to "surface latest" and
+    /// present a "What's New in vN" sheet for a freshly downloaded
+    /// version.
+    ///
+    /// `nonisolated` so it can be called from `AppState.init` (also
+    /// nonisolated) without a MainActor hop. Only writes through
+    /// `Defaults`, which is thread-safe.
+    nonisolated func seedWhatsNewOnFreshInstall() {
+        Defaults[.lastShownWhatsNewVersion] = Self.bundleVersionString
+    }
+
+    // MARK: - Update check
+
+    /// Background check — respects the 24h throttle and only sets
+    /// `pendingUpdate` (never `lastManualCheckResult`). Safe to call on
+    /// every scene-active transition; the throttle eats the dupes.
+    ///
+    /// Refuses to fire while onboarding is still on screen, otherwise a
+    /// pending prompt set during onboarding would be stranded (the
+    /// sheet host only mounts on `MainTabView`) and then pop on top of
+    /// the user's first home screen the instant they complete the
+    /// onboarding hand-off. Calls during onboarding no-op silently; the
+    /// `MainTabView.onAppear` post-onboarding kicks off the first real
+    /// check.
+    func checkInBackground() {
+        guard Defaults[.hasCompletedOnboarding] else { return }
+        #if DEBUG
+        // Debug "Triggers" page can request a synthetic update prompt
+        // on next launch — consumed once and surfaced before any real
+        // throttle / iTunes Lookup so it works even when a recent real
+        // check has been throttled.
+        if Self.consumeDebugSimulateUpdateFlag() {
+            surfaceSyntheticUpdatePrompt()
+            return
+        }
+        #endif
+        if let last = Defaults[.lastUpdateCheckAt] {
+            let delta = Date().timeIntervalSince(last)
+            // `delta >= 0` filters a future-stamped timestamp (clock
+            // skew, restore-from-backup, manual Settings → Date & Time
+            // adjustment): a negative delta is `< throttle` trivially
+            // true, which would otherwise suppress checks until real
+            // time caught up to the bogus future stamp.
+            if delta >= 0 && delta < AppConstants.updateCheckThrottle {
+                return
+            }
+        }
+        Task { await performCheck(manual: false) }
+    }
+
+    #if DEBUG
+    /// Debug-only UserDefaults flag set by the Triggers page so the next
+    /// background check surfaces a fake update prompt. The key is plain
+    /// UserDefaults (not `Defaults` typed-keys) on purpose — it never
+    /// ships in Release, and constraining it to debug code keeps the
+    /// production storage surface clean.
+    private static let debugSimulateUpdateKey = "debug.simulateUpdateOnNextLaunch"
+
+    /// Arm a fake update prompt for the next scene-active / app launch.
+    /// Called from the Triggers debug page; consumed by
+    /// ``checkInBackground()``.
+    static func armDebugSimulatedUpdate() {
+        UserDefaults.standard.set(true, forKey: debugSimulateUpdateKey)
+    }
+
+    /// True iff the debug arm flag is currently set. Lets the Triggers
+    /// page surface "armed — relaunch to fire" feedback.
+    static var isDebugSimulatedUpdateArmed: Bool {
+        UserDefaults.standard.bool(forKey: debugSimulateUpdateKey)
+    }
+
+    /// Atomic read-and-clear so a single arm fires exactly one synthetic
+    /// prompt, not one per scene-active for the rest of the session.
+    private static func consumeDebugSimulateUpdateFlag() -> Bool {
+        let armed = UserDefaults.standard.bool(forKey: debugSimulateUpdateKey)
+        if armed {
+            UserDefaults.standard.removeObject(forKey: debugSimulateUpdateKey)
+        }
+        return armed
+    }
+
+    /// Plant a synthetic ``PendingUpdate`` so the regular sheet host
+    /// surfaces the prompt. The URL points at the App Store homepage so
+    /// "Update Now" doesn't 404 on a real device — we don't have a real
+    /// `trackId` to deep-link to during pre-launch debug.
+    private func surfaceSyntheticUpdatePrompt() {
+        guard let url = URL(string: "https://apps.apple.com/") else { return }
+        // "99.0.0" is the sentinel version surfaced in the debug update
+        // prompt. Picked to be unambiguously larger than any shipping
+        // TigerDuck version for the foreseeable future, so:
+        //   1. The real iTunes Lookup pipeline (if it were running)
+        //      would also classify it as "newer than installed" — keeps
+        //      the simulated prompt structurally identical to a real
+        //      one rather than going through a special debug code path.
+        //   2. The version string reads as "obviously not a real
+        //      release" on screen, so the debug-triggered prompt is
+        //      visually distinguishable from a real available update.
+        pendingUpdate = PendingUpdate(latestVersion: "99.0.0", appStoreURL: url)
+    }
+    #endif
+
+    /// User-initiated "Check for Updates" in Settings. Always hits the
+    /// network, populates `lastManualCheckResult` so the Settings row
+    /// can react, and (if an update is found) also sets `pendingUpdate`
+    /// so the same sheet path triggers.
+    func checkManually() async {
+        await performCheck(manual: true)
+    }
+
+    /// Three-button dispatch for the update prompt's actions.
+    func handleUpdatePromptAction(_ action: UpdatePromptAction) {
+        guard let pending = pendingUpdate else { return }
+        switch action {
+        case .updateNow:
+            UIApplication.shared.open(pending.appStoreURL, options: [:], completionHandler: nil)
+            // Clear the prompt immediately. The next foreground re-runs
+            // `checkInBackground()` and only re-arms if `latest >
+            // installed` still holds — once the App Store install
+            // completes, installed == latest and the prompt stays
+            // quiet without needing a separate "I updated" signal.
+            pendingUpdate = nil
+        case .later:
+            // Stamp the prompted version + timestamp so the same
+            // version is suppressed for ``AppConstants/updatePromptCooldown``.
+            // A NEWER version landing on the store re-arms the prompt
+            // immediately — only the same-version case is suppressed.
+            Defaults[.lastPromptedUpdateVersion] = pending.latestVersion
+            Defaults[.lastPromptedUpdateAt] = Date()
+            pendingUpdate = nil
+        case .skipThisVersion:
+            Defaults[.skippedUpdateVersion] = pending.latestVersion
+            pendingUpdate = nil
+        }
+    }
+
+    enum UpdatePromptAction {
+        case updateNow
+        case later
+        case skipThisVersion
+    }
+
+    // MARK: - Sheet binding
+
+    /// Single sheet item consumed by ``updateNotifySheetHost()``. Both
+    /// pending flags fold into the same `.sheet(item:)` to avoid the
+    /// SwiftUI race that stacking two `.sheet(item:)` modifiers on the
+    /// same view introduces. What's New presents first when both are
+    /// set so the upgrade summary is read before the next-version
+    /// prompt — dismissing it lets the update prompt take its place on
+    /// the next observation cycle.
+    var activeNotifySheet: NotifySheet? {
+        if let entry = pendingWhatsNew { return .whatsNew(entry) }
+        if let pending = pendingUpdate { return .update(pending) }
+        return nil
+    }
+
+    /// Called by the sheet host when SwiftUI clears its binding (swipe
+    /// to dismiss, tap outside on iPad, etc). Mirrors the per-sheet
+    /// dismissal semantics each surface had when they lived in
+    /// independent `.sheet(item:)` modifiers:
+    ///   * What's New: advance `lastShownWhatsNewVersion` so the gate
+    ///     does not re-arm on the next launch (same as a Continue tap).
+    ///   * Update prompt: clear the pending flag without stamping the
+    ///     "Later" cooldown — the next throttle-elapsed background check
+    ///     is free to re-arm. Tapping a button on the prompt instead
+    ///     routes through ``handleUpdatePromptAction(_:)`` and DOES
+    ///     stamp.
+    func dismissActiveNotifySheet() {
+        if pendingWhatsNew != nil {
+            acknowledgeWhatsNew()
+            return
+        }
+        if pendingUpdate != nil {
+            pendingUpdate = nil
+        }
+    }
+
+    // MARK: - Private
+
+    private func performCheck(manual: Bool) async {
+        if manual {
+            isCheckingForUpdate = true
+            lastManualCheckResult = nil
+        }
+        defer { if manual { isCheckingForUpdate = false } }
+
+        let result = await sharedLookup()
+        // Stamp the throttle on ANY successful answer from Apple
+        // (including "no record yet" during the TestFlight phase) so
+        // the dormant lifecycle state does not generate one iTunes
+        // Lookup per scene-active. Real network failures (`.failed`)
+        // skip the stamp so a brief offline state at launch retries
+        // on the next foreground. Manual taps always stamp so the
+        // next background trigger respects the throttle.
+        switch result {
+        case .found, .noRecord:
+            Defaults[.lastUpdateCheckAt] = Date()
+        case .failed:
+            if manual { Defaults[.lastUpdateCheckAt] = Date() }
+        }
+
+        switch result {
+        case .failed:
+            if manual { lastManualCheckResult = .failed }
+            return
+        case .noRecord:
+            // Apple has no public record — TestFlight phase or
+            // unlisted region. Treat as "you're on the latest"
+            // for manual UX (the user is on whatever build they
+            // installed; nothing newer is publicly available) and
+            // quietly no-op for background checks.
+            if manual { lastManualCheckResult = .upToDate }
+            return
+        case .found:
+            break
+        }
+
+        guard case let .found(lookup) = result else { return }
+
+        guard
+            let latest = AppVersion(lookup.version),
+            latest > AppVersion.current
+        else {
+            if manual { lastManualCheckResult = .upToDate }
+            return
+        }
+
+        // "Skip This Version" suppression. Manual checks deliberately
+        // ignore it — a user opening Settings → Check for Updates is
+        // explicitly re-asking, and we shouldn't pretend nothing is
+        // available because they previously waved off the same version.
+        if !manual, Defaults[.skippedUpdateVersion] == lookup.version {
+            return
+        }
+
+        // 7-day same-version cooldown for "Later". Manual checks bypass
+        // (same reasoning as Skip). A NEWER version always re-arms —
+        // the cooldown only suppresses the exact `lookup.version`
+        // already presented via the sheet. The `delta >= 0` guard
+        // releases the cooldown for a future-stamped timestamp (clock
+        // skew); a negative delta is trivially `< cooldown` and would
+        // otherwise suppress the prompt indefinitely.
+        if !manual,
+           Defaults[.lastPromptedUpdateVersion] == lookup.version,
+           let lastPromptedAt = Defaults[.lastPromptedUpdateAt] {
+            let delta = Date().timeIntervalSince(lastPromptedAt)
+            if delta >= 0 && delta < AppConstants.updatePromptCooldown {
+                return
+            }
+        }
+
+        let appStoreURL = URL.knownGoodAppStoreLink(trackId: lookup.trackId)
+        let pending = PendingUpdate(latestVersion: lookup.version, appStoreURL: appStoreURL)
+        pendingUpdate = pending
+        if manual { lastManualCheckResult = .offered(pending) }
+    }
+
+    private func sharedLookup() async -> LookupResult {
+        if let existing = inFlight {
+            return await existing.value
+        }
+        let task = Task<LookupResult, Never> { [bundleId, session] in
+            do {
+                let outcome = try await AppStoreUpdateService.fetchLatest(
+                    bundleId: bundleId,
+                    session: session
+                )
+                switch outcome {
+                case .found(let lookup): return .found(lookup)
+                case .noRecord: return .noRecord
+                }
+            } catch {
+                AppLogger.captureError(
+                    error,
+                    context: ["phase": "AppStoreUpdateService.fetchLatest"]
+                )
+                return .failed
+            }
+        }
+        inFlight = task
+        let result = await task.value
+        inFlight = nil
+        return result
+    }
+
+    /// Static + nonisolated so the fresh-install seed (also nonisolated)
+    /// can read it without a MainActor hop. Falls back to `"0.0.0"` so the
+    /// gate fails closed; a DEBUG assertion surfaces the underlying
+    /// bundle misconfiguration rather than letting it silently inert the
+    /// feature.
+    nonisolated static var bundleVersionString: String {
+        if let raw = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            return raw
+        }
+        assertionFailure("CFBundleShortVersionString missing from Bundle.main — What's New gate will use the 0.0.0 fallback.")
+        return "0.0.0"
+    }
+
+    /// Instance accessor for call sites already on the MainActor (the
+    /// rest of the coordinator). Same value, no concurrency hop.
+    private var bundleVersionString: String { Self.bundleVersionString }
+}
+
+private extension URL {
+    /// `https://apps.apple.com/app/id<trackId>` — the canonical App
+    /// Store deep link. Tapping it on a device with the App Store
+    /// installed opens the product page directly; falls back to a web
+    /// view on Mac Catalyst / device-less Simulator runs.
+    static func knownGoodAppStoreLink(trackId: Int) -> URL {
+        // Build through URLComponents so a future trackId edit can't
+        // produce a malformed literal that crashes the open call.
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "apps.apple.com"
+        components.path = "/app/id\(trackId)"
+        // URLComponents always returns non-nil here for a well-formed
+        // scheme+host+path, but guarding keeps the call site honest if
+        // the path template ever changes.
+        return components.url ?? URL(string: "https://apps.apple.com/app/id\(trackId)")!
+    }
+}
+#endif

--- a/swift/TigerDuck/Features/Updates/UpdateNotifyCoordinator.swift
+++ b/swift/TigerDuck/Features/Updates/UpdateNotifyCoordinator.swift
@@ -455,9 +455,13 @@ final class UpdateNotifyCoordinator {
         }
         let task = Task<LookupResult, Never> { [bundleId, session] in
             do {
+                // Pin the storefront so users abroad / on a VPN don't
+                // get an IP-inferred storefront that returns no record
+                // and silently masks an available update.
                 let outcome = try await AppStoreUpdateService.fetchLatest(
                     bundleId: bundleId,
-                    session: session
+                    session: session,
+                    country: AppConstants.appStoreLookupStorefront
                 )
                 switch outcome {
                 case .found(let lookup): return .found(lookup)

--- a/swift/TigerDuck/Features/Updates/UpdateNotifySheetHost.swift
+++ b/swift/TigerDuck/Features/Updates/UpdateNotifySheetHost.swift
@@ -1,0 +1,98 @@
+#if os(iOS)
+import SwiftUI
+
+/// View-modifier wrapper that mounts the update-related sheets (Update
+/// Prompt + What's New) on `MainTabView`. Applied at the same level as
+/// `.flipToLibraryAttached()` and `.firstTriggerPromptHost()` so a stale
+/// presentation cannot leak across tab swaps the way a per-tab
+/// `.sheet(...)` would.
+///
+/// Both surfaces flow through a single `.sheet(item:)` driven by
+/// ``UpdateNotifyCoordinator/activeNotifySheet``. Two stacked
+/// `.sheet(item:)` modifiers on the same view race in SwiftUI — when
+/// both items become non-nil in the same render cycle (a post-update
+/// launch that's ALSO behind on App Store), only one ever presents and
+/// the loser's `onDismiss` never fires, leaving its persisted seen-marker
+/// un-advanced. The single-binding design dequeues them in priority
+/// order instead: What's New presents first; dismissing it (any path)
+/// acknowledges it and lets the update prompt take its place on the
+/// next observation cycle.
+private struct UpdateNotifySheetHost: ViewModifier {
+    @Environment(AppState.self) private var appState
+
+    func body(content: Content) -> some View {
+        let coordinator = appState.updateNotifyCoordinator
+        return content.sheet(
+            item: Binding<NotifySheet?>(
+                get: { coordinator.activeNotifySheet },
+                set: { newValue in
+                    // Only `set(nil)` (dismissal) matters here; non-nil
+                    // writes are driven by the coordinator's pending
+                    // flags, not the sheet binding.
+                    guard newValue == nil else { return }
+                    coordinator.dismissActiveNotifySheet()
+                }
+            )
+        ) { sheet in
+            switch sheet {
+            case .whatsNew(let entry):
+                WhatsNewSheetView(entry: entry) {
+                    coordinator.acknowledgeWhatsNew()
+                }
+                // Fraction picked to leave the icon + headline visible
+                // above the first highlight on a 4.7" iPhone SE without
+                // forcing scroll. The .large fallback accommodates
+                // Dynamic Type's larger sizes via a drag-to-expand
+                // gesture rather than capping the layout at the
+                // smaller detent.
+                .presentationDetents([.fraction(0.85), .large])
+            case .update(let pending):
+                UpdatePromptView(pending: pending) { action in
+                    coordinator.handleUpdatePromptAction(action)
+                }
+                .presentationDetents([.fraction(0.6), .large])
+            }
+        }
+    }
+}
+
+/// Discriminated union mapping the coordinator's two independent
+/// pending flags to a single sheet item. The order in
+/// ``UpdateNotifyCoordinator/activeNotifySheet`` decides priority when
+/// both flags are set simultaneously.
+enum NotifySheet: Identifiable, Equatable {
+    case whatsNew(WhatsNewRepository.ResolvedWhatsNew)
+    case update(UpdateNotifyCoordinator.PendingUpdate)
+
+    var id: String {
+        switch self {
+        case .whatsNew(let entry): return "whatsNew:\(entry.version)"
+        case .update(let pending): return "update:\(pending.latestVersion)"
+        }
+    }
+}
+
+extension View {
+    /// Apply the update-notify + What's New sheet host to a root view.
+    /// Idempotent — safe to call multiple times, but should be applied
+    /// exactly once near the app's root.
+    func updateNotifySheetHost() -> some View {
+        modifier(UpdateNotifySheetHost())
+    }
+}
+
+extension UpdateNotifyCoordinator.PendingUpdate: Identifiable {
+    /// `.sheet(item:)` needs Identifiable. The latest-version string is
+    /// unique-per-presentation: re-arming with the same version requires
+    /// the throttle to elapse AND a non-Skip dismiss path, by which
+    /// point SwiftUI has cleared the previous sheet binding and reusing
+    /// the same id is fine.
+    var id: String { latestVersion }
+}
+
+extension WhatsNewRepository.ResolvedWhatsNew: Identifiable {
+    /// `version` is the natural primary key for the registry — one
+    /// entry per release.
+    var id: String { version }
+}
+#endif

--- a/swift/TigerDuck/Features/Updates/UpdatePromptView.swift
+++ b/swift/TigerDuck/Features/Updates/UpdatePromptView.swift
@@ -1,0 +1,84 @@
+#if os(iOS)
+import SwiftUI
+
+/// Three-button "an update is ready" sheet. Owned by the
+/// ``UpdateNotifyCoordinator`` flow — view receives the pending update
+/// and dispatches the selected action through the closure passed in.
+///
+/// Why a custom sheet over `.alert`: the Update / Later / Skip choice
+/// triad doesn't fit the iOS alert primary/secondary/destructive
+/// rhetoric (Skip is destructive-ish but not OS-level "danger"), and a
+/// sheet lets us include the latest version string with proper
+/// hierarchy and a release-notes-style accent illustration. The
+/// existing `FirstTriggerPromptCenter` pattern is the closest cousin in
+/// the app but bakes in a per-feature "seen once" persistence model
+/// that doesn't apply here — Later re-arms the same version after the
+/// 24h throttle, only Skip suppresses it indefinitely.
+struct UpdatePromptView: View {
+    let pending: UpdateNotifyCoordinator.PendingUpdate
+    let onAction: (UpdateNotifyCoordinator.UpdatePromptAction) -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            VStack(spacing: 16) {
+                Image(systemName: "arrow.down.app.fill")
+                    .font(.system(size: 64, weight: .medium))
+                    .foregroundStyle(.tint)
+                    .padding(.top, 32)
+                Text(String(localized: "update_available_title"))
+                    .font(.title2.bold())
+                    .multilineTextAlignment(.center)
+                Text(String(
+                    format: NSLocalizedString("update_available_message", comment: ""),
+                    pending.latestVersion
+                ))
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 24)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+
+            VStack(spacing: 10) {
+                Button {
+                    onAction(.updateNow)
+                } label: {
+                    Text(String(localized: "update_action_update_now"))
+                        .font(.body.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button {
+                    onAction(.later)
+                } label: {
+                    Text(String(localized: "update_action_later"))
+                        .font(.body.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+                .buttonStyle(.bordered)
+
+                // Skip is the destructive-tinted tail option so it reads
+                // as "this version specifically — never again" without
+                // looking like the primary action. Mirrors the iOS
+                // Settings → App Updates "Skip this version" placement.
+                Button(role: .destructive) {
+                    onAction(.skipThisVersion)
+                } label: {
+                    Text(String(localized: "update_action_skip_version"))
+                        .font(.body.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 24)
+        }
+    }
+}
+#endif

--- a/swift/TigerDuck/Features/Updates/WhatsNewModels.swift
+++ b/swift/TigerDuck/Features/Updates/WhatsNewModels.swift
@@ -1,0 +1,29 @@
+#if os(iOS)
+import Foundation
+
+/// One localized "What's new" block, decoded from `whatsnew.json`. The
+/// JSON shape mirrors the Android port (`assets/whatsnew.json`):
+///
+/// ```json
+/// {
+///   "1.7.0": {
+///     "zh-TW": { "title": "...", "highlights": ["...", "..."] },
+///     "en":    { "title": "...", "highlights": ["...", "..."] }
+///   }
+/// }
+/// ```
+///
+/// Top-level keys are `CFBundleShortVersionString` values (iOS marketing
+/// version, e.g. `"1.7.0"`). Each entry holds a per-locale map; the
+/// repository picks the locale that best matches the resolved app
+/// language tag, falling back to `en`.
+///
+/// Fields are optional defensively — a release with no JSON edit should
+/// silently skip the prompt instead of crashing on decode. The
+/// repository's selector treats an entry with missing/blank `title` or
+/// empty `highlights` as absent.
+struct WhatsNewEntry: Decodable, Equatable {
+    let title: String?
+    let highlights: [String]?
+}
+#endif

--- a/swift/TigerDuck/Features/Updates/WhatsNewRepository.swift
+++ b/swift/TigerDuck/Features/Updates/WhatsNewRepository.swift
@@ -13,10 +13,12 @@ import Foundation
 /// bug-fix releases can be skipped — the gate stays quiet when no
 /// entry is registered.
 ///
-/// **Locale resolution**: a Chinese language tag (`zh-*`) maps to the
-/// `zh-TW` block; everything else falls back to `en`. Intentionally
-/// matches Android's selector so the same content renders on both
-/// platforms for a given account.
+/// **Locale resolution**: Traditional Chinese tags (`zh-Hant*`, bare
+/// `zh`, `zh-TW`, `zh-HK`, …) map to the `zh-TW` block; Simplified
+/// tags (`zh-Hans*`, `zh-CN`, `zh-SG`) map to a `zh-Hans` block when
+/// authored, otherwise fall through to `en` — a Simplified reader
+/// gets English rather than Traditional, which would otherwise render
+/// awkwardly. Everything non-Chinese falls back to `en`.
 struct WhatsNewRepository {
     /// Resolved entry for the current locale — what the UI actually
     /// renders. Decoupled from the on-disk ``WhatsNewEntry`` so the
@@ -107,11 +109,23 @@ struct WhatsNewRepository {
     ) -> ResolvedWhatsNew? {
         guard let versionEntry else { return nil }
         let localeKey: String = {
-            // Match by language subtag prefix so "zh-Hant", "zh-Hans",
-            // "zh_TW", "zh" all hit the same Chinese block. Everything
-            // else (including non-existent locales) falls back to en.
-            if languageTag.lowercased().hasPrefix("zh") { return "zh-TW" }
-            return "en"
+            // Distinguish Simplified ("zh-Hans*", "zh-CN", "zh-SG") from
+            // Traditional ("zh-Hant*", "zh-TW", "zh-HK", bare "zh").
+            // Simplified resolves to "zh-Hans", which is intentionally
+            // allowed to fall through to "en" below when whatsnew.json
+            // has no Simplified block — preferable to serving Traditional
+            // text to a Simplified reader.
+            guard languageTag.lowercased().hasPrefix("zh") else { return "en" }
+            let locale = Locale(identifier: languageTag)
+            switch locale.language.script?.identifier {
+            case "Hans": return "zh-Hans"
+            case "Hant": return "zh-TW"
+            default:
+                switch locale.region?.identifier {
+                case "CN", "SG": return "zh-Hans"
+                default: return "zh-TW"
+                }
+            }
         }()
         let entry = versionEntry[localeKey] ?? versionEntry["en"]
         guard let entry,

--- a/swift/TigerDuck/Features/Updates/WhatsNewRepository.swift
+++ b/swift/TigerDuck/Features/Updates/WhatsNewRepository.swift
@@ -1,0 +1,128 @@
+#if os(iOS)
+import Foundation
+
+/// Loads maintainer-authored "What's new" content from the bundled
+/// `whatsnew.json` asset. Ported from the Android `WhatsNewRepository`:
+/// the JSON is a versionString → per-locale map; this repo picks the
+/// locale block that best matches the resolved app language tag and
+/// surfaces it as a ``ResolvedWhatsNew``.
+///
+/// **Maintainer ritual** (matches the Android side): every release
+/// worth surfacing in-app adds a new top-level entry to
+/// `whatsnew.json` BEFORE the version is tagged / merged to main. Pure
+/// bug-fix releases can be skipped — the gate stays quiet when no
+/// entry is registered.
+///
+/// **Locale resolution**: a Chinese language tag (`zh-*`) maps to the
+/// `zh-TW` block; everything else falls back to `en`. Intentionally
+/// matches Android's selector so the same content renders on both
+/// platforms for a given account.
+struct WhatsNewRepository {
+    /// Resolved entry for the current locale — what the UI actually
+    /// renders. Decoupled from the on-disk ``WhatsNewEntry`` so the
+    /// view doesn't have to deal with the optional/empty edge cases the
+    /// repo already filters out.
+    struct ResolvedWhatsNew: Equatable {
+        let version: String
+        let title: String
+        let highlights: [String]
+    }
+
+    private let bundle: Bundle
+    private let resourceName: String
+
+    /// Nonisolated so `UpdateNotifyCoordinator`'s (also nonisolated)
+    /// `init` can construct one without a MainActor hop. The struct
+    /// only reads bundle resources and never touches actor-isolated
+    /// state, so there's no isolation to preserve here.
+    nonisolated init(bundle: Bundle = .main, resourceName: String = "whatsnew") {
+        self.bundle = bundle
+        self.resourceName = resourceName
+    }
+
+    /// Resolved entry for `version` in the locale implied by
+    /// `languageTag`, or `nil` if the asset is missing/malformed, has no
+    /// entry for that version, or the entry is empty after filtering.
+    func entry(forVersion version: String, languageTag: String) -> ResolvedWhatsNew? {
+        guard let byVersion = loadByVersion() else { return nil }
+        return Self.select(
+            versionEntry: byVersion[version],
+            version: version,
+            languageTag: languageTag
+        )
+    }
+
+    /// Resolved entry for the newest registered version, ignoring the
+    /// running build's version. Backs the Settings → What's New entry,
+    /// which has to surface the latest authored content even on the
+    /// build that ships it.
+    func latestEntry(languageTag: String) -> ResolvedWhatsNew? {
+        guard let byVersion = loadByVersion(), !byVersion.isEmpty else { return nil }
+        // Sort by parsed AppVersion so "1.10.0" outranks "1.9.0" (lexical
+        // sort would invert them). Falls back to lexical ordering when
+        // any key fails to parse, which matters for a maintainer typo —
+        // surfacing *something* beats surfacing nothing.
+        let pairs = byVersion.keys.compactMap { key -> (String, AppVersion)? in
+            guard let v = AppVersion(key) else { return nil }
+            return (key, v)
+        }
+        let latestKey: String? = pairs
+            .max(by: { $0.1 < $1.1 })?
+            .0 ?? byVersion.keys.sorted().last
+        guard let latestKey else { return nil }
+        return Self.select(
+            versionEntry: byVersion[latestKey],
+            version: latestKey,
+            languageTag: languageTag
+        )
+    }
+
+    /// True when the asset has at least one usable entry. Used by the
+    /// Settings row to hide the "What's New" button on a build that
+    /// shipped without any registered content yet.
+    func hasAnyContent(languageTag: String) -> Bool {
+        latestEntry(languageTag: languageTag) != nil
+    }
+
+    // MARK: - Internal
+
+    private typealias ByVersion = [String: [String: WhatsNewEntry]]
+
+    private func loadByVersion() -> ByVersion? {
+        guard
+            let url = bundle.url(forResource: resourceName, withExtension: "json"),
+            let data = try? Data(contentsOf: url)
+        else {
+            return nil
+        }
+        return try? JSONDecoder().decode(ByVersion.self, from: data)
+    }
+
+    /// Pure selector — kept static so tests can drive it without mounting
+    /// a bundle. Matches the Android `select` logic.
+    static func select(
+        versionEntry: [String: WhatsNewEntry]?,
+        version: String,
+        languageTag: String
+    ) -> ResolvedWhatsNew? {
+        guard let versionEntry else { return nil }
+        let localeKey: String = {
+            // Match by language subtag prefix so "zh-Hant", "zh-Hans",
+            // "zh_TW", "zh" all hit the same Chinese block. Everything
+            // else (including non-existent locales) falls back to en.
+            if languageTag.lowercased().hasPrefix("zh") { return "zh-TW" }
+            return "en"
+        }()
+        let entry = versionEntry[localeKey] ?? versionEntry["en"]
+        guard let entry,
+              let title = entry.title?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !title.isEmpty,
+              let highlights = entry.highlights,
+              !highlights.isEmpty
+        else {
+            return nil
+        }
+        return ResolvedWhatsNew(version: version, title: title, highlights: highlights)
+    }
+}
+#endif

--- a/swift/TigerDuck/Features/Updates/WhatsNewRepository.swift
+++ b/swift/TigerDuck/Features/Updates/WhatsNewRepository.swift
@@ -13,12 +13,13 @@ import Foundation
 /// bug-fix releases can be skipped — the gate stays quiet when no
 /// entry is registered.
 ///
-/// **Locale resolution**: Traditional Chinese tags (`zh-Hant*`, bare
-/// `zh`, `zh-TW`, `zh-HK`, …) map to the `zh-TW` block; Simplified
-/// tags (`zh-Hans*`, `zh-CN`, `zh-SG`) map to a `zh-Hans` block when
-/// authored, otherwise fall through to `en` — a Simplified reader
-/// gets English rather than Traditional, which would otherwise render
-/// awkwardly. Everything non-Chinese falls back to `en`.
+/// **Locale resolution**: every Sinitic-family language (Mandarin
+/// `zh-Hant*` / `zh-Hans*`, Cantonese `yue`, Wu `wuu`, Min Nan `nan`,
+/// Hakka `hak`, Classical `lzh`) falls back to the `zh-TW` block when
+/// no closer match is authored — a Chinese-language reader gets
+/// readable Chinese text rather than English. Simplified-script tags
+/// additionally prefer a `zh-Hans` block first when one is authored.
+/// Non-Sinitic languages fall back to `en`.
 struct WhatsNewRepository {
     /// Resolved entry for the current locale — what the UI actually
     /// renders. Decoupled from the on-disk ``WhatsNewEntry`` so the
@@ -101,33 +102,17 @@ struct WhatsNewRepository {
     }
 
     /// Pure selector — kept static so tests can drive it without mounting
-    /// a bundle. Matches the Android `select` logic.
+    /// a bundle. See the type doc comment for the locale fallback policy.
     static func select(
         versionEntry: [String: WhatsNewEntry]?,
         version: String,
         languageTag: String
     ) -> ResolvedWhatsNew? {
         guard let versionEntry else { return nil }
-        let localeKey: String = {
-            // Distinguish Simplified ("zh-Hans*", "zh-CN", "zh-SG") from
-            // Traditional ("zh-Hant*", "zh-TW", "zh-HK", bare "zh").
-            // Simplified resolves to "zh-Hans", which is intentionally
-            // allowed to fall through to "en" below when whatsnew.json
-            // has no Simplified block — preferable to serving Traditional
-            // text to a Simplified reader.
-            guard languageTag.lowercased().hasPrefix("zh") else { return "en" }
-            let locale = Locale(identifier: languageTag)
-            switch locale.language.script?.identifier {
-            case "Hans": return "zh-Hans"
-            case "Hant": return "zh-TW"
-            default:
-                switch locale.region?.identifier {
-                case "CN", "SG": return "zh-Hans"
-                default: return "zh-TW"
-                }
-            }
-        }()
-        let entry = versionEntry[localeKey] ?? versionEntry["en"]
+        let entry = localeCandidates(for: languageTag)
+            .lazy
+            .compactMap { versionEntry[$0] }
+            .first
         guard let entry,
               let title = entry.title?.trimmingCharacters(in: .whitespacesAndNewlines),
               !title.isEmpty,
@@ -137,6 +122,31 @@ struct WhatsNewRepository {
             return nil
         }
         return ResolvedWhatsNew(version: version, title: title, highlights: highlights)
+    }
+
+    /// ISO 639 codes treated as "Chinese-family" for locale fallback —
+    /// mirrors ``LanguageManager/chineseLanguageCodes`` (kept local
+    /// because that one is private). A reader of any of these prefers
+    /// Traditional Chinese over English when no closer block exists.
+    private static let sinitic: Set<String> = ["zh", "yue", "nan", "hak", "wuu", "lzh"]
+
+    /// Ordered list of `whatsnew.json` locale keys to try for a given
+    /// language tag. The lookup walks this until it finds an authored
+    /// block; only the universal `en` tail catches non-Sinitic locales.
+    private static func localeCandidates(for languageTag: String) -> [String] {
+        let locale = Locale(identifier: languageTag)
+        let code = locale.language.languageCode?.identifier ?? ""
+        guard sinitic.contains(code) else { return ["en"] }
+        // Simplified-script readers (`zh-Hans*`, `zh-CN`, `zh-SG`) prefer
+        // an authored Simplified block when one exists; everyone in the
+        // Sinitic family — including Cantonese, Wu, Hakka, etc. — falls
+        // back to Traditional (`zh-TW`) before ever reaching English.
+        let isSimplified: Bool = {
+            if let script = locale.language.script?.identifier { return script == "Hans" }
+            if let region = locale.region?.identifier { return region == "CN" || region == "SG" }
+            return false
+        }()
+        return isSimplified ? ["zh-Hans", "zh-TW", "en"] : ["zh-TW", "en"]
     }
 }
 #endif

--- a/swift/TigerDuck/Features/Updates/WhatsNewSheetView.swift
+++ b/swift/TigerDuck/Features/Updates/WhatsNewSheetView.swift
@@ -1,0 +1,89 @@
+#if os(iOS)
+import SwiftUI
+
+/// Sheet shown either (a) automatically on first launch after the
+/// installed version moves past `lastShownWhatsNewVersion`, or (b)
+/// manually from Settings → What's New (which always opens the latest
+/// authored entry regardless of seen-state).
+///
+/// Content comes from the bundled `whatsnew.json` via
+/// ``WhatsNewRepository``, not from in-code Swift constants — devs
+/// update the JSON before tagging a release. The shape mirrors the
+/// Android dialog: a one-line title plus a vertical list of bullet
+/// highlights. Keeping the bullets text-only (no per-row SF Symbols)
+/// matches the Android port and means a new release doesn't need a
+/// designer pass to pick icons.
+struct WhatsNewSheetView: View {
+    let entry: WhatsNewRepository.ResolvedWhatsNew
+    let onAcknowledge: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // Hero icon + version banner. The hero stays a constant
+            // sparkles glyph across releases — varying it per release
+            // would force a designer pass for every What's New, which
+            // is the kind of friction the JSON-driven content split
+            // was meant to remove.
+            VStack(spacing: 12) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 56, weight: .medium))
+                    .foregroundStyle(.tint)
+                Text(entry.title)
+                    .font(.title2.bold())
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
+            .padding(.top, 28)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    ForEach(entry.highlights.indices, id: \.self) { idx in
+                        WhatsNewBulletRow(text: entry.highlights[idx])
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            // Sticky Continue anchor. Apple's What's New pattern keeps
+            // the dismiss button visible regardless of scroll position
+            // so a user with a long release-notes list never has to
+            // scroll to find the way out.
+            Button {
+                onAcknowledge()
+            } label: {
+                Text(String(localized: "whats_new_continue"))
+                    .font(.body.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.horizontal, 24)
+            .padding(.bottom, 24)
+        }
+    }
+}
+
+private struct WhatsNewBulletRow: View {
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            // Filled-circle bullet at the leading edge — lines up with
+            // the first text baseline so wrapped lines indent under the
+            // text rather than the bullet.
+            Image(systemName: "circle.fill")
+                .font(.system(size: 6))
+                .foregroundStyle(.tint)
+                .accessibilityHidden(true)
+                .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 4 }
+            Text(text)
+                .font(.body)
+                .foregroundStyle(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+}
+#endif

--- a/swift/TigerDuck/Services/API/AppStoreUpdateService.swift
+++ b/swift/TigerDuck/Services/API/AppStoreUpdateService.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Talks to Apple's public iTunes Lookup endpoint to discover whether a
+/// newer build of this app has been published to the App Store.
+///
+/// **Lifecycle note**: until the iOS app ships publicly,
+/// `resultCount == 0` for this bundle id — the service surfaces that as
+/// ``LookupOutcome/noRecord``, the coordinator stamps the throttle (a
+/// successful "no record" is still a successful answer) and quietly
+/// no-ops without a prompt. The day the app lands on the App Store the
+/// same code path activates with zero additional release work.
+/// TestFlight builds are explicitly NOT indexed by this endpoint;
+/// that's a known gap of the iTunes Lookup approach and the reason
+/// this feature ships dormant during the TF phase.
+enum AppStoreUpdateService {
+    struct Lookup: Equatable {
+        /// Latest marketing version on the App Store, e.g. `"1.8.0"`.
+        let version: String
+        /// App Store track id. Used to build the deep link
+        /// `https://apps.apple.com/app/id<trackId>` that the Update Now
+        /// button opens. iTunes Lookup uses `trackId`, not `bundleId`,
+        /// for the App Store deep link — the latter has no canonical URL.
+        let trackId: Int
+        /// "What's New on the App Store" notes for the latest version, in
+        /// the requesting Apple ID's locale (NOT the app's selected
+        /// language). The What's New sheet uses the bundled per-version
+        /// registry instead so the text stays in sync with the app
+        /// locale; this field is captured for diagnostics only.
+        let releaseNotes: String?
+    }
+
+    enum LookupError: Error {
+        case invalidResponse
+        case decodingFailed
+    }
+
+    static let lookupURL = URL.knownGood("https://itunes.apple.com/lookup")
+
+    /// Discriminated result for `fetchLatest`. The caller needs to tell
+    /// "Apple has no public record" (legit pre-launch state — stamp the
+    /// throttle, don't surface a failure alert) from "couldn't reach
+    /// Apple" (retry next foreground, surface failure on manual taps).
+    enum LookupOutcome: Equatable {
+        case found(Lookup)
+        case noRecord
+    }
+
+    /// Fetch the App Store record for `bundleId`. Returns
+    /// ``LookupOutcome/noRecord`` when Apple successfully responded
+    /// but has no public record yet (TestFlight phase). Throws on
+    /// network / decoding failures so the caller can distinguish those
+    /// two paths.
+    static func fetchLatest(
+        bundleId: String,
+        session: URLSession = .shared,
+        country: String? = nil
+    ) async throws -> LookupOutcome {
+        var components = URLComponents(url: lookupURL, resolvingAgainstBaseURL: false)!
+        var items: [URLQueryItem] = [URLQueryItem(name: "bundleId", value: bundleId)]
+        if let country, !country.isEmpty {
+            // iTunes Lookup is per-storefront. Caller can scope to a
+            // specific country (e.g. "tw") if the app is regionally
+            // released; default leaves Apple to pick by the request IP.
+            items.append(URLQueryItem(name: "country", value: country))
+        }
+        components.queryItems = items
+        guard let url = components.url else { throw LookupError.invalidResponse }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw LookupError.invalidResponse
+        }
+
+        let decoded: Envelope
+        do {
+            decoded = try JSONDecoder().decode(Envelope.self, from: data)
+        } catch {
+            throw LookupError.decodingFailed
+        }
+
+        guard let first = decoded.results.first else { return .noRecord }
+        return .found(Lookup(
+            version: first.version,
+            trackId: first.trackId,
+            releaseNotes: first.releaseNotes
+        ))
+    }
+
+    // MARK: - Wire format
+
+    private struct Envelope: Decodable {
+        let results: [Result]
+    }
+
+    private struct Result: Decodable {
+        let version: String
+        let trackId: Int
+        let releaseNotes: String?
+    }
+}

--- a/swift/TigerDuck/Shared/AppVersion.swift
+++ b/swift/TigerDuck/Shared/AppVersion.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Dotted-numeric app-version comparison used by the in-app update prompt
+/// and the What's New gate. Stays semver-shaped on purpose — both surfaces
+/// only ever compare release versions sourced from `MARKETING_VERSION` and
+/// iTunes Lookup's `version` field, neither of which carries pre-release
+/// or build metadata. Anything richer (e.g. `1.7.0-beta.1+sha`) is treated
+/// as malformed and returned as `nil`.
+struct AppVersion: Comparable, Equatable {
+    let components: [Int]
+
+    /// Parse a dotted-numeric string into ordered components. Returns `nil`
+    /// for anything that isn't a non-empty sequence of integers separated
+    /// by `.` — guarding the update prompt against a future App Store
+    /// response that ships build metadata we'd otherwise sort lexically
+    /// and mis-rank ("1.10.0" < "1.9.0" under string comparison).
+    init?(_ raw: String) {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let parts = trimmed.split(separator: ".", omittingEmptySubsequences: false)
+        var parsed: [Int] = []
+        parsed.reserveCapacity(parts.count)
+        for part in parts {
+            // `Int(_:)` accepts a leading `+` or `-`, so `Int("+1")`
+            // returns 1 and the `n >= 0` check below would pass it
+            // through. Require pure digits before parsing so a typo'd
+            // key in `whatsnew.json` or a future iTunes Lookup
+            // response carrying a sign prefix is rejected cleanly
+            // (returns `nil`) rather than silently collapsing to the
+            // unsigned variant.
+            guard !part.isEmpty, part.allSatisfy(\.isASCII), part.allSatisfy(\.isNumber) else {
+                return nil
+            }
+            guard let n = Int(part), n >= 0 else { return nil }
+            parsed.append(n)
+        }
+        guard !parsed.isEmpty else { return nil }
+        self.components = parsed
+    }
+
+    /// Compare component-wise, padding the shorter side with zeros so
+    /// `1.7` and `1.7.0` are equal and `1.7.0 < 1.7.1`.
+    static func < (lhs: AppVersion, rhs: AppVersion) -> Bool {
+        let width = max(lhs.components.count, rhs.components.count)
+        for i in 0..<width {
+            let l = i < lhs.components.count ? lhs.components[i] : 0
+            let r = i < rhs.components.count ? rhs.components[i] : 0
+            if l != r { return l < r }
+        }
+        return false
+    }
+
+    /// Current marketing version baked into the app bundle. Falls back to
+    /// `"0.0.0"` so the update check fails closed (newer-on-store wins)
+    /// rather than treating a missing key as "infinitely new"; a DEBUG
+    /// assertion surfaces the underlying bundle misconfiguration so the
+    /// fallback does not silently inert the feature in development.
+    static var current: AppVersion {
+        if let raw = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+           let parsed = AppVersion(raw) {
+            return parsed
+        }
+        assertionFailure("CFBundleShortVersionString missing or unparseable — AppVersion.current using 0.0.0 fallback.")
+        return AppVersion("0.0.0")!
+    }
+}

--- a/swift/TigerDuck/Shared/FirstTriggerPrompt.swift
+++ b/swift/TigerDuck/Shared/FirstTriggerPrompt.swift
@@ -106,6 +106,14 @@ final class FirstTriggerPromptCenter {
         UserDefaults.standard.set(true, forKey: Self.storageKey(key))
     }
 
+    /// Re-arm a previously-seen prompt so the next ``requestIfFirstTime``
+    /// call for the same key surfaces it again. Used by the debug
+    /// "Triggers" page to re-test the first-flip experience; also a clean
+    /// hook for any future user-facing "reset onboarding" surface.
+    func reset(_ key: FirstTriggerPromptKey) {
+        UserDefaults.standard.removeObject(forKey: Self.storageKey(key))
+    }
+
     private static func storageKey(_ key: FirstTriggerPromptKey) -> String {
         "firstTriggerPromptSeen.\(key.rawValue)"
     }

--- a/swift/TigerDuck/TigerDuckApp.swift
+++ b/swift/TigerDuck/TigerDuckApp.swift
@@ -86,6 +86,12 @@ struct TigerDuckApp: App {
                         widgetSnapshotWriter = WidgetSnapshotWriter(appState: appState)
                         widgetSnapshotWriter?.regenerate()
                     }
+                    // First-launch path. `.onChange(of: scenePhase)` does
+                    // not fire for the initial `.active` value, so the
+                    // first background check needs an explicit kickoff
+                    // here; subsequent foreground returns go through the
+                    // scene-phase observer.
+                    appState.updateNotifyCoordinator.checkInBackground()
                 }
                 .onOpenURL { url in
                     guard let destination = WidgetURLRouter.route(url) else { return }
@@ -110,6 +116,12 @@ struct TigerDuckApp: App {
                             appState.requestPushScheduleSync()
                         }
                         widgetSnapshotWriter?.regenerate()
+                        // Background "is there a newer build on the App
+                        // Store?" check. Internally throttled to once
+                        // per ``AppConstants/updateCheckThrottle`` so
+                        // rapid scene toggles don't generate iTunes
+                        // Lookup traffic.
+                        appState.updateNotifyCoordinator.checkInBackground()
                     }
                 }
         }

--- a/swift/TigerDuck/whatsnew.json
+++ b/swift/TigerDuck/whatsnew.json
@@ -1,0 +1,20 @@
+{
+  "1.7.0": {
+    "zh-TW": {
+      "title": "1.7.0 有什麼新功能",
+      "highlights": [
+        "可以調整課表與主畫面小工具中的課名字型大小。",
+        "App Store 上推出新版本時，會在 App 內提醒你更新。",
+        "升級後首次開啟會顯示這個「新功能」說明。"
+      ]
+    },
+    "en": {
+      "title": "What's new in 1.7.0",
+      "highlights": [
+        "Resize course names in the class table and home-screen widgets.",
+        "We'll let you know when a new release is ready on the App Store.",
+        "After upgrading, this 'What's new' summary appears on first launch."
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds an iOS-only update-notify flow mirroring Android's `UpdatePromptGate` + `WhatsNewGate`. iTunes Lookup surfaces a three-button Update / Later / Skip prompt with a 7-day same-version cooldown, plus a Settings → Check for Updates manual entry point.
- Bundles `whatsnew.json` and auto-presents a per-release What's New sheet on the first launch after upgrade; Settings → What's New also opens it on demand.
- Debug → Triggers gains arming for both prompts and a replay button for the flip-to-Library first-trigger surface.

## Key surfaces
- `UpdateNotifyCoordinator` (lives on `AppState`) owns the iTunes Lookup pipeline, throttle, cooldown, and sheet flags.
- `UpdateNotifySheetHost` mounts a single `.sheet(item:)` driven by a `NotifySheet` enum so both prompts share one host (avoids SwiftUI's two-`.sheet(item:)` race).
- `WhatsNewRepository` + `WhatsNewSheetView` render maintainer-authored release notes from `whatsnew.json`.
- `AppStoreUpdateService` returns a tri-state `LookupOutcome` (`found` / `noRecord` / throws) so the coordinator distinguishes "Apple has no public record yet" (TestFlight phase — stamp throttle, no failure alert) from "couldn't reach Apple" (retry next foreground).

## Notable design decisions
- Background check is gated on `hasCompletedOnboarding`, so a pending prompt cannot be stranded by the sheet host while OnboardingView is on screen.
- `lastShownWhatsNewVersion` is seeded eagerly on fresh install, independent of the Keychain-wipe outcome, so a partial wipe failure cannot trigger a misleading What's New sheet.
- Throttle / cooldown comparisons require `delta >= 0` so a future-stamped timestamp (clock skew, restore-from-backup) does not suppress checks indefinitely.
- Surfacing the latest entry in the pre-feature-upgrade fallback now requires the entry's version to match the running bundle, so a release that forgets to add a `whatsnew.json` entry does not pop the previous version's sheet.

## Test plan
- [x] Cold launch on a fresh install: no update prompt; no What's New sheet (seed stamps the running version).
- [x] Upgrade install with a registered entry for the new version: What's New sheet auto-presents on first MainTabView appearance after onboarding.
- [x] Settings → Check for Updates on a TestFlight build: shows "You're up to date" (noRecord → upToDate), not "Update Check Failed".
- [x] Settings → What's New: opens the latest registered entry without advancing the seen marker.
- [x] Debug → Triggers → "Trigger Update Available on next open": cold-launch fires the synthetic v99.0.0 prompt once and only once per arm.
- [x] Debug → Triggers → "First library flip after 3 sec": prompt fires at root; navigating away/back during the 3 s window does not let a second tap spawn a duplicate prompt.
- [x] Library off → on round-trip with `flipToLibraryEnabled` persisted true: the Other Settings row stays visible while library is off so the user can opt out before re-enabling.