### PR TITLE
Custom push: tap routing, server-push opt-out, device-class targeting

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -42,6 +42,10 @@ Ever used [TAT](https://github.com/morris13579/tat_ntust)? We're working hard ma
 ### 🏛️ **Library** (Experimental)
 - Instant library entry QR code with zero delay
 
+### ⌚ **Apple Watch**
+- Raise your wrist for the **library entry QR code** — fullscreen, with idle-fade page dots
+- Credentials sync over WatchConnectivity — no separate sign-in on the Watch
+
 ### 🌏 **Multilingual**
 - Built-in support for **67+ locales** — follows the system language or set per-app
 - Course / classroom names are **automatically abbreviated**
@@ -142,6 +146,7 @@ Ever used [TAT](https://github.com/morris13579/tat_ntust)? We're working hard ma
 | Item | Requirement |
 |------|-------------|
 | OS | iOS 18 or later |
+| Apple Watch (optional) | watchOS 11+, paired iPhone required |
 | SSO Account | Student account (required for some features) |
 | Library | Library account (required for some features) |
 
@@ -206,34 +211,39 @@ cp api/.env.template api/.env
 
 ```
 tigerduck-app/
-├── swift/                              # iOS App (Xcode 26+ / iOS 18+)
-│   └── TigerDuck/
-│       ├── App/                        # Global state (AppState), language manager, push delegate
-│       ├── Bridge/                     # Service orchestration (KMP / native fetch bridge)
-│       ├── Features/                   # Screen-level feature modules
-│       │   ├── Home/                   # Home (Time Slider, assignments, widgets)
-│       │   ├── ClassTable/             # Class table
-│       │   ├── Calendar/               # Academic calendar
-│       │   ├── Bulletins/              # Server-driven, LLM-classified announcements
-│       │   ├── Score/                  # Historical GPA & rankings
-│       │   ├── Library/                # Library
-│       │   ├── More/                   # "More" hub + feature pinning
-│       │   ├── Settings/               # Settings (language, abbreviations, theme, source)
-│       │   └── Onboarding/             # First-run onboarding flow
-│       ├── LiveActivity/               # Live Activity / Dynamic Island
-│       │   ├── Models/  Preferences/  Providers/
-│       │   ├── Resolvers/  Runtime/  Scheduling/
-│       ├── Models/
-│       │   ├── Domain/                 # Business logic models
-│       │   └── SwiftData/              # Local persistence models
-│       ├── Services/
-│       │   ├── Auth/                   # NTUST SSO authentication
-│       │   ├── Network/                # Networking layer
-│       │   ├── Push/                   # APNs / push registration
-│       │   ├── Logging/                # Structured logging
-│       │   └── Migrations/             # One-shot migrations
-│       ├── SharedUI/                   # Reusable cross-feature views
-│       └── Theme/                      # Tokens, palette, visual presets
+├── swift/                              # iOS App + companion targets (Xcode 26+ / iOS 18+ / watchOS 11+)
+│   ├── TigerDuck/                      # Main iOS app sources
+│   │   ├── App/                        # Global state (AppState), language manager, push delegate
+│   │   ├── Bridge/                     # Service orchestration (KMP / native fetch bridge)
+│   │   ├── Features/                   # Screen-level feature modules
+│   │   │   ├── Home/                   # Home (Time Slider, assignments, widgets)
+│   │   │   ├── ClassTable/             # Class table
+│   │   │   ├── Calendar/               # Academic calendar
+│   │   │   ├── Bulletins/              # Server-driven, LLM-classified announcements
+│   │   │   ├── Score/                  # Historical GPA & rankings
+│   │   │   ├── Library/                # Library
+│   │   │   ├── More/                   # "More" hub + feature pinning
+│   │   │   ├── Settings/               # Settings (language, abbreviations, theme, source)
+│   │   │   └── Onboarding/             # First-run onboarding flow
+│   │   ├── LiveActivity/               # Live Activity / Dynamic Island (in-app logic)
+│   │   │   ├── Models/  Preferences/  Providers/
+│   │   │   ├── Resolvers/  Runtime/  Scheduling/
+│   │   ├── Models/
+│   │   │   ├── Domain/                 # Business logic models
+│   │   │   └── SwiftData/              # Local persistence models
+│   │   ├── Services/
+│   │   │   ├── Auth/                   # NTUST SSO authentication
+│   │   │   ├── Network/                # Networking layer
+│   │   │   ├── Push/                   # APNs / push registration
+│   │   │   ├── Logging/                # Structured logging
+│   │   │   └── Migrations/             # One-shot migrations
+│   │   ├── SharedUI/                   # Reusable cross-feature views
+│   │   └── Theme/                      # Tokens, palette, visual presets
+│   ├── TigerDuckLiveActivity/          # Live Activity / Dynamic Island widget extension
+│   ├── TigerDuckWidgets/               # iOS Home / Lock Screen widgets
+│   ├── TigerDuckWatch Watch App/       # Apple Watch app (Library QR)
+│   ├── TigerDuckWatchWidget/           # Apple Watch complication
+│   └── Shared/                         # Cross-target shared code (sensors, Watch comms, theme)
 ├── api-poc/                            # Third-party API validation scripts (NTUST / Moodle / Calendar)
 │   └── api/                            # ntust_sso / course_lookup / moodle / calendar
 ├── docs/                               # Planning docs, migration notes (iOS side)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [![TestFlight](https://img.shields.io/badge/TestFlight-Join-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/eVt9Gjkw)
 
-**繁體中文** | [English](README_en.md)
+**繁體中文** | [English](README.en.md)
 </div>
 
 ## 總覽
@@ -41,6 +41,10 @@ TigerDuck 是由一群學生共同開發的校園助手
 
 ### 🏛️ **圖書館**（實驗性）
 - 秒開入館 QR-Code，無任何延遲
+
+### ⌚ **Apple Watch**
+- 抬腕即見**入館 QR-Code**，全螢幕顯示、閒置自動淡出頁碼
+- 透過 WatchConnectivity 自動同步登入憑證，無需在 Watch 上重新登入
 
 ### 🌏 **外觀**
 - 內建 **67+ 種語系**，自行設定或跟著系統語言切換
@@ -143,6 +147,7 @@ TigerDuck 是由一群學生共同開發的校園助手
 | 項目 | 需求 |
 |------|------|
 | 作業系統 | iOS 18 以上 |
+| Apple Watch（選用） | watchOS 11 以上，需配對 iPhone |
 | SSO 帳號 | 學生帳號（部分功能需要）|
 | 圖書館 | 圖書館帳號（部分功能需要）|
 
@@ -207,34 +212,39 @@ cp api/.env.template api/.env
 
 ```
 tigerduck-app/
-├── swift/                              # iOS App（Xcode 26+ / iOS 18+）
-│   └── TigerDuck/
-│       ├── App/                        # 全域狀態（AppState）、語言管理、推播代理
-│       ├── Bridge/                     # 服務協調層（KMP / 原生抓取 bridge）
-│       ├── Features/                   # 各分頁功能模組
-│       │   ├── Home/                   # 首頁（時光機、作業、小工具）
-│       │   ├── ClassTable/             # 課表
-│       │   ├── Calendar/               # 行事曆
-│       │   ├── Bulletins/              # 公告（後端 LLM 分類、訂閱、推播）
-│       │   ├── Score/                  # 歷年成績與排名
-│       │   ├── Library/                # 圖書館
-│       │   ├── More/                   # 「更多」聚合頁與功能釘選
-│       │   ├── Settings/               # 設定（語言、簡稱、主題、來源碼）
-│       │   └── Onboarding/             # 初次使用引導
-│       ├── LiveActivity/               # 即時動態 / 動態島
-│       │   ├── Models/  Preferences/  Providers/
-│       │   ├── Resolvers/  Runtime/  Scheduling/
-│       ├── Models/
-│       │   ├── Domain/                 # 業務邏輯模型
-│       │   └── SwiftData/              # 本地持久化模型
-│       ├── Services/
-│       │   ├── Auth/                   # NTUST SSO 認證
-│       │   ├── Network/                # 網路請求
-│       │   ├── Push/                   # APNs / Push 註冊
-│       │   ├── Logging/                # 結構化日誌
-│       │   └── Migrations/             # 一次性遷移
-│       ├── SharedUI/                   # 共用 UI 元件
-│       └── Theme/                      # 主題、配色、視覺預設
+├── swift/                              # iOS App + 周邊 target（Xcode 26+ / iOS 18+ / watchOS 11+）
+│   ├── TigerDuck/                      # 主 iOS App 來源
+│   │   ├── App/                        # 全域狀態（AppState）、語言管理、推播代理
+│   │   ├── Bridge/                     # 服務協調層（KMP / 原生抓取 bridge）
+│   │   ├── Features/                   # 各分頁功能模組
+│   │   │   ├── Home/                   # 首頁（時光機、作業、小工具）
+│   │   │   ├── ClassTable/             # 課表
+│   │   │   ├── Calendar/               # 行事曆
+│   │   │   ├── Bulletins/              # 公告（後端 LLM 分類、訂閱、推播）
+│   │   │   ├── Score/                  # 歷年成績與排名
+│   │   │   ├── Library/                # 圖書館
+│   │   │   ├── More/                   # 「更多」聚合頁與功能釘選
+│   │   │   ├── Settings/               # 設定（語言、簡稱、主題、來源碼）
+│   │   │   └── Onboarding/             # 初次使用引導
+│   │   ├── LiveActivity/               # 即時動態 / 動態島（App 內邏輯）
+│   │   │   ├── Models/  Preferences/  Providers/
+│   │   │   ├── Resolvers/  Runtime/  Scheduling/
+│   │   ├── Models/
+│   │   │   ├── Domain/                 # 業務邏輯模型
+│   │   │   └── SwiftData/              # 本地持久化模型
+│   │   ├── Services/
+│   │   │   ├── Auth/                   # NTUST SSO 認證
+│   │   │   ├── Network/                # 網路請求
+│   │   │   ├── Push/                   # APNs / Push 註冊
+│   │   │   ├── Logging/                # 結構化日誌
+│   │   │   └── Migrations/             # 一次性遷移
+│   │   ├── SharedUI/                   # 共用 UI 元件
+│   │   └── Theme/                      # 主題、配色、視覺預設
+│   ├── TigerDuckLiveActivity/          # Live Activity / 動態島 Widget Extension
+│   ├── TigerDuckWidgets/               # iOS 主畫面 / 鎖定畫面 Widget
+│   ├── TigerDuckWatch Watch App/       # Apple Watch App（Library QR）
+│   ├── TigerDuckWatchWidget/           # Apple Watch 複雜功能 (Complication)
+│   └── Shared/                         # 跨 target 共用程式碼（感測器、Watch 通訊、Theme）
 ├── api-poc/                            # 第三方 API 驗證腳本（NTUST / Moodle / Calendar）
 │   └── api/                            # ntust_sso / course_lookup / moodle / calendar
 ├── docs/                               # 規劃文件、移轉計畫（iOS 端）

--- a/swift/TigerDuck/App/AppConstants.swift
+++ b/swift/TigerDuck/App/AppConstants.swift
@@ -127,6 +127,8 @@ nonisolated enum AppConstants {
         static let pushServerURLOverride = "pushServerURLOverride"
         static let pushLastRegistrationAt = "pushLastRegistrationAt"
         static let pushLastSyncAt = "pushLastSyncAt"
+        static let serverPushUserOptOut = "serverPushUserOptOut"
+        static let shownServerPopupIds = "shownServerPopupIds"
 
         // MARK: Bulletins
         static let bulletinReadIds = "bulletinReadIds"

--- a/swift/TigerDuck/App/AppDefaults.swift
+++ b/swift/TigerDuck/App/AppDefaults.swift
@@ -118,12 +118,13 @@ nonisolated extension Defaults.Keys {
     )
 
     // MARK: Push server
-    /// Default off: device tokens / metadata are POSTed to the push server
-    /// only after the user explicitly opts in. The previous default sent
-    /// device data on first launch with no consent surface.
+    /// Default on as of the custom-push feature: every device registers on
+    /// launch so operator-issued pushes can target it. Notification
+    /// *permission* is still requested only via onboarding; the device row
+    /// just exists either way. Users can opt out via `serverPushUserOptOut`.
     static let pushServerEnabled = Key<Bool>(
         AppConstants.UserDefaultsKeys.pushServerEnabled,
-        default: false
+        default: true
     )
     static let pushServerURLOverride = Key<String?>(
         AppConstants.UserDefaultsKeys.pushServerURLOverride
@@ -133,6 +134,20 @@ nonisolated extension Defaults.Keys {
     )
     static let pushLastSyncAt = Key<Date?>(
         AppConstants.UserDefaultsKeys.pushLastSyncAt
+    )
+    /// User-facing opt-out for operator-issued "server" pushes. Default off
+    /// (i.e. user is opted in). Backend reads the inverse as
+    /// `server_push_enabled` and the dispatcher filters on
+    /// `server_push_enabled = true`.
+    static let serverPushUserOptOut = Key<Bool>(
+        AppConstants.UserDefaultsKeys.serverPushUserOptOut,
+        default: false
+    )
+    /// FIFO-capped set of custom-push popup ids the client has already
+    /// rendered. Caps at 100 entries to dedupe replayed taps.
+    static let shownServerPopupIds = Key<[String]>(
+        AppConstants.UserDefaultsKeys.shownServerPopupIds,
+        default: []
     )
 
     // MARK: Bulletins

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -244,6 +244,14 @@ final class AppState {
     /// the value when the user dismisses.
     var pendingServerPopup: ServerPopupPayload?
 
+    /// In-flight task that re-assigns `pendingServerPopup` after the
+    /// nil-bounce used to force SwiftUI's alert to refresh. Stored here
+    /// so back-to-back popup taps can cancel a stale swap before it
+    /// wakes from its short sleep and overwrites a newer payload.
+    /// `@ObservationIgnored` because it isn't UI state.
+    @ObservationIgnored
+    var pendingServerPopupSwapTask: Task<Void, Never>?
+
     /// Has the user already been shown the popup for this notification id?
     /// Persisted via `Defaults[.shownServerPopupIds]` as a FIFO list
     /// capped at 100 entries. Read-only — call `markServerPopupShown`

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -244,23 +244,30 @@ final class AppState {
     /// the value when the user dismisses.
     var pendingServerPopup: ServerPopupPayload?
 
-    /// Records `notification_id` so a replayed tap (Notification Center
-    /// keeps cleared notifications around briefly) does not re-pop the
-    /// same modal. Persisted via `Defaults[.shownServerPopupIds]` as a
-    /// FIFO list capped at 100 entries.
-    ///
-    /// - Returns: `true` when the id is new and the caller should now
-    ///   surface the popup; `false` when it has been seen before.
-    @discardableResult
-    func markServerPopupShown(_ id: String) -> Bool {
+    /// Has the user already been shown the popup for this notification id?
+    /// Persisted via `Defaults[.shownServerPopupIds]` as a FIFO list
+    /// capped at 100 entries. Read-only — call `markServerPopupShown`
+    /// from the alert's dismiss action so an alert that was suppressed
+    /// (e.g. by a competing onboarding sheet) isn't permanently deduped.
+    @MainActor
+    func isServerPopupShown(_ id: String) -> Bool {
+        Defaults[.shownServerPopupIds].contains(id)
+    }
+
+    /// Record that the user has actually seen the popup for `id`. Only
+    /// call this from the alert dismiss path — calling it at routing
+    /// time risks marking a popup as seen when its alert never rendered
+    /// (mid-onboarding, modal collision, etc.), permanently suppressing
+    /// it on future taps.
+    @MainActor
+    func markServerPopupShown(_ id: String) {
         var seen = Defaults[.shownServerPopupIds]
-        if seen.contains(id) { return false }
+        if seen.contains(id) { return }
         seen.append(id)
         if seen.count > 100 {
             seen.removeFirst(seen.count - 100)
         }
         Defaults[.shownServerPopupIds] = seen
-        return true
     }
     #endif
 
@@ -910,10 +917,11 @@ final class AppState {
 
     /// Enable server push (registers for remote notifications, starts PTS
     /// relay, queues an immediate sync). Call only from explicit user intent
-    /// — turning on the Settings toggle.
+    /// — turning on the Settings toggle. Passes `requestPermission: true`
+    /// so the user sees an iOS prompt as feedback for their tap.
     func enablePushServer() {
         Defaults[.pushServerEnabled] = true
-        pushCoordinator.enable()
+        pushCoordinator.enable(requestPermission: true)
         requestPushScheduleSync()
     }
 
@@ -924,10 +932,11 @@ final class AppState {
     }
 
     /// Wire the settings toggle to the registration actor. The actor
-    /// persists the local pref AND PATCHes the backend so the change
-    /// propagates without waiting for the next register call.
-    func updateServerPushOptOut(_ optOut: Bool) async {
-        await pushCoordinator.registration.updateServerPushOptOut(optOut)
+    /// PATCHes the backend and only then persists the local pref so a
+    /// transient failure doesn't leave the UI claiming agreement with
+    /// the server. Throws on failure so the caller can roll back.
+    func updateServerPushOptOut(_ optOut: Bool) async throws {
+        try await pushCoordinator.registration.updateServerPushOptOut(optOut)
     }
     #endif // os(iOS) — closes the Live Activity / reminder / push block
 

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -132,9 +132,12 @@ final class AppState {
             await self?.pushCoordinator.registerLiveActivityUpdateToken(registration)
         }
 
-        // Auto-enable the push stack when the user has already opted in
-        // (e.g. across app launches). The coordinator no-ops when the
-        // toggle is off, so this is safe to call unconditionally.
+        // Auto-enable the push stack on every launch so the device row
+        // exists in the backend regardless of subscription state — that's
+        // what lets operator-issued custom pushes target the device. The
+        // coordinator is idempotent. Notification *permission* is still
+        // requested through onboarding, not here; users can opt out of
+        // server pushes via `serverPushUserOptOut`.
         pushCoordinator.enable()
         #endif
 
@@ -869,6 +872,13 @@ final class AppState {
     func disablePushServer() async {
         Defaults[.pushServerEnabled] = false
         await pushCoordinator.disable()
+    }
+
+    /// Wire the settings toggle to the registration actor. The actor
+    /// persists the local pref AND PATCHes the backend so the change
+    /// propagates without waiting for the next register call.
+    func updateServerPushOptOut(_ optOut: Bool) async {
+        await pushCoordinator.registration.updateServerPushOptOut(optOut)
     }
     #endif // os(iOS) — closes the Live Activity / reminder / push block
 

--- a/swift/TigerDuck/App/AppState.swift
+++ b/swift/TigerDuck/App/AppState.swift
@@ -213,6 +213,55 @@ final class AppState {
     // and the entire PushCoordinator stack pulls in ActivityKit symbols).
 
     let pushCoordinator = PushCoordinator()
+
+    // MARK: - Custom-push tap routing
+
+    /// In-process deep-link targets resolved from a custom-push tap. The
+    /// `NotificationDelegate` writes here; the destination view observes
+    /// and clears the value once it has acted on it.
+    enum DeepLink: Equatable {
+        case bulletin(Int)
+    }
+
+    /// Payload for an operator-issued popup push. `id` is the server-side
+    /// notification id and is also used by SwiftUI's `.alert(_:isPresented:
+    /// presenting:)` for view identity, so re-tapping the same notification
+    /// while the previous alert is still on screen does not double-present.
+    struct ServerPopupPayload: Equatable, Identifiable {
+        let id: String   // notification_id
+        let title: String
+        let body: String
+    }
+
+    /// Set by the notification delegate when the user taps a
+    /// `custom_push_bulletin` push. Bulletins UI observes this and clears
+    /// it after navigating into the detail view.
+    var pendingDeepLink: DeepLink?
+
+    /// Set by the notification delegate when the user taps a
+    /// `custom_push_popup` push and the id has not been shown before.
+    /// The root view presents an alert against this binding and clears
+    /// the value when the user dismisses.
+    var pendingServerPopup: ServerPopupPayload?
+
+    /// Records `notification_id` so a replayed tap (Notification Center
+    /// keeps cleared notifications around briefly) does not re-pop the
+    /// same modal. Persisted via `Defaults[.shownServerPopupIds]` as a
+    /// FIFO list capped at 100 entries.
+    ///
+    /// - Returns: `true` when the id is new and the caller should now
+    ///   surface the popup; `false` when it has been seen before.
+    @discardableResult
+    func markServerPopupShown(_ id: String) -> Bool {
+        var seen = Defaults[.shownServerPopupIds]
+        if seen.contains(id) { return false }
+        seen.append(id)
+        if seen.count > 100 {
+            seen.removeFirst(seen.count - 100)
+        }
+        Defaults[.shownServerPopupIds] = seen
+        return true
+    }
     #endif
 
     var isNTUSTLoggedIn: Bool { authService.isNTUSTAuthenticated }

--- a/swift/TigerDuck/App/NotificationDelegate.swift
+++ b/swift/TigerDuck/App/NotificationDelegate.swift
@@ -1,0 +1,43 @@
+import Foundation
+import UserNotifications
+import os
+
+/// Routes incoming `UNNotificationResponse`s to whatever state the rest
+/// of the app subscribes to. The wiring is split so this delegate has no
+/// dependency on AppState — `TigerDuckApp` hands it closures at launch.
+///
+/// Lifetime: `UNUserNotificationCenter` holds its delegate weakly, so
+/// `PushAppDelegate` keeps the strong reference. The delegate itself
+/// lives for the whole app process.
+final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+    /// Invoked when the user taps a notification (either from the lock
+    /// screen / banner or from Notification Center).
+    var routeTap: ((UNNotificationResponse) -> Void)?
+
+    /// Decide whether to show a banner / play a sound when a push arrives
+    /// while the app is in the foreground. Defaults to banner+sound+list.
+    var allowForegroundPresentation: ((UNNotification) -> UNNotificationPresentationOptions)?
+
+    private let logger = Logger(
+        subsystem: "org.ntust.app.TigerDuck",
+        category: "Push.Delegate"
+    )
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        let opts = allowForegroundPresentation?(notification) ?? [.banner, .sound, .list]
+        completionHandler(opts)
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        routeTap?(response)
+        completionHandler()
+    }
+}

--- a/swift/TigerDuck/App/NotificationDelegate.swift
+++ b/swift/TigerDuck/App/NotificationDelegate.swift
@@ -11,12 +11,28 @@ import os
 /// lives for the whole app process.
 final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
     /// Invoked when the user taps a notification (either from the lock
-    /// screen / banner or from Notification Center).
-    var routeTap: ((UNNotificationResponse) -> Void)?
+    /// screen / banner or from Notification Center). Assignment drains
+    /// any responses buffered while the closure was still nil — covers
+    /// the cold-launch case where iOS delivers `didReceive` before
+    /// SwiftUI's `.onAppear` runs to wire this closure.
+    var routeTap: ((UNNotificationResponse) -> Void)? {
+        didSet {
+            guard routeTap != nil, !pendingResponses.isEmpty else { return }
+            let drained = pendingResponses
+            pendingResponses.removeAll()
+            for r in drained { routeTap?(r) }
+        }
+    }
 
     /// Decide whether to show a banner / play a sound when a push arrives
     /// while the app is in the foreground. Defaults to banner+sound+list.
     var allowForegroundPresentation: ((UNNotification) -> UNNotificationPresentationOptions)?
+
+    /// Buffer for responses delivered before `routeTap` is wired. UN
+    /// dispatches its delegate callbacks on main and SwiftUI bodies/
+    /// onAppear also run on main, so this array is only ever touched
+    /// from the main thread — no extra synchronization needed.
+    private var pendingResponses: [UNNotificationResponse] = []
 
     private let logger = Logger(
         subsystem: "org.ntust.app.TigerDuck",
@@ -37,7 +53,14 @@ final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
-        routeTap?(response)
+        if let routeTap {
+            routeTap(response)
+        } else {
+            // Cold-launch path: SwiftUI hasn't run onAppear yet, so the
+            // routing closure isn't installed. Hold the response until
+            // it is, then drain via `routeTap.didSet`.
+            pendingResponses.append(response)
+        }
         completionHandler()
     }
 }

--- a/swift/TigerDuck/App/PushAppDelegate.swift
+++ b/swift/TigerDuck/App/PushAppDelegate.swift
@@ -1,4 +1,5 @@
 import UIKit
+import UserNotifications
 import os
 
 /// UIKit hook that captures the standard APNs device token.
@@ -23,7 +24,28 @@ final class PushAppDelegate: NSObject, UIApplicationDelegate {
     /// Same app-lifetime contract as ``forwardToken``.
     var forwardError: ((Error) -> Void)?
 
+    /// Owns the `UNUserNotificationCenterDelegate` for the lifetime of the
+    /// app. `UNUserNotificationCenter` retains the delegate weakly, so this
+    /// strong reference is what keeps it alive — without it the singleton
+    /// would silently drop taps the moment ARC reclaimed the local variable
+    /// set in `didFinishLaunchingWithOptions`.
+    var notificationDelegate: NotificationDelegate?
+
     private let logger = Logger(subsystem: "org.ntust.app.TigerDuck", category: "Push.Delegate")
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        // Install the notification delegate BEFORE any push can arrive so
+        // a cold-launch tap (where iOS launches the app from a tapped
+        // notification) is routed through `routeTap` instead of falling
+        // back to the OS default open behaviour.
+        let nd = NotificationDelegate()
+        UNUserNotificationCenter.current().delegate = nd
+        self.notificationDelegate = nd
+        return true
+    }
 
     func application(
         _ application: UIApplication,

--- a/swift/TigerDuck/App/PushAppDelegate.swift
+++ b/swift/TigerDuck/App/PushAppDelegate.swift
@@ -19,10 +19,33 @@ final class PushAppDelegate: NSObject, UIApplicationDelegate {
     /// no shorter lifetime to escape from, and a `[weak]` capture here would
     /// silently drop the token if scene-phase plumbing ever ran the closure
     /// before the strong reference had been established.
-    var forwardToken: ((Data) -> Void)?
+    ///
+    /// `AppState.init` triggers `registerForRemoteNotifications()` before
+    /// SwiftUI runs `.onAppear` — the appearance hook is what wires the
+    /// forwarders, so APNs can race ahead and deliver the token while the
+    /// closure is still nil. Any token/error that arrives in that gap is
+    /// stashed in `bufferedToken`/`bufferedError` and replayed by the
+    /// `didSet`s below when the closures are finally installed, so a
+    /// launch token never gets dropped on the floor.
+    var forwardToken: ((Data) -> Void)? {
+        didSet {
+            guard let forward = forwardToken, let token = bufferedToken else { return }
+            bufferedToken = nil
+            forward(token)
+        }
+    }
     /// Called when APNs registration fails (e.g. no entitlement, no network).
     /// Same app-lifetime contract as ``forwardToken``.
-    var forwardError: ((Error) -> Void)?
+    var forwardError: ((Error) -> Void)? {
+        didSet {
+            guard let forward = forwardError, let error = bufferedError else { return }
+            bufferedError = nil
+            forward(error)
+        }
+    }
+
+    private var bufferedToken: Data?
+    private var bufferedError: Error?
 
     /// Owns the `UNUserNotificationCenterDelegate` for the lifetime of the
     /// app. `UNUserNotificationCenter` retains the delegate weakly, so this
@@ -52,7 +75,13 @@ final class PushAppDelegate: NSObject, UIApplicationDelegate {
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
         logger.info("APNs registered (len=\(deviceToken.count, privacy: .public))")
-        forwardToken?(deviceToken)
+        if let forward = forwardToken {
+            forward(deviceToken)
+        } else {
+            // `.onAppear` hasn't wired the forwarder yet — hold the token
+            // until it does so the launch registration isn't lost.
+            bufferedToken = deviceToken
+        }
     }
 
     func application(
@@ -60,6 +89,10 @@ final class PushAppDelegate: NSObject, UIApplicationDelegate {
         didFailToRegisterForRemoteNotificationsWithError error: Error
     ) {
         logger.error("APNs registration failed: \(error.localizedDescription, privacy: .public)")
-        forwardError?(error)
+        if let forward = forwardError {
+            forward(error)
+        } else {
+            bufferedError = error
+        }
     }
 }

--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -121,6 +121,15 @@ struct MainTabView: View {
         .onChange(of: appState.pendingWidgetDestination) { _, _ in
             drainPendingWidgetDestination()
         }
+        #if os(iOS)
+        // Tap on a custom_push_bulletin notification arrives as a
+        // pendingDeepLink before BulletinsView is mounted. Switch to the
+        // announcements tab (or route via More if it isn't pinned) so the
+        // view drains the deep link and pushes the detail screen.
+        .onChange(of: appState.pendingDeepLink, initial: true) { _, new in
+            routeBulletinDeepLinkIfNeeded(new)
+        }
+        #endif
         .onChange(of: scenePhase) { _, newPhase in
             // Multitask-switch path: every time the app re-enters the
             // foreground, re-evaluate. The observer keeps `isNonTaipei`
@@ -153,6 +162,22 @@ struct MainTabView: View {
             showTimezoneAlert = true
         }
     }
+
+    #if os(iOS)
+    /// Switches to the announcements tab when a bulletin deep link is set
+    /// so `BulletinsView` mounts and its own onChange handler can navigate
+    /// to the detail view. The deep link itself is left in place — the
+    /// downstream view clears it after acting.
+    private func routeBulletinDeepLinkIfNeeded(_ link: AppState.DeepLink?) {
+        guard case .bulletin = link else { return }
+        if visibleTabs.contains(.announcements) {
+            selectedTab = .announcements
+        } else {
+            selectedTab = .more
+            appState.pendingMoreDeepLink = .announcements
+        }
+    }
+    #endif
 
     private func drainPendingWidgetDestination() {
         guard let destination = appState.pendingWidgetDestination else { return }

--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -12,8 +12,47 @@ struct ContentView: View {
             }
         }
         .ntustLoginSheetHost()
+        #if os(iOS)
+        .serverPushPopupHost()
+        #endif
     }
 }
+
+#if os(iOS)
+/// Hosts the modal alert that surfaces an operator-issued
+/// `custom_push_popup` tap. Pulled into its own modifier so the binding
+/// dance (Optional<ServerPopupPayload> → Bool) stays local and the
+/// root view's `body` doesn't grow another inline `.alert`.
+private struct ServerPushPopupHost: ViewModifier {
+    @Environment(AppState.self) private var appState
+
+    func body(content: Content) -> some View {
+        @Bindable var bindable = appState
+        content
+            .alert(
+                bindable.pendingServerPopup?.title ?? "",
+                isPresented: Binding(
+                    get: { bindable.pendingServerPopup != nil },
+                    set: { newValue in
+                        if !newValue { bindable.pendingServerPopup = nil }
+                    }
+                ),
+                presenting: bindable.pendingServerPopup
+            ) { _ in
+                // System-localized "OK" / "確定" comes from the cancel role.
+                Button(String(localized: "action_got_it"), role: .cancel) {}
+            } message: { popup in
+                Text(popup.body)
+            }
+    }
+}
+
+private extension View {
+    func serverPushPopupHost() -> some View {
+        modifier(ServerPushPopupHost())
+    }
+}
+#endif
 
 struct MainTabView: View {
     @Environment(AppState.self) private var appState

--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -38,9 +38,15 @@ private struct ServerPushPopupHost: ViewModifier {
                     }
                 ),
                 presenting: bindable.pendingServerPopup
-            ) { _ in
+            ) { popup in
                 // System-localized "OK" / "確定" comes from the cancel role.
-                Button(String(localized: "action_got_it"), role: .cancel) {}
+                // Marking happens here (not at routing time) so a popup
+                // that was actually presented gets added to the FIFO
+                // dedupe — but one that was suppressed by a competing
+                // modal stays "unseen" and can re-present on next tap.
+                Button(String(localized: "action_got_it"), role: .cancel) {
+                    appState.markServerPopupShown(popup.id)
+                }
             } message: { popup in
                 Text(popup.body)
             }

--- a/swift/TigerDuck/Features/Bulletins/BulletinTaxonomyStore.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinTaxonomyStore.swift
@@ -78,6 +78,13 @@ final class BulletinTaxonomyStore {
     }
 
     func tagLabel(for rawId: String) -> String {
+        // Operator-issued "server" notifications need a per-locale label
+        // (unlike every other tag, which the server ships zh-only).
+        // Intercept that one id and return the localized string instead
+        // of whatever the server sent.
+        if rawId == "server_notification" {
+            return String(localized: "tag_server_notification")
+        }
         guard case .loaded(let tax) = state else { return rawId }
         return tax.tags.first(where: { $0.rawId == rawId })?.label ?? rawId
     }

--- a/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
@@ -73,11 +73,30 @@ struct BulletinsView: View {
             if newPhase == .background {
                 lastBackgroundedAt = Date()
             }
+            #if os(iOS)
+            // Foregrounding is the natural retry point for a deep link that
+            // a previous tap couldn't resolve (poor signal at tap time, app
+            // suspended mid-fetch). The `pendingDeepLink` value itself
+            // hasn't changed, so the `onChange` observer below wouldn't
+            // re-fire on its own — kick the drain here.
+            if newPhase == .active {
+                drainPendingBulletinDeepLink()
+            }
+            #endif
         }
         #if os(iOS)
         .onAppear { drainPendingBulletinDeepLink() }
         .onChange(of: appState.pendingDeepLink) { _, _ in
             drainPendingBulletinDeepLink()
+        }
+        // A successful list refresh indicates network is back AND may have
+        // pulled the target bulletin into `items`, so this is a cheap
+        // retry point for a deep link that was preserved through an
+        // earlier transient failure.
+        .onChange(of: viewModel.loadState) { _, newState in
+            if case .loaded = newState {
+                drainPendingBulletinDeepLink()
+            }
         }
         #endif
     }

--- a/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
@@ -69,7 +69,31 @@ struct BulletinsView: View {
                 lastBackgroundedAt = Date()
             }
         }
+        #if os(iOS)
+        .onAppear { drainPendingBulletinDeepLink() }
+        .onChange(of: appState.pendingDeepLink) { _, _ in
+            drainPendingBulletinDeepLink()
+        }
+        #endif
     }
+
+    #if os(iOS)
+    /// Resolve a tap-routed deep link into a navigation push. Done in two
+    /// hops because we have to materialise a `BulletinSummary` to feed
+    /// `.navigationDestination(item:)` before we can show the detail
+    /// view — `summary(forId:)` first checks the live list, then disk
+    /// cache, then falls back to the detail endpoint.
+    private func drainPendingBulletinDeepLink() {
+        guard case .bulletin(let id) = appState.pendingDeepLink else { return }
+        // Clear the deep link eagerly so a slow network fetch can't be
+        // re-triggered by a SwiftUI re-render before it resolves.
+        appState.pendingDeepLink = nil
+        Task {
+            guard let summary = await viewModel.summary(forId: id) else { return }
+            detailingBulletin = summary
+        }
+    }
+    #endif
 
     private var hasUnreadBulletins: Bool {
         viewModel.items.contains { !readState.isRead($0.id) }

--- a/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
@@ -28,6 +28,11 @@ struct BulletinsView: View {
     /// can evaporate, the fallback `.onAppear { id = nil }` fires, and
     /// the navigation stack oscillates.
     @State private var detailingBulletin: BulletinAPI.BulletinSummary?
+    /// Deep-link ids currently being resolved. Prevents SwiftUI re-renders
+    /// from re-triggering the same fetch while it's in flight and lets us
+    /// leave `pendingDeepLink` set until the fetch resolves (so a slow
+    /// network doesn't lose the tap by clearing it eagerly).
+    @State private var inflightDeepLinkIds: Set<Int> = []
     @State private var unreadOnly: Bool = false
     /// Drives `.searchable`'s expansion — bound so we can force-collapse
     /// it when the app returns to foreground (users expect the search
@@ -85,10 +90,26 @@ struct BulletinsView: View {
     /// cache, then falls back to the detail endpoint.
     private func drainPendingBulletinDeepLink() {
         guard case .bulletin(let id) = appState.pendingDeepLink else { return }
-        // Clear the deep link eagerly so a slow network fetch can't be
-        // re-triggered by a SwiftUI re-render before it resolves.
-        appState.pendingDeepLink = nil
+        // Use an inflight guard instead of clearing the deep link eagerly:
+        //   * Prevents a SwiftUI re-render (e.g. a sibling onChange firing
+        //     for an unrelated state change) from re-entering this drain
+        //     for the same id while the fetch is still resolving.
+        //   * Leaves `pendingDeepLink` set during the network hop so a
+        //     transient failure / cold start doesn't permanently lose the
+        //     tap before any user-visible navigation happens.
+        guard !inflightDeepLinkIds.contains(id) else { return }
+        inflightDeepLinkIds.insert(id)
         Task {
+            defer {
+                inflightDeepLinkIds.remove(id)
+                // Clear only the slot we owned — a fresh tap that landed
+                // after we started (different id, or replay after our
+                // remove) is preserved for the next drain.
+                if case .bulletin(let pendingId) = appState.pendingDeepLink,
+                   pendingId == id {
+                    appState.pendingDeepLink = nil
+                }
+            }
             guard let summary = await viewModel.summary(forId: id) else { return }
             detailingBulletin = summary
         }

--- a/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
@@ -100,18 +100,27 @@ struct BulletinsView: View {
         guard !inflightDeepLinkIds.contains(id) else { return }
         inflightDeepLinkIds.insert(id)
         Task {
-            defer {
-                inflightDeepLinkIds.remove(id)
-                // Clear only the slot we owned — a fresh tap that landed
-                // after we started (different id, or replay after our
-                // remove) is preserved for the next drain.
-                if case .bulletin(let pendingId) = appState.pendingDeepLink,
-                   pendingId == id {
-                    appState.pendingDeepLink = nil
-                }
+            defer { inflightDeepLinkIds.remove(id) }
+            let summary: BulletinAPI.BulletinSummary?
+            do {
+                summary = try await viewModel.summary(forId: id)
+            } catch {
+                // Transient failure (network drop, timeout, etc.) — leave
+                // `pendingDeepLink` set so a later drain (foreground return,
+                // list refresh) can re-attempt navigation. Without this the
+                // tap is lost on the first poor-connectivity attempt.
+                return
             }
-            guard let summary = await viewModel.summary(forId: id) else { return }
-            detailingBulletin = summary
+            // Terminal outcome — either we have a summary or the bulletin
+            // is tombstoned and will never become navigable. Either way,
+            // clear the deep link so we don't keep redriving the drain.
+            if case .bulletin(let pendingId) = appState.pendingDeepLink,
+               pendingId == id {
+                appState.pendingDeepLink = nil
+            }
+            if let summary {
+                detailingBulletin = summary
+            }
         }
     }
     #endif

--- a/swift/TigerDuck/Features/Bulletins/BulletinsViewModel.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinsViewModel.swift
@@ -91,48 +91,61 @@ final class BulletinsViewModel {
     /// a last resort fetches the detail endpoint and synthesises a summary
     /// shaped row from it — that mirror lets `BulletinDetailView` re-fetch
     /// the same detail and render normally without an extra contract.
-    func summary(forId id: Int) async -> BulletinAPI.BulletinSummary? {
+    ///
+    /// Returns `nil` for a *terminal* miss (the bulletin is tombstoned and
+    /// will never be navigable). Throws for a *transient* miss (network /
+    /// decode failure) so the caller can preserve the deep link and retry
+    /// when conditions improve, instead of dropping the tap.
+    func summary(forId id: Int) async throws -> BulletinAPI.BulletinSummary? {
         if let existing = items.first(where: { $0.id == id }) {
             return existing
         }
         let cached = DataCache.shared.loadBulletinSummaries()
         if let hit = cached.first(where: { $0.id == id }) {
-            return hit
-        }
-        do {
-            let detail = try await apiClient.getBulletin(id: id)
-            // Don't surface or merge a tombstoned bulletin — the /list
-            // endpoint filters these out, and merging here would inject
-            // a ghost row at the top of the feed AND persist it to disk
-            // cache where it would survive until the next page load
-            // overwrote it.
-            guard !detail.isDeleted else {
-                logger.info("summary(forId:) skipped deleted bulletin id=\(id, privacy: .public)")
+            // Cache can hold a pre-tombstone row written before the server
+            // marked the bulletin deleted; honour the flag here so the tap
+            // doesn't land on a ghost detail page.
+            guard !hit.isDeleted else {
+                logger.info("summary(forId:) skipped cached deleted bulletin id=\(id, privacy: .public)")
                 return nil
             }
-            let synthesised = BulletinAPI.BulletinSummary(
-                id: detail.id,
-                externalId: detail.externalId,
-                title: detail.title,
-                titleClean: detail.titleClean,
-                canonicalOrg: detail.canonicalOrg,
-                contentTags: detail.contentTags,
-                importance: detail.importance,
-                summary: detail.summary,
-                sourceUrl: detail.sourceUrl,
-                postedAt: detail.postedAt,
-                isDeleted: detail.isDeleted
-            )
-            // Merge into the live list so a subsequent return to the list
-            // shows the row without another network round trip.
-            items = Self.merge(existing: items, incoming: [synthesised])
-            refilter()
-            persistSummaries()
-            return synthesised
+            return hit
+        }
+        let detail: BulletinAPI.BulletinDetail
+        do {
+            detail = try await apiClient.getBulletin(id: id)
         } catch {
             logger.error("summary(forId:) fetch failed id=\(id, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+        // Don't surface or merge a tombstoned bulletin — the /list
+        // endpoint filters these out, and merging here would inject
+        // a ghost row at the top of the feed AND persist it to disk
+        // cache where it would survive until the next page load
+        // overwrote it.
+        guard !detail.isDeleted else {
+            logger.info("summary(forId:) skipped deleted bulletin id=\(id, privacy: .public)")
             return nil
         }
+        let synthesised = BulletinAPI.BulletinSummary(
+            id: detail.id,
+            externalId: detail.externalId,
+            title: detail.title,
+            titleClean: detail.titleClean,
+            canonicalOrg: detail.canonicalOrg,
+            contentTags: detail.contentTags,
+            importance: detail.importance,
+            summary: detail.summary,
+            sourceUrl: detail.sourceUrl,
+            postedAt: detail.postedAt,
+            isDeleted: detail.isDeleted
+        )
+        // Merge into the live list so a subsequent return to the list
+        // shows the row without another network round trip.
+        items = Self.merge(existing: items, incoming: [synthesised])
+        refilter()
+        persistSummaries()
+        return synthesised
     }
 
     /// Request the next page. Safe to call on every scroll — guarded by

--- a/swift/TigerDuck/Features/Bulletins/BulletinsViewModel.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinsViewModel.swift
@@ -101,6 +101,15 @@ final class BulletinsViewModel {
         }
         do {
             let detail = try await apiClient.getBulletin(id: id)
+            // Don't surface or merge a tombstoned bulletin — the /list
+            // endpoint filters these out, and merging here would inject
+            // a ghost row at the top of the feed AND persist it to disk
+            // cache where it would survive until the next page load
+            // overwrote it.
+            guard !detail.isDeleted else {
+                logger.info("summary(forId:) skipped deleted bulletin id=\(id, privacy: .public)")
+                return nil
+            }
             let synthesised = BulletinAPI.BulletinSummary(
                 id: detail.id,
                 externalId: detail.externalId,

--- a/swift/TigerDuck/Features/Bulletins/BulletinsViewModel.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinsViewModel.swift
@@ -98,6 +98,14 @@ final class BulletinsViewModel {
     /// when conditions improve, instead of dropping the tap.
     func summary(forId id: Int) async throws -> BulletinAPI.BulletinSummary? {
         if let existing = items.first(where: { $0.id == id }) {
+            // `items` is seeded from the on-disk cache at init, so a row
+            // that has since been tombstoned on the server can already
+            // be in memory when the push tap arrives. Honour the flag
+            // here too, mirroring the cache and detail-fetch guards.
+            guard !existing.isDeleted else {
+                logger.info("summary(forId:) skipped in-memory deleted bulletin id=\(id, privacy: .public)")
+                return nil
+            }
             return existing
         }
         let cached = DataCache.shared.loadBulletinSummaries()

--- a/swift/TigerDuck/Features/Bulletins/BulletinsViewModel.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinsViewModel.swift
@@ -85,6 +85,47 @@ final class BulletinsViewModel {
         await inflight?.value
     }
 
+    /// Resolve a bulletin id (typically from a push-tap deep link) into a
+    /// `BulletinSummary` the view can hand to its `.navigationDestination`.
+    /// Prefers the in-memory list, then the on-disk summary cache, and as
+    /// a last resort fetches the detail endpoint and synthesises a summary
+    /// shaped row from it — that mirror lets `BulletinDetailView` re-fetch
+    /// the same detail and render normally without an extra contract.
+    func summary(forId id: Int) async -> BulletinAPI.BulletinSummary? {
+        if let existing = items.first(where: { $0.id == id }) {
+            return existing
+        }
+        let cached = DataCache.shared.loadBulletinSummaries()
+        if let hit = cached.first(where: { $0.id == id }) {
+            return hit
+        }
+        do {
+            let detail = try await apiClient.getBulletin(id: id)
+            let synthesised = BulletinAPI.BulletinSummary(
+                id: detail.id,
+                externalId: detail.externalId,
+                title: detail.title,
+                titleClean: detail.titleClean,
+                canonicalOrg: detail.canonicalOrg,
+                contentTags: detail.contentTags,
+                importance: detail.importance,
+                summary: detail.summary,
+                sourceUrl: detail.sourceUrl,
+                postedAt: detail.postedAt,
+                isDeleted: detail.isDeleted
+            )
+            // Merge into the live list so a subsequent return to the list
+            // shows the row without another network round trip.
+            items = Self.merge(existing: items, incoming: [synthesised])
+            refilter()
+            persistSummaries()
+            return synthesised
+        } catch {
+            logger.error("summary(forId:) fetch failed id=\(id, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
     /// Request the next page. Safe to call on every scroll — guarded by
     /// `isPaginating` and `hasMore`.
     func loadMoreIfNeeded(triggeredBy item: BulletinAPI.BulletinSummary) async {

--- a/swift/TigerDuck/Features/More/MoreView.swift
+++ b/swift/TigerDuck/Features/More/MoreView.swift
@@ -79,12 +79,21 @@ struct MoreView: View {
         // Consume deep-links from callers that can't reach this view's
         // local navigationPath directly (e.g. the flip-to-Library
         // coordinator routing here when Library is enabled but not pinned
-        // as a top-level tab). `initial: true` covers cold-launch /
-        // tab-switch ordering where the flag is already set by the time
-        // the body re-renders.
+        // as a top-level tab, or a custom-push tap routing into
+        // Announcements). `initial: true` covers cold-launch / tab-switch
+        // ordering where the flag is already set by the time the body
+        // re-renders.
+        //
+        // We REPLACE the navigation path instead of appending: cross-
+        // context deep links mean "go to X", not "push X on top of
+        // whatever the user was already viewing in More". Appending was
+        // surfacing the target view stacked underneath an unrelated
+        // earlier destination, leaving the user with an extra back-tap.
         .onChange(of: appState.pendingMoreDeepLink, initial: true) { _, new in
             guard let new else { return }
-            navigationPath.append(new)
+            var path = NavigationPath()
+            path.append(new)
+            navigationPath = path
             appState.pendingMoreDeepLink = nil
         }
     }

--- a/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/OtherSettingsView.swift
@@ -107,6 +107,16 @@ struct OtherSettingsView: View {
                     Text(String(localized: "settings_privacy_policy"))
                         .foregroundStyle(.primary)
                 }
+                Button {
+                    if appState.browserPreference == .inApp {
+                        showDeleteAccount = true
+                    } else {
+                        openURL(Self.deleteAccountURL)
+                    }
+                } label: {
+                    Text(String(localized: "settings_delete_account"))
+                        .foregroundStyle(.primary)
+                }
                 Button(String(localized: "settings_open_source_licenses")) {
                     if appState.browserPreference == .inApp {
                         showLicense = true
@@ -117,16 +127,6 @@ struct OtherSettingsView: View {
                 .foregroundStyle(.primary)
                 NavigationLink(String(localized: "settings_view_source_code")) {
                     SourceCodePickerView()
-                }
-                Button {
-                    if appState.browserPreference == .inApp {
-                        showDeleteAccount = true
-                    } else {
-                        openURL(Self.deleteAccountURL)
-                    }
-                } label: {
-                    Text(String(localized: "settings_delete_account"))
-                        .foregroundStyle(.primary)
                 }
             }
         }

--- a/swift/TigerDuck/Features/Settings/Components/PushServerSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/PushServerSettingsView.swift
@@ -25,6 +25,11 @@ struct PushServerSettingsView: View {
     /// rolled back. The Toggle binds against this so a failed PATCH
     /// can revert the visual state in lock-step with the stored Default.
     @State private var serverPushOptOutFailed: Bool = false
+    /// In-flight server-push opt-out PATCH. Held so a rapid second tap
+    /// can cancel the prior request before starting a new one — without
+    /// this, two independent tasks race and the slower one can overwrite
+    /// the latest user choice.
+    @State private var serverPushOptOutTask: Task<Void, Never>?
     #if os(iOS)
     // Per-row copy state. `nil` = idle (no recent action). Last tap wins
     // the shared footer so the user gets immediate feedback without us
@@ -224,11 +229,24 @@ struct PushServerSettingsView: View {
         Binding(
             get: { !serverPushOptOut },
             set: { isOn in
-                Task {
+                // Cancel any prior PATCH so only the latest tap can
+                // finish writing the stored opt-out. Two independent
+                // tasks would otherwise race: if the user flips off
+                // then quickly back on, the slower first request could
+                // finish last and overwrite the second one's value.
+                serverPushOptOutTask?.cancel()
+                serverPushOptOutTask = Task {
                     do {
                         try await appState.updateServerPushOptOut(!isOn)
+                        // Superseded mid-flight — let the newer task own
+                        // the UI state. (URLSession surfaces cancellation
+                        // as `URLError(.cancelled)` rather than
+                        // `CancellationError`, so we gate on
+                        // `Task.isCancelled` rather than the error type.)
+                        guard !Task.isCancelled else { return }
                         serverPushOptOutFailed = false
                     } catch {
+                        guard !Task.isCancelled else { return }
                         // Server didn't accept the change — flag for the
                         // shared footer. The @Default never flipped (the
                         // actor only writes on success) so the Toggle

--- a/swift/TigerDuck/Features/Settings/Components/PushServerSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/PushServerSettingsView.swift
@@ -21,10 +21,14 @@ struct PushServerSettingsView: View {
     @State private var snapshot: PushDiagnostic?
     @State private var refreshTimer: Timer?
     @State private var disableTask: Task<Void, Never>?
-    #if os(iOS) && DEBUG
-    @State private var deviceIdCopyState: DeviceIdCopyState = .idle
+    #if os(iOS)
+    // Per-row copy state. `nil` = idle (no recent action). Last tap wins
+    // the shared footer so the user gets immediate feedback without us
+    // having to render two footer messages side by side.
+    @State private var copyStatus: [IdKind: CopyResult] = [:]
 
-    private enum DeviceIdCopyState { case idle, copied, blocked }
+    private enum IdKind: Hashable { case user, device }
+    private enum CopyResult { case copied, blocked }
     #endif
 
     var body: some View {
@@ -77,37 +81,15 @@ struct PushServerSettingsView: View {
                     Button(String(localized: "push_server_sync_now_action")) { appState.requestPushScheduleSync() }
                 }
 
-                #if os(iOS) && DEBUG
+                #if os(iOS)
                 Section {
-                    Button {
-                        let pb = UIPasteboard.general
-                        pb.string = s.deviceId
-                        // MDM-managed devices can block pasteboard writes
-                        // silently (`UIPasteboard.string =` is non-throwing),
-                        // so confirm via read-back rather than assuming
-                        // success. Compare to s.deviceId (not just
-                        // hasStrings) so we don't falsely confirm when an
-                        // unrelated string was already on the pasteboard.
-                        deviceIdCopyState = (pb.string == s.deviceId) ? .copied : .blocked
-                        Task {
-                            try? await Task.sleep(for: .seconds(1.5))
-                            deviceIdCopyState = .idle
-                        }
-                    } label: {
-                        LabeledContent("Device ID") {
-                            Text(s.deviceId)
-                                .font(.system(.caption, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                        }
-                    }
-                    .buttonStyle(.plain)
+                    idRow(kind: .user, label: "User ID", value: s.userId)
+                    idRow(kind: .device, label: "Device ID", value: s.deviceId)
                 } header: {
-                    Text("Developer")
+                    Text("IDs")
                 } footer: {
-                    Text(deviceIdCopyFooter)
-                        .foregroundStyle(deviceIdCopyFooterColor)
+                    Text(copyFooter)
+                        .foregroundStyle(copyFooterColor)
                 }
                 #endif
             }
@@ -127,21 +109,67 @@ struct PushServerSettingsView: View {
         }
     }
 
-    #if os(iOS) && DEBUG
-    private var deviceIdCopyFooter: String {
-        switch deviceIdCopyState {
-        case .idle: return "Tap to copy. Use this in the backend portal's test page to target this device."
-        case .copied: return "Copied."
-        case .blocked: return "Copy blocked — pasteboard access is restricted on this device (likely an MDM profile)."
+    #if os(iOS)
+    @ViewBuilder
+    private func idRow(kind: IdKind, label: String, value: String) -> some View {
+        Button {
+            copyToPasteboard(kind: kind, value: value)
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text(label)
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    Image(systemName: copyStatus[kind] == .copied ? "checkmark" : "doc.on.doc")
+                        .foregroundStyle(copyStatus[kind] == .copied ? .green : .secondary)
+                        .font(.caption)
+                }
+                // No lineLimit / truncation — IDs are short today (UUIDs)
+                // but tokens we might surface here later can be 150+ chars,
+                // and the user explicitly asked for the full value to be
+                // visible. `fixedSize(vertical:)` keeps the row from being
+                // clipped to a single line by the surrounding Form metrics.
+                Text(value)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func copyToPasteboard(kind: IdKind, value: String) {
+        let pb = UIPasteboard.general
+        pb.string = value
+        // MDM-managed devices can block pasteboard writes silently
+        // (`UIPasteboard.string =` is non-throwing), so confirm via
+        // read-back rather than assuming success. Compare to the value
+        // we just wrote (not just hasStrings) so we don't falsely
+        // confirm when an unrelated string was already on the board.
+        copyStatus[kind] = (pb.string == value) ? .copied : .blocked
+        Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            copyStatus[kind] = nil
         }
     }
 
-    private var deviceIdCopyFooterColor: Color {
-        switch deviceIdCopyState {
-        case .idle: return .secondary
-        case .copied: return .green
-        case .blocked: return .orange
+    private var copyFooter: String {
+        if copyStatus.values.contains(.blocked) {
+            return "Copy blocked — pasteboard access is restricted on this device (likely an MDM profile)."
         }
+        if copyStatus.values.contains(.copied) {
+            return "Copied."
+        }
+        return "Tap an ID to copy. Share with support or use in the backend portal to identify this device."
+    }
+
+    private var copyFooterColor: Color {
+        if copyStatus.values.contains(.blocked) { return .orange }
+        if copyStatus.values.contains(.copied) { return .green }
+        return .secondary
     }
     #endif
 

--- a/swift/TigerDuck/Features/Settings/Components/PushServerSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/PushServerSettingsView.swift
@@ -21,11 +21,18 @@ struct PushServerSettingsView: View {
     @State private var snapshot: PushDiagnostic?
     @State private var refreshTimer: Timer?
     @State private var disableTask: Task<Void, Never>?
+    /// Tracks whether the server-push opt-out PATCH is in flight or
+    /// rolled back. The Toggle binds against this so a failed PATCH
+    /// can revert the visual state in lock-step with the stored Default.
+    @State private var serverPushOptOutFailed: Bool = false
     #if os(iOS)
     // Per-row copy state. `nil` = idle (no recent action). Last tap wins
     // the shared footer so the user gets immediate feedback without us
     // having to render two footer messages side by side.
     @State private var copyStatus: [IdKind: CopyResult] = [:]
+    /// Reset Tasks keyed per row so rapid double-taps cancel the prior
+    /// timer instead of letting it wake mid-feedback for the second tap.
+    @State private var copyResetTasks: [IdKind: Task<Void, Never>] = [:]
 
     private enum IdKind: Hashable { case user, device }
     private enum CopyResult { case copied, blocked }
@@ -42,7 +49,18 @@ struct PushServerSettingsView: View {
             Section {
                 Toggle(String(localized: "settings_server_push_label"), isOn: serverPushBinding)
             } footer: {
-                Text(String(localized: "settings_server_push_footer"))
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(String(localized: "settings_server_push_footer"))
+                    if serverPushOptOutFailed {
+                        // Surfaces the rollback so the user knows the
+                        // tap didn't take. The Toggle has already
+                        // snapped back to the server-agreeing value
+                        // because the actor only writes Defaults on
+                        // success.
+                        Text("Server didn't accept the change — try again later.")
+                            .foregroundStyle(.orange)
+                    }
+                }
             }
 
             if pushServerEnabled, let s = snapshot {
@@ -154,9 +172,14 @@ struct PushServerSettingsView: View {
         // we just wrote (not just hasStrings) so we don't falsely
         // confirm when an unrelated string was already on the board.
         copyStatus[kind] = (pb.string == value) ? .copied : .blocked
-        Task {
+        // Cancel any earlier reset so its 1.5s timer can't fire during
+        // a freshly-confirmed copy on the same row.
+        copyResetTasks[kind]?.cancel()
+        copyResetTasks[kind] = Task {
             try? await Task.sleep(for: .seconds(1.5))
+            if Task.isCancelled { return }
             copyStatus[kind] = nil
+            copyResetTasks[kind] = nil
         }
     }
 
@@ -164,7 +187,7 @@ struct PushServerSettingsView: View {
         if copyStatus.values.contains(.blocked) {
             return (
                 "Copy blocked — pasteboard access is restricted on this device (likely an MDM profile).",
-                .orange,
+                .orange
             )
         }
         if copyStatus.values.contains(.copied) {
@@ -192,11 +215,27 @@ struct PushServerSettingsView: View {
     /// User-facing opt-out for operator-issued "server" pushes. Bound as
     /// `isOn` (i.e. ON = user wants to receive them); we invert into
     /// `serverPushUserOptOut` for storage.
+    ///
+    /// The setter awaits the actor, which PATCHes first and only writes
+    /// the local Default on success. A throw rolls back any optimistic
+    /// `@Default` write the system might surface and trips
+    /// `serverPushOptOutFailed` so the footer surfaces the failure.
     private var serverPushBinding: Binding<Bool> {
         Binding(
             get: { !serverPushOptOut },
             set: { isOn in
-                Task { await appState.updateServerPushOptOut(!isOn) }
+                Task {
+                    do {
+                        try await appState.updateServerPushOptOut(!isOn)
+                        serverPushOptOutFailed = false
+                    } catch {
+                        // Server didn't accept the change — flag for the
+                        // shared footer. The @Default never flipped (the
+                        // actor only writes on success) so the Toggle
+                        // reflects the prior, server-agreeing value.
+                        serverPushOptOutFailed = true
+                    }
+                }
             }
         )
     }

--- a/swift/TigerDuck/Features/Settings/Components/PushServerSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/PushServerSettingsView.swift
@@ -88,8 +88,12 @@ struct PushServerSettingsView: View {
                 } header: {
                     Text("IDs")
                 } footer: {
-                    Text(copyFooter)
-                        .foregroundStyle(copyFooterColor)
+                    // Only render the footer when there's actual feedback
+                    // to show — the idle hint was noise once the icon in
+                    // the row already telegraphs tap-to-copy.
+                    if let footer = copyFooter {
+                        Text(footer.text).foregroundStyle(footer.color)
+                    }
                 }
                 #endif
             }
@@ -156,20 +160,17 @@ struct PushServerSettingsView: View {
         }
     }
 
-    private var copyFooter: String {
+    private var copyFooter: (text: String, color: Color)? {
         if copyStatus.values.contains(.blocked) {
-            return "Copy blocked — pasteboard access is restricted on this device (likely an MDM profile)."
+            return (
+                "Copy blocked — pasteboard access is restricted on this device (likely an MDM profile).",
+                .orange,
+            )
         }
         if copyStatus.values.contains(.copied) {
-            return "Copied."
+            return ("Copied.", .green)
         }
-        return "Tap an ID to copy. Share with support or use in the backend portal to identify this device."
-    }
-
-    private var copyFooterColor: Color {
-        if copyStatus.values.contains(.blocked) { return .orange }
-        if copyStatus.values.contains(.copied) { return .green }
-        return .secondary
+        return nil
     }
     #endif
 

--- a/swift/TigerDuck/Features/Settings/Components/PushServerSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/PushServerSettingsView.swift
@@ -16,6 +16,7 @@ struct PushServerSettingsView: View {
     @Default(.pushServerEnabled) private var pushServerEnabled
     @Default(.pushLastRegistrationAt) private var lastRegistrationAt
     @Default(.pushLastSyncAt) private var lastSyncAt
+    @Default(.serverPushUserOptOut) private var serverPushOptOut
 
     @State private var snapshot: PushDiagnostic?
     @State private var refreshTimer: Timer?
@@ -32,6 +33,12 @@ struct PushServerSettingsView: View {
                 Toggle(String(localized: "push_server_enable_toggle"), isOn: toggleBinding)
             } footer: {
                 Text(String(localized: "push_server_footer"))
+            }
+
+            Section {
+                Toggle(String(localized: "settings_server_push_label"), isOn: serverPushBinding)
+            } footer: {
+                Text(String(localized: "settings_server_push_footer"))
             }
 
             if pushServerEnabled, let s = snapshot {
@@ -149,6 +156,18 @@ struct PushServerSettingsView: View {
                     disableTask = Task { await appState.disablePushServer() }
                 }
                 Task { await refreshSnapshot() }
+            }
+        )
+    }
+
+    /// User-facing opt-out for operator-issued "server" pushes. Bound as
+    /// `isOn` (i.e. ON = user wants to receive them); we invert into
+    /// `serverPushUserOptOut` for storage.
+    private var serverPushBinding: Binding<Bool> {
+        Binding(
+            get: { !serverPushOptOut },
+            set: { isOn in
+                Task { await appState.updateServerPushOptOut(!isOn) }
             }
         )
     }

--- a/swift/TigerDuck/Features/Settings/SettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/SettingsView.swift
@@ -123,28 +123,24 @@ struct SettingsView: View {
                         isOn: $appState.useEnglishClassroomAbbreviation
                     )
                     if appState.useEnglishClassroomAbbreviation {
-                        // Default Picker layout puts the label and the
-                        // selected value on the same line — with a long
-                        // localized label (e.g. "When classroom name is
-                        // in Mandarin") the value gets squeezed and
-                        // truncated. Render the label above the menu so
-                        // both halves can use the full row width.
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(String(localized: "settings_classroom_mandarin_display"))
-                                .fixedSize(horizontal: false, vertical: true)
-                            Picker(
-                                String(localized: "settings_classroom_mandarin_display"),
-                                selection: $appState.classroomMandarinDisplay
-                            ) {
-                                Text(String(localized: "settings_classroom_mandarin_display_original"))
-                                    .tag("original")
-                                Text(String(localized: "settings_classroom_mandarin_display_pinyin"))
-                                    .tag("pinyin")
-                                Text(String(localized: "settings_classroom_mandarin_display_translated"))
-                                    .tag("translated")
-                            }
-                            .labelsHidden()
+                        // `.menu` style (the Form default) packs label and
+                        // value into one row whose height is computed from
+                        // a single line — long localized labels then wrap
+                        // to two lines and get clipped at the bottom.
+                        // `.navigationLink` renders the picker as a real
+                        // NavigationLink whose row sizes to fit the label.
+                        Picker(
+                            String(localized: "settings_classroom_mandarin_display"),
+                            selection: $appState.classroomMandarinDisplay
+                        ) {
+                            Text(String(localized: "settings_classroom_mandarin_display_original"))
+                                .tag("original")
+                            Text(String(localized: "settings_classroom_mandarin_display_pinyin"))
+                                .tag("pinyin")
+                            Text(String(localized: "settings_classroom_mandarin_display_translated"))
+                                .tag("translated")
                         }
+                        .pickerStyle(.navigationLink)
                     }
                 }
             }
@@ -176,6 +172,17 @@ struct SettingsView: View {
                 }
             }
 
+            // MARK: - Other settings
+            // Library toggle keeps its position at the top of the
+            // "Other settings" group; the rest of the miscellany now lives
+            // behind a NavigationLink to `OtherSettingsView`.
+            Section(String(localized: "settings_section_other_settings")) {
+                Toggle(String(localized: "settings_library_related_features"), isOn: libraryToggleBinding)
+                NavigationLink(String(localized: "settings_section_other_settings")) {
+                    OtherSettingsView()
+                }
+            }
+
             // MARK: - Language
             // The user picks the app language in iOS Settings (per-app
             // language picker). iOS restarts the process on selection,
@@ -196,17 +203,6 @@ struct SettingsView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                }
-            }
-
-            // MARK: - Other settings
-            // Library toggle keeps its position at the top of the
-            // "Other settings" group; the rest of the miscellany now lives
-            // behind a NavigationLink to `OtherSettingsView`.
-            Section(String(localized: "settings_section_other_settings")) {
-                Toggle(String(localized: "settings_library_related_features"), isOn: libraryToggleBinding)
-                NavigationLink(String(localized: "settings_section_other_settings")) {
-                    OtherSettingsView()
                 }
             }
 

--- a/swift/TigerDuck/Features/Settings/SettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/SettingsView.swift
@@ -123,29 +123,29 @@ struct SettingsView: View {
                         isOn: $appState.useEnglishClassroomAbbreviation
                     )
                     if appState.useEnglishClassroomAbbreviation {
-                        Picker(
-                            String(localized: "settings_classroom_mandarin_display"),
-                            selection: $appState.classroomMandarinDisplay
-                        ) {
-                            Text(String(localized: "settings_classroom_mandarin_display_original"))
-                                .tag("original")
-                            Text(String(localized: "settings_classroom_mandarin_display_pinyin"))
-                                .tag("pinyin")
-                            Text(String(localized: "settings_classroom_mandarin_display_translated"))
-                                .tag("translated")
+                        // Default Picker layout puts the label and the
+                        // selected value on the same line — with a long
+                        // localized label (e.g. "When classroom name is
+                        // in Mandarin") the value gets squeezed and
+                        // truncated. Render the label above the menu so
+                        // both halves can use the full row width.
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(String(localized: "settings_classroom_mandarin_display"))
+                                .fixedSize(horizontal: false, vertical: true)
+                            Picker(
+                                String(localized: "settings_classroom_mandarin_display"),
+                                selection: $appState.classroomMandarinDisplay
+                            ) {
+                                Text(String(localized: "settings_classroom_mandarin_display_original"))
+                                    .tag("original")
+                                Text(String(localized: "settings_classroom_mandarin_display_pinyin"))
+                                    .tag("pinyin")
+                                Text(String(localized: "settings_classroom_mandarin_display_translated"))
+                                    .tag("translated")
+                            }
+                            .labelsHidden()
                         }
                     }
-                }
-            }
-
-            // MARK: - Other settings
-            // Library toggle keeps its position at the top of the
-            // "Other settings" group; the rest of the miscellany now lives
-            // behind a NavigationLink to `OtherSettingsView`.
-            Section(String(localized: "settings_section_other_settings")) {
-                Toggle(String(localized: "settings_library_related_features"), isOn: libraryToggleBinding)
-                NavigationLink(String(localized: "settings_section_other_settings")) {
-                    OtherSettingsView()
                 }
             }
 
@@ -196,6 +196,17 @@ struct SettingsView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
+                }
+            }
+
+            // MARK: - Other settings
+            // Library toggle keeps its position at the top of the
+            // "Other settings" group; the rest of the miscellany now lives
+            // behind a NavigationLink to `OtherSettingsView`.
+            Section(String(localized: "settings_section_other_settings")) {
+                Toggle(String(localized: "settings_library_related_features"), isOn: libraryToggleBinding)
+                NavigationLink(String(localized: "settings_section_other_settings")) {
+                    OtherSettingsView()
                 }
             }
 

--- a/swift/TigerDuck/Services/Push/PushAPIClient.swift
+++ b/swift/TigerDuck/Services/Push/PushAPIClient.swift
@@ -42,6 +42,22 @@ final class PushAPIClient: Sendable {
         _ = try await postExpectingNoBody(path: "/devices/unregister", body: body)
     }
 
+    /// PATCH the user-facing server-push opt-out. Called from the Settings
+    /// toggle so the change propagates without waiting for the next
+    /// `/devices/register` call.
+    func updateDevicePreferences(
+        deviceId: String,
+        serverPushEnabled: Bool
+    ) async throws -> PushAPI.DevicePreferencesResponse {
+        let body = PushAPI.DevicePreferencesRequest(serverPushEnabled: serverPushEnabled)
+        let safeDevice = Self.percentEncoded(deviceId)
+        return try await patch(
+            path: "/devices/\(safeDevice)/preferences",
+            body: body,
+            returning: PushAPI.DevicePreferencesResponse.self
+        )
+    }
+
     func syncSchedule(_ request: PushAPI.ScheduleSyncRequest) async throws -> PushAPI.ScheduleSyncResponse {
         try await post(path: "/schedule/sync", body: request, returning: PushAPI.ScheduleSyncResponse.self)
     }
@@ -99,6 +115,23 @@ final class PushAPIClient: Sendable {
     ) async throws -> Data {
         let request = try makePostRequest(path: path, body: body)
         return try await execute(request)
+    }
+
+    private func patch<Request: Encodable, Response: Decodable>(
+        path: String,
+        body: Request,
+        returning: Response.Type
+    ) async throws -> Response {
+        var request = try makePostRequest(path: path, body: body)
+        request.httpMethod = "PATCH"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let data = try await execute(request)
+        do {
+            return try Self.decoder.decode(Response.self, from: data)
+        } catch {
+            logger.error("Push.API decode failed path=\(path, privacy: .public) error=\(String(describing: error), privacy: .public)")
+            throw PushAPIError.decodingFailed(error)
+        }
     }
 
     private func makePostRequest<Request: Encodable>(path: String, body: Request) throws -> URLRequest {

--- a/swift/TigerDuck/Services/Push/PushAPIDTO.swift
+++ b/swift/TigerDuck/Services/Push/PushAPIDTO.swift
@@ -14,6 +14,13 @@ enum PushAPI {
         let bundleId: String
         let attrsType: String
         let apnsEnv: String
+        /// "iphone" | "ipad" | "mac"; empty for legacy installs that pre-date
+        /// the field. Backend's validator allows empty + maps it to the
+        /// platform family at query time.
+        let deviceClass: String
+        /// User-facing opt-out for operator-issued "server" pushes. Sent on
+        /// every register so the most recent local value wins.
+        let serverPushEnabled: Bool
 
         enum CodingKeys: String, CodingKey {
             case userId = "user_id"
@@ -24,6 +31,8 @@ enum PushAPI {
             case bundleId = "bundle_id"
             case attrsType = "attrs_type"
             case apnsEnv = "apns_env"
+            case deviceClass = "device_class"
+            case serverPushEnabled = "server_push_enabled"
         }
     }
 
@@ -44,6 +53,24 @@ enum PushAPI {
 
         enum CodingKeys: String, CodingKey {
             case deviceId = "device_id"
+        }
+    }
+
+    struct DevicePreferencesRequest: Codable, Sendable {
+        let serverPushEnabled: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case serverPushEnabled = "server_push_enabled"
+        }
+    }
+
+    struct DevicePreferencesResponse: Codable, Sendable {
+        let deviceId: String
+        let serverPushEnabled: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case deviceId = "device_id"
+            case serverPushEnabled = "server_push_enabled"
         }
     }
 

--- a/swift/TigerDuck/Services/Push/PushCoordinator.swift
+++ b/swift/TigerDuck/Services/Push/PushCoordinator.swift
@@ -95,13 +95,24 @@ final class PushCoordinator {
     ///   Auto-enable must NOT prompt — that would land the system alert
     ///   on top of OnboardingView.
     func enable(requestPermission: Bool = false) {
-        guard !isStarted else { return }
         guard Defaults[.pushServerEnabled] else {
             logger.info("enable skipped — pushServerEnabled=false")
             return
         }
-        isStarted = true
-        logger.info("enabling push stack (requestPermission=\(requestPermission, privacy: .public))")
+        // One-time stack bring-up: relay + `isStarted` flip happen on the
+        // first call only. The permission/register block below intentionally
+        // runs every time — auto-enable at launch (`requestPermission:
+        // false`) lands first and sets `isStarted = true`, so a later
+        // onboarding/Settings call with `requestPermission: true` must NOT
+        // return early; otherwise the system alert never appears and APNs
+        // is never asked to deliver a token, and the device never gets a
+        // server registration row even with notifications granted.
+        let firstStart = !isStarted
+        if firstStart {
+            isStarted = true
+            relay.start()
+        }
+        logger.info("enabling push stack (firstStart=\(firstStart, privacy: .public), requestPermission=\(requestPermission, privacy: .public))")
 
         Task { @MainActor in
             if requestPermission {
@@ -117,8 +128,6 @@ final class PushCoordinator {
             // another explicit hook.
             UIApplication.shared.registerForRemoteNotifications()
         }
-
-        relay.start()
     }
 
     /// Returns the latest diagnostic snapshot for the settings view.

--- a/swift/TigerDuck/Services/Push/PushCoordinator.swift
+++ b/swift/TigerDuck/Services/Push/PushCoordinator.swift
@@ -12,6 +12,7 @@ struct PushDiagnostic: Sendable {
     let notificationAuthStatus: UNAuthorizationStatus
     let registration: PushRegistrationSnapshot
     let resolvedServerURL: URL
+    let userId: String
     let deviceId: String
 }
 
@@ -119,6 +120,7 @@ final class PushCoordinator {
             notificationAuthStatus: notificationStatus,
             registration: reg,
             resolvedServerURL: PushServerConfig.resolveServerURL(),
+            userId: identity.userId,
             deviceId: identity.deviceId
         )
     }

--- a/swift/TigerDuck/Services/Push/PushCoordinator.swift
+++ b/swift/TigerDuck/Services/Push/PushCoordinator.swift
@@ -30,7 +30,11 @@ struct PushDiagnostic: Sendable {
 final class PushCoordinator {
     private let identity: PushIdentity
     private let apiClient: PushAPIClient
-    private let registration: PushRegistrationService
+    /// Exposed `internal` so AppState can call user-preference helpers
+    /// (e.g. `updateServerPushOptOut`) without re-plumbing them through
+    /// every layer. The actor still owns its own state — callers only see
+    /// its async methods.
+    let registration: PushRegistrationService
     private let relay: PushTokenRelay
     let scheduleSync: ScheduleSyncService
 

--- a/swift/TigerDuck/Services/Push/PushCoordinator.swift
+++ b/swift/TigerDuck/Services/Push/PushCoordinator.swift
@@ -84,24 +84,37 @@ final class PushCoordinator {
     }
 
     /// Enable the full push stack. Safe to call repeatedly.
-    func enable() {
+    ///
+    /// - Parameter requestPermission: When `true`, the call also fires
+    ///   the iOS system permission prompt — appropriate for the explicit
+    ///   "turn on" Settings toggle, which needs visible feedback that the
+    ///   toggle "did something". Pass `false` for the silent auto-enable
+    ///   path that runs at every launch: it only calls
+    ///   `registerForRemoteNotifications`, which is a no-op until the
+    ///   user has granted permission elsewhere (typically onboarding).
+    ///   Auto-enable must NOT prompt — that would land the system alert
+    ///   on top of OnboardingView.
+    func enable(requestPermission: Bool = false) {
         guard !isStarted else { return }
         guard Defaults[.pushServerEnabled] else {
             logger.info("enable skipped — pushServerEnabled=false")
             return
         }
         isStarted = true
-        logger.info("enabling push stack")
+        logger.info("enabling push stack (requestPermission=\(requestPermission, privacy: .public))")
 
-        // Request user-visible notification permission first so the user gets
-        // an iOS system prompt as visible feedback that the toggle "did
-        // something". PTS (Push-to-Start) tokens don't strictly require this
-        // permission, but it unblocks standard-alert push later AND avoids
-        // the silent-toggle-does-nothing UX.
         Task { @MainActor in
-            let granted = (try? await UNUserNotificationCenter.current()
-                .requestAuthorization(options: [.alert, .sound, .badge])) ?? false
-            logger.info("notification authorization granted=\(granted, privacy: .public)")
+            if requestPermission {
+                let granted = (try? await UNUserNotificationCenter.current()
+                    .requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+                logger.info("notification authorization granted=\(granted, privacy: .public)")
+            }
+            // registerForRemoteNotifications is safe to call regardless of
+            // permission state — it returns an APNs token if authorized
+            // and stays quiet otherwise. Calling it on every enable lets
+            // a later permission grant (via onboarding or iOS Settings)
+            // flow into the existing token-forwarding pipeline without
+            // another explicit hook.
             UIApplication.shared.registerForRemoteNotifications()
         }
 

--- a/swift/TigerDuck/Services/Push/PushRegistrationService.swift
+++ b/swift/TigerDuck/Services/Push/PushRegistrationService.swift
@@ -68,6 +68,12 @@ actor PushRegistrationService {
     private var lastAttempt: Task<Void, Never>?
     private var lastError: String?
     private var lastRegisteredAt: Date?
+    /// Most recently scheduled opt-out PATCH. New `updateServerPushOptOut`
+    /// calls chain onto this task so PATCHes run in tap order, and the
+    /// `apiClient → Defaults` pair always executes atomically — cancelling
+    /// at the boundary would let a server-accepted change desync from the
+    /// stored value.
+    private var optOutPatchChain: Task<Void, Error>?
     private var pendingActivityRegistrations: [String: LiveActivityUpdateTokenRegistration] = [:]
     // Retry scheduling for activity-token registration. A transient network
     // or 5xx failure against `/live-activities/register` would otherwise drop
@@ -144,25 +150,46 @@ actor PushRegistrationService {
     /// The next `/devices/register` call also re-sends the value, so a
     /// later success backstops eventual consistency.
     ///
-    /// Honours Task cancellation between the PATCH and the local write:
-    /// the view cancels older taps when the user rapidly toggles, and
-    /// without this check two interleaved invocations could complete
-    /// out of order and let the older choice clobber the latest one in
-    /// `Defaults` (URLSession may surface the response before cancellation
-    /// arrives, so we re-check before mutating shared state).
+    /// Concurrent calls are serialised through `optOutPatchChain` so two
+    /// rapid taps cannot interleave at the network suspension point. A
+    /// previous version short-circuited with `Task.checkCancellation()`
+    /// here, but cancellation can land *after* the server has already
+    /// accepted the PATCH — skipping the local `Defaults` write in that
+    /// window leaves Settings showing one value while the server holds
+    /// another (operator pushes silently disabled while the toggle still
+    /// reads enabled, and vice versa). Chaining instead lets every
+    /// successfully-applied server change reach `Defaults`, and tap
+    /// order is preserved because each task awaits its predecessor.
     func updateServerPushOptOut(_ optOut: Bool) async throws {
-        let id = identity.deviceId
-        do {
-            _ = try await apiClient.updateDevicePreferences(
-                deviceId: id, serverPushEnabled: !optOut
-            )
-            try Task.checkCancellation()
-            await MainActor.run { Defaults[.serverPushUserOptOut] = optOut }
-            logger.info("server push opt-out=\(optOut, privacy: .public) propagated")
-        } catch {
-            logger.error("server push opt-out PATCH failed: \(error.localizedDescription, privacy: .public)")
-            throw error
+        let predecessor = optOutPatchChain
+        let deviceId = identity.deviceId
+        let apiClient = self.apiClient
+        let logger = self.logger
+        let task = Task<Void, Error> {
+            // Tolerate predecessor failure — each tap's success is
+            // independent of whether the previous one succeeded; we just
+            // need its work to be done before ours starts.
+            _ = try? await predecessor?.value
+            do {
+                _ = try await apiClient.updateDevicePreferences(
+                    deviceId: deviceId, serverPushEnabled: !optOut
+                )
+                await MainActor.run { Defaults[.serverPushUserOptOut] = optOut }
+                logger.info("server push opt-out=\(optOut, privacy: .public) propagated")
+            } catch {
+                logger.error("server push opt-out PATCH failed: \(error.localizedDescription, privacy: .public)")
+                throw error
+            }
         }
+        optOutPatchChain = task
+        defer {
+            // Don't pin a long-completed task as the chain head — clear
+            // it unless a newer call has already taken our place.
+            if optOutPatchChain == task {
+                optOutPatchChain = nil
+            }
+        }
+        try await task.value
     }
 
     /// Snapshot of internal state for UI display. Safe to call from any isolation.

--- a/swift/TigerDuck/Services/Push/PushRegistrationService.swift
+++ b/swift/TigerDuck/Services/Push/PushRegistrationService.swift
@@ -1,5 +1,8 @@
 import Defaults
 import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
 import os
 
 /// Orchestrates the `device ↔ server` binding.
@@ -29,12 +32,30 @@ nonisolated enum PushAPNsEnv {
     #endif
 }
 
+/// `device_class` value the iOS client reports. Drives operator-side
+/// targeting (iPhone vs iPad vs Mac) without needing the backend to
+/// re-parse build metadata.
+nonisolated enum PushDeviceClass {
+    static var resolvedForBuild: String {
+        #if os(macOS)
+        return "mac"
+        #else
+        switch UIDevice.current.userInterfaceIdiom {
+        case .pad:   return "ipad"
+        case .phone: return "iphone"
+        default:     return "iphone"
+        }
+        #endif
+    }
+}
+
 actor PushRegistrationService {
     private let identity: PushIdentity
     private let apiClient: PushAPIClient
     private let bundleId: String
     private let attrsType: String
     private let apnsEnv: String
+    private let deviceClass: String
     private let logger = Logger(subsystem: "org.ntust.app.TigerDuck", category: "Push.Register")
 
     private var deviceTokenHex: String?
@@ -67,13 +88,15 @@ actor PushRegistrationService {
         apiClient: PushAPIClient,
         bundleId: String = "org.ntust.app.TigerDuck",
         attrsType: String = "TigerDuckActivityAttributes",
-        apnsEnv: String = PushAPNsEnv.resolvedForBuild
+        apnsEnv: String = PushAPNsEnv.resolvedForBuild,
+        deviceClass: String = PushDeviceClass.resolvedForBuild
     ) {
         self.identity = identity
         self.apiClient = apiClient
         self.bundleId = bundleId
         self.attrsType = attrsType
         self.apnsEnv = apnsEnv
+        self.deviceClass = deviceClass
     }
 
     // MARK: - Token intake
@@ -107,6 +130,23 @@ actor PushRegistrationService {
     func registrationFailed(_ error: Error) {
         lastError = "APNs register failed: \(error.localizedDescription)"
         logger.error("APNs registration failed: \(error.localizedDescription, privacy: .public)")
+    }
+
+    /// Called from the settings toggle. Writes the local pref and PATCHes
+    /// the backend immediately. On transient failure we don't retry here —
+    /// the next `/devices/register` call will re-send the value, so
+    /// eventual consistency is preserved.
+    func updateServerPushOptOut(_ optOut: Bool) async {
+        await MainActor.run { Defaults[.serverPushUserOptOut] = optOut }
+        let id = identity.deviceId
+        do {
+            _ = try await apiClient.updateDevicePreferences(
+                deviceId: id, serverPushEnabled: !optOut
+            )
+            logger.info("server push opt-out=\(optOut, privacy: .public) propagated")
+        } catch {
+            logger.error("server push opt-out PATCH failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     /// Snapshot of internal state for UI display. Safe to call from any isolation.
@@ -175,6 +215,7 @@ actor PushRegistrationService {
     /// stale `let`s from the enqueue site.
     private func performRegister(logger: Logger) async {
         guard let pts = ptsTokenHex else { return }
+        let optOut = await MainActor.run { Defaults[.serverPushUserOptOut] }
         let request = PushAPI.DeviceRegisterRequest(
             userId: identity.userId,
             deviceId: identity.deviceId,
@@ -183,7 +224,9 @@ actor PushRegistrationService {
             deviceTokenHex: deviceTokenHex,
             bundleId: bundleId,
             attrsType: attrsType,
-            apnsEnv: apnsEnv
+            apnsEnv: apnsEnv,
+            deviceClass: deviceClass,
+            serverPushEnabled: !optOut
         )
         do {
             let response = try await apiClient.registerDevice(request)

--- a/swift/TigerDuck/Services/Push/PushRegistrationService.swift
+++ b/swift/TigerDuck/Services/Push/PushRegistrationService.swift
@@ -40,8 +40,13 @@ nonisolated enum PushDeviceClass {
         #if os(macOS)
         return "mac"
         #else
+        // `.mac` covers the "Designed for iPad" runtime on Apple Silicon,
+        // where the iOS binary runs as a Mac app and the idiom reports
+        // `.mac`. Falling through to "iphone" there would mis-target
+        // operator pushes that filter on `device_class`.
         switch UIDevice.current.userInterfaceIdiom {
         case .pad:   return "ipad"
+        case .mac:   return "mac"
         case .phone: return "iphone"
         default:     return "iphone"
         }
@@ -132,20 +137,23 @@ actor PushRegistrationService {
         logger.error("APNs registration failed: \(error.localizedDescription, privacy: .public)")
     }
 
-    /// Called from the settings toggle. Writes the local pref and PATCHes
-    /// the backend immediately. On transient failure we don't retry here —
-    /// the next `/devices/register` call will re-send the value, so
-    /// eventual consistency is preserved.
-    func updateServerPushOptOut(_ optOut: Bool) async {
-        await MainActor.run { Defaults[.serverPushUserOptOut] = optOut }
+    /// Called from the settings toggle. PATCHes the backend first; only
+    /// flips the local pref after a 2xx so a transient failure doesn't
+    /// leave local state pretending the server agrees. Throws on failure
+    /// so the caller can roll back the Toggle UI and surface the error.
+    /// The next `/devices/register` call also re-sends the value, so a
+    /// later success backstops eventual consistency.
+    func updateServerPushOptOut(_ optOut: Bool) async throws {
         let id = identity.deviceId
         do {
             _ = try await apiClient.updateDevicePreferences(
                 deviceId: id, serverPushEnabled: !optOut
             )
+            await MainActor.run { Defaults[.serverPushUserOptOut] = optOut }
             logger.info("server push opt-out=\(optOut, privacy: .public) propagated")
         } catch {
             logger.error("server push opt-out PATCH failed: \(error.localizedDescription, privacy: .public)")
+            throw error
         }
     }
 

--- a/swift/TigerDuck/Services/Push/PushRegistrationService.swift
+++ b/swift/TigerDuck/Services/Push/PushRegistrationService.swift
@@ -143,12 +143,20 @@ actor PushRegistrationService {
     /// so the caller can roll back the Toggle UI and surface the error.
     /// The next `/devices/register` call also re-sends the value, so a
     /// later success backstops eventual consistency.
+    ///
+    /// Honours Task cancellation between the PATCH and the local write:
+    /// the view cancels older taps when the user rapidly toggles, and
+    /// without this check two interleaved invocations could complete
+    /// out of order and let the older choice clobber the latest one in
+    /// `Defaults` (URLSession may surface the response before cancellation
+    /// arrives, so we re-check before mutating shared state).
     func updateServerPushOptOut(_ optOut: Bool) async throws {
         let id = identity.deviceId
         do {
             _ = try await apiClient.updateDevicePreferences(
                 deviceId: id, serverPushEnabled: !optOut
             )
+            try Task.checkCancellation()
             await MainActor.run { Defaults[.serverPushUserOptOut] = optOut }
             logger.info("server push opt-out=\(optOut, privacy: .public) propagated")
         } catch {

--- a/swift/TigerDuck/TigerDuckApp.swift
+++ b/swift/TigerDuck/TigerDuckApp.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import SwiftData
+#if os(iOS)
+import UserNotifications
+#endif
 
 #if os(iOS)
 
@@ -81,6 +84,20 @@ struct TigerDuckApp: App {
                 .environment(appState)
                 .onAppear {
                     appState.bindPushDelegate(pushAppDelegate)
+                    // Route custom-push taps into AppState. Capture the
+                    // class instance weakly to avoid a retain cycle
+                    // through `pushAppDelegate.notificationDelegate`.
+                    if let nd = pushAppDelegate.notificationDelegate {
+                        let state = appState
+                        nd.routeTap = { [weak state] response in
+                            Task { @MainActor in
+                                Self.routeServerPushTap(
+                                    response: response,
+                                    appState: state
+                                )
+                            }
+                        }
+                    }
                     appState.backgroundSync()
                     if widgetSnapshotWriter == nil {
                         widgetSnapshotWriter = WidgetSnapshotWriter(appState: appState)
@@ -126,6 +143,47 @@ struct TigerDuckApp: App {
                 }
         }
         .modelContainer(sharedModelContainer)
+    }
+
+    /// Translates a tapped notification into the right AppState mutation.
+    /// Kept as a static helper so the SwiftUI body stays uncluttered and
+    /// the routing logic can be unit-tested independently of the App
+    /// scene plumbing.
+    ///
+    /// - Note: `bulletin_id` is read as both `Int` and `String` because
+    ///   APNs / FCM serialisers occasionally ship JSON numbers as
+    ///   quoted strings depending on the publisher path.
+    @MainActor
+    private static func routeServerPushTap(
+        response: UNNotificationResponse,
+        appState: AppState?
+    ) {
+        guard let appState else { return }
+        let info = response.notification.request.content.userInfo
+        let kind = info["kind"] as? String
+        switch kind {
+        case "custom_push_bulletin":
+            if let id = info["bulletin_id"] as? Int {
+                appState.pendingDeepLink = .bulletin(id)
+            } else if let s = info["bulletin_id"] as? String, let id = Int(s) {
+                appState.pendingDeepLink = .bulletin(id)
+            }
+        case "custom_push_popup":
+            guard let nid = info["notification_id"] as? String,
+                  let title = info["title"] as? String,
+                  let body = info["body"] as? String else { return }
+            if appState.markServerPopupShown(nid) {
+                appState.pendingServerPopup = AppState.ServerPopupPayload(
+                    id: nid,
+                    title: title,
+                    body: body
+                )
+            }
+        default:
+            // Unknown / legacy kinds fall through to the OS default open
+            // behaviour — no-op here so we don't accidentally swallow them.
+            break
+        }
     }
 }
 

--- a/swift/TigerDuck/TigerDuckApp.swift
+++ b/swift/TigerDuck/TigerDuckApp.swift
@@ -156,9 +156,12 @@ struct TigerDuckApp: App {
     /// the routing logic can be unit-tested independently of the App
     /// scene plumbing.
     ///
-    /// - Note: `bulletin_id` is read as both `Int` and `String` because
-    ///   APNs / FCM serialisers occasionally ship JSON numbers as
-    ///   quoted strings depending on the publisher path.
+    /// - Note: `bulletin_id` is decoded through three paths (`Int`,
+    ///   `NSNumber.intValue`, and `String → Int`) because APNs / FCM /
+    ///   intermediate relays bridge JSON numbers inconsistently — some
+    ///   land as a tagged-int NSNumber that succeeds `as? Int`, others
+    ///   as a Double-tagged NSNumber where `as? Int` fails, and a few
+    ///   re-encode the value as a quoted string.
     @MainActor
     private static func routeServerPushTap(
         response: UNNotificationResponse,
@@ -169,27 +172,53 @@ struct TigerDuckApp: App {
         let kind = info["kind"] as? String
         switch kind {
         case "custom_push_bulletin":
-            if let id = info["bulletin_id"] as? Int {
-                appState.pendingDeepLink = .bulletin(id)
-            } else if let s = info["bulletin_id"] as? String, let id = Int(s) {
+            if let id = bulletinId(from: info["bulletin_id"]) {
                 appState.pendingDeepLink = .bulletin(id)
             }
         case "custom_push_popup":
             guard let nid = info["notification_id"] as? String,
                   let title = info["title"] as? String,
                   let body = info["body"] as? String else { return }
-            if appState.markServerPopupShown(nid) {
-                appState.pendingServerPopup = AppState.ServerPopupPayload(
-                    id: nid,
-                    title: title,
-                    body: body
-                )
+            // Only the *check* runs at routing time — the actual mark
+            // happens when the user dismisses the alert (see
+            // `ServerPushPopupHost`). That way a popup that's suppressed
+            // by a competing modal (mid-onboarding etc.) isn't permanently
+            // deduped before the user ever sees it.
+            guard !appState.isServerPopupShown(nid) else { return }
+            let payload = AppState.ServerPopupPayload(
+                id: nid,
+                title: title,
+                body: body
+            )
+            // Force SwiftUI's `.alert(_:isPresented:presenting:)` to
+            // refresh when a second popup arrives while the first alert
+            // is still on screen: dismiss the current alert, then present
+            // the new payload on the next runloop tick so `isPresented`
+            // actually transitions false → true.
+            if appState.pendingServerPopup != nil {
+                appState.pendingServerPopup = nil
+                Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(50))
+                    appState.pendingServerPopup = payload
+                }
+            } else {
+                appState.pendingServerPopup = payload
             }
         default:
             // Unknown / legacy kinds fall through to the OS default open
             // behaviour — no-op here so we don't accidentally swallow them.
             break
         }
+    }
+
+    /// Decode `bulletin_id` from a JSON-bridged userInfo value. See the
+    /// `routeServerPushTap` doc comment for why all three paths exist.
+    @MainActor
+    private static func bulletinId(from raw: Any?) -> Int? {
+        if let n = raw as? Int { return n }
+        if let n = raw as? NSNumber { return n.intValue }
+        if let s = raw as? String { return Int(s) }
+        return nil
     }
 }
 

--- a/swift/TigerDuck/TigerDuckApp.swift
+++ b/swift/TigerDuck/TigerDuckApp.swift
@@ -109,6 +109,7 @@ struct TigerDuckApp: App {
                     // here; subsequent foreground returns go through the
                     // scene-phase observer.
                     appState.updateNotifyCoordinator.checkInBackground()
+                    UNUserNotificationCenter.current().setBadgeCount(0)
                 }
                 .onOpenURL { url in
                     guard let destination = WidgetURLRouter.route(url) else { return }
@@ -121,6 +122,11 @@ struct TigerDuckApp: App {
                 }
                 .onChange(of: scenePhase) { _, newPhase in
                     if newPhase == .active {
+                        // Reset the app-icon badge but leave delivered
+                        // notifications in Notification Center — user can
+                        // still scroll back to them, the red badge just
+                        // stops nagging once they've opened the app.
+                        UNUserNotificationCenter.current().setBadgeCount(0)
                         // Cancel any still-running refresh from a previous
                         // .active transition so rapid scene toggles do not
                         // interleave through cancelAllOwnedRequests()'s

--- a/swift/TigerDuck/TigerDuckApp.swift
+++ b/swift/TigerDuck/TigerDuckApp.swift
@@ -195,11 +195,19 @@ struct TigerDuckApp: App {
             // is still on screen: dismiss the current alert, then present
             // the new payload on the next runloop tick so `isPresented`
             // actually transitions false → true.
+            //
+            // Always cancel any previous swap first — if popup B's swap
+            // is mid-sleep when popup C arrives, the stale B task would
+            // otherwise wake up and overwrite C's payload with B's.
+            appState.pendingServerPopupSwapTask?.cancel()
+            appState.pendingServerPopupSwapTask = nil
             if appState.pendingServerPopup != nil {
                 appState.pendingServerPopup = nil
-                Task { @MainActor in
+                appState.pendingServerPopupSwapTask = Task { @MainActor [weak appState] in
                     try? await Task.sleep(for: .milliseconds(50))
+                    guard !Task.isCancelled, let appState else { return }
                     appState.pendingServerPopup = payload
+                    appState.pendingServerPopupSwapTask = nil
                 }
             } else {
                 appState.pendingServerPopup = payload


### PR DESCRIPTION
## Summary

Adds the iOS half of the operator-issued custom-push pipeline:

- **Tap routing**: `NotificationDelegate` translates `custom_push_bulletin` and `custom_push_popup` payloads into `AppState.pendingDeepLink` / `pendingServerPopup`. Cold-launch taps are buffered until SwiftUI wires the routing closure (would otherwise be dropped before `.onAppear` ran). Popup deduping defers the FIFO mark to the alert's dismiss action so a suppressed alert can re-present on the next tap.
- **Server-push opt-out toggle**: new `serverPushUserOptOut` Default backs a Settings switch that PATCHes `/devices/{id}/preferences`. The actor writes the local Default only after a 2xx, throws on failure, and the toggle footer surfaces the rollback so the UI never claims agreement the server didn't accept.
- **Always-on device registration**: `pushServerEnabled` default flipped to `true`. `enable()` gained `requestPermission: Bool` so `AppState.init`'s auto-enable registers silently; the iOS permission prompt stays inside the onboarding flow / explicit toggle path.
- **device_class targeting**: register / re-register sends `device_class` (iphone / ipad / mac, with `.mac` covering Designed-for-iPad on Apple Silicon).
- **Settings polish**: new IDs section (User ID + Device ID, copy-to-pasteboard with MDM-blocked detection; rapid-tap reset Tasks now cancel correctly), badge clears on foreground, deleted-bulletin tombstones no longer leak into the local list via `summary(forId:)`, MoreView replaces its `navigationPath` for cross-context deep links so the target view doesn't layer on top of whatever the user was already viewing.
- **Settings ordering**: Delete account row sits between Privacy policy and Open-source licences (groups the privacy-control links and matches the Android layout).

## Test plan

- [ ] Cold-launch tap on a `custom_push_bulletin` → routes to the bulletin detail (was previously dropped before `routeTap` wired).
- [ ] Cold-launch tap on a `custom_push_popup` → alert presents post-launch and the OK button writes to the FIFO.
- [ ] Two `custom_push_popup` notifications back-to-back without dismissing → alert refreshes to the second payload (A→B atomic-swap path).
- [ ] Tap on a since-deleted `custom_push_bulletin` → no ghost row in the announcement list or disk cache.
- [ ] Settings → Server push toggle: flip off → on offline → confirm toggle snaps back and footer shows "Server didn't accept the change…".
- [ ] Rapid double-tap on User ID / Device ID copy row → checkmark stays visible until the second tap's 1.5s window elapses (no premature reset from the first Task).
- [ ] Bulletin deep link with poor network → tap is preserved across the failed fetch (pendingDeepLink stays set during inflight, clears on resolve).
- [ ] Fresh install: notification permission prompt only appears inside onboarding, not at AppState.init.
- [ ] iPad / Designed-for-iPad on Apple Silicon → device_class registered as `ipad` / `mac` respectively (verify via Settings → Push Server → IDs and backend portal).
- [ ] Settings → Other settings → confirm row order: Feedback → Privacy policy → Delete account → Open-source licences → View source code.