### PR TITLE
docs(readme): add App Store badge for download link

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -9,6 +9,7 @@
 [![Version](https://img.shields.io/badge/Version-v1.7.0-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.7.0)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/ios)
 
+[![App Store](https://img.shields.io/badge/App%20Store-Download-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://apps.apple.com/app/id6761084888)
 [![TestFlight](https://img.shields.io/badge/TestFlight-Join-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/eVt9Gjkw)
 
 [繁體中文](README.md) | **English**
@@ -80,6 +81,8 @@ Ever used [TAT](https://github.com/morris13579/tat_ntust)? We're working hard ma
 <br/>
 
 ## Get the App
+[![App Store](https://img.shields.io/badge/App%20Store-Download-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://apps.apple.com/app/id6761084888)
+
 [![TestFlight](https://img.shields.io/badge/TestFlight-Join-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/eVt9Gjkw)
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Version](https://img.shields.io/badge/Version-v1.7.0-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.7.0)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/ios)
 
+[![App Store](https://img.shields.io/badge/App%20Store-Download-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://apps.apple.com/app/id6761084888)
 [![TestFlight](https://img.shields.io/badge/TestFlight-Join-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/eVt9Gjkw)
 
 **繁體中文** | [English](README.en.md)
@@ -81,6 +82,8 @@ TigerDuck 是由一群學生共同開發的校園助手
 <br/>
 
 ## 取得 App
+[![App Store](https://img.shields.io/badge/App%20Store-Download-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://apps.apple.com/app/id6761084888)
+
 [![TestFlight](https://img.shields.io/badge/TestFlight-Join-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/eVt9Gjkw)
 
 <br/>


### PR DESCRIPTION
This pull request updates both the English (`README.en.md`) and Chinese (`README.md`) README files to add a prominent App Store download badge and link, making it easier for users to find and download the app directly from the App Store.

Documentation updates:

* Added an App Store badge with a direct download link to the top badge section in both `README.md` and `README.en.md` for better visibility. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12) [[2]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213R12)
* Added an App Store badge and link to the "Get the App" / "取得 App" sections in both `README.md` and `README.en.md` to highlight the official App Store release alongside the TestFlight link. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R85-R86) [[2]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213R84-R85)