### PR TITLE
fix(ios18): gesture arbitration, concurrency warnings & update/onboarding polish

### DIFF
--- a/swift/TigerDuck/Extensions/View+ScrollSafeGesture.swift
+++ b/swift/TigerDuck/Extensions/View+ScrollSafeGesture.swift
@@ -16,11 +16,20 @@ extension View {
     /// arbitration against an enclosing scroll view. `.contentShape` keeps the
     /// whole frame (including transparent padding) hittable; `Button` supplies
     /// the `.isButton` accessibility trait automatically.
-    func scrollSafeTapAction(_ action: @escaping () -> Void) -> some View {
+    ///
+    /// `onPressChanged`, when supplied, reports the Button's press state —
+    /// `true` at touch-down (before the tap action is delivered on release),
+    /// `false` when the press lifts or cancels. Callers that run a
+    /// `.simultaneousGesture` drag alongside the tap use the touch-down edge as
+    /// a per-interaction reset hook that doesn't depend on callback ordering.
+    func scrollSafeTapAction(
+        onPressChanged: ((Bool) -> Void)? = nil,
+        _ action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
             self.contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(ScrollSafeButtonStyle(onPressChanged: onPressChanged))
     }
 
     /// A 0.5 s long-press that enters an edit / reorder mode, attached as a
@@ -43,5 +52,21 @@ extension View {
     /// that left onboarding links dead.
     func dismissTapGesture(_ action: @escaping () -> Void) -> some View {
         simultaneousGesture(TapGesture().onEnded(action))
+    }
+}
+
+/// Visually inert button style (no border, background, or press dimming —
+/// identical to `.plain` for the content cards `scrollSafeTapAction` wraps)
+/// that additionally forwards `configuration.isPressed` so callers can observe
+/// the press lifecycle. Reading `isPressed` requires a `ButtonStyle`; there is
+/// no plain-modifier equivalent.
+private struct ScrollSafeButtonStyle: ButtonStyle {
+    let onPressChanged: ((Bool) -> Void)?
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .onChange(of: configuration.isPressed) { _, isPressed in
+                onPressChanged?(isPressed)
+            }
     }
 }

--- a/swift/TigerDuck/Extensions/View+ScrollSafeGesture.swift
+++ b/swift/TigerDuck/Extensions/View+ScrollSafeGesture.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+// iOS 18 changed scroll-view gesture arbitration: a plain `.onTapGesture`
+// placed on content inside a ScrollView / LazyVGrid loses to the scroll view
+// and only registers on the *second* tap, and a plain `.onTapGesture` /
+// `.onLongPressGesture` installed over the whole scroll content competes with —
+// and swallows — the *first* tap on every interactive child.
+//
+// The fix, centralized here so every scroll-embedded surface applies it the
+// same way (and new surfaces can't forget it):
+//   • wrap tap targets in a real `Button` — its tap wins arbitration;
+//   • attach whole-view recognizers (keyboard dismiss, edit-mode long-press)
+//     via `.simultaneousGesture` so they coexist without eating child taps.
+extension View {
+    /// Wraps the view in a borderless `Button` whose tap wins iOS 18 gesture
+    /// arbitration against an enclosing scroll view. `.contentShape` keeps the
+    /// whole frame (including transparent padding) hittable; `Button` supplies
+    /// the `.isButton` accessibility trait automatically.
+    func scrollSafeTapAction(_ action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            self.contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// A 0.5 s long-press that enters an edit / reorder mode, attached as a
+    /// `.simultaneousGesture` so it never blocks child `Button` taps. Pass the
+    /// caller's `reduceMotion` so the enter animation honors the setting.
+    func longPressToEdit(
+        reduceMotion: Bool,
+        perform action: @escaping () -> Void
+    ) -> some View {
+        simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.5)
+                .onEnded { _ in
+                    withAnimation(reduceMotion ? nil : .smoothSpring) { action() }
+                }
+        )
+    }
+
+    /// A keyboard / focus-dismiss tap attached as a `.simultaneousGesture` so it
+    /// doesn't swallow taps on interactive children — the iOS 18 failure mode
+    /// that left onboarding links dead.
+    func dismissTapGesture(_ action: @escaping () -> Void) -> some View {
+        simultaneousGesture(TapGesture().onEnded(action))
+    }
+}

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -288,46 +288,52 @@ private struct ConflictClusterView: View {
                 sharpBottomOuter: sharpBottom
             )
 
-            ZStack(alignment: .topLeading) {
-                courseRegion(
-                    course: courseA,
-                    shape: shapeA,
-                    labelAlignment: .topTrailing,
-                    barFraction: aBarFraction
-                )
-                .frame(width: proxy.size.width, height: aHeight)
-                .offset(y: aTop)
-
-                courseRegion(
-                    course: courseB,
-                    shape: shapeB,
-                    labelAlignment: .bottomLeading,
-                    barFraction: bBarFraction
-                )
-                .frame(width: proxy.size.width, height: bHeight)
-                .offset(y: bTop)
-            }
-            .overlay(alignment: .topTrailing) {
-                if diffWithoutColor {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.caption2)
-                        .foregroundStyle(.orange)
-                        .padding(2)
-                        .accessibilityHidden(true)
-                }
-            }
-            // One tap anywhere in the cluster opens the picker; the picker
-            // resolves which course to inspect. Per-shape hit-testing would
-            // bypass the picker entirely, but the Android version still goes
-            // through the sheet so the user can see both options.
-            .contentShape(Rectangle())
-            .onTapGesture {
+            // A real `Button` (replacing `.onTapGesture`) wins iOS 18 gesture
+            // arbitration against the surrounding scroll view, matching the
+            // single-course cell above so the conflict picker opens on the
+            // first tap. `.contentShape` (moved inside the label) keeps the
+            // whole cluster hittable; `Button` supplies the `.isButton` trait.
+            Button {
                 viewModel.presentConflictPicker(
                     courseA: courseA, courseB: courseB,
                     weekday: weekday, periodId: periodId
                 )
+            } label: {
+                ZStack(alignment: .topLeading) {
+                    courseRegion(
+                        course: courseA,
+                        shape: shapeA,
+                        labelAlignment: .topTrailing,
+                        barFraction: aBarFraction
+                    )
+                    .frame(width: proxy.size.width, height: aHeight)
+                    .offset(y: aTop)
+
+                    courseRegion(
+                        course: courseB,
+                        shape: shapeB,
+                        labelAlignment: .bottomLeading,
+                        barFraction: bBarFraction
+                    )
+                    .frame(width: proxy.size.width, height: bHeight)
+                    .offset(y: bTop)
+                }
+                .overlay(alignment: .topTrailing) {
+                    if diffWithoutColor {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.caption2)
+                            .foregroundStyle(.orange)
+                            .padding(2)
+                            .accessibilityHidden(true)
+                    }
+                }
+                // One tap anywhere in the cluster opens the picker; the picker
+                // resolves which course to inspect. Per-shape hit-testing would
+                // bypass the picker entirely, but the Android version still goes
+                // through the sheet so the user can see both options.
+                .contentShape(Rectangle())
             }
-            .accessibilityAddTraits(.isButton)
+            .buttonStyle(.plain)
             .accessibilityLabel(
                 Text("\(String(localized: "a11y_class_table_conflict_prefix")): " +
                      String(format: String(localized: "a11y_timetable_cell"),

--- a/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/TimetableGridView.swift
@@ -109,49 +109,50 @@ struct TimetableGridView: View {
 
             Color.clear
                 .overlay(alignment: .top) {
-                    Button {
-                        viewModel.selectCourse(course, weekday: weekday, periodId: periodId)
-                    } label: {
-                        RoundedRectangle(cornerRadius: TigerDuckTheme.CornerRadius.sm)
-                            .fill(course.color.opacity(0.4))
-                            .overlay {
-                                Text(course.displayName)
-                                    .font(.system(size: courseNameSize, weight: .medium))
-                                    .foregroundStyle(Color.textPrimary)
-                                    .lineLimit(spanCount > 1 ? 3 : 2)
-                                    .minimumScaleFactor(0.7)
-                                    .multilineTextAlignment(.center)
-                                    .padding(2)
+                    // `scrollSafeTapAction` wraps the cell in a real `Button` so
+                    // the first tap wins iOS 18 arbitration against the grid's
+                    // scroll view. See View+ScrollSafeGesture.
+                    RoundedRectangle(cornerRadius: TigerDuckTheme.CornerRadius.sm)
+                        .fill(course.color.opacity(0.4))
+                        .overlay {
+                            Text(course.displayName)
+                                .font(.system(size: courseNameSize, weight: .medium))
+                                .foregroundStyle(Color.textPrimary)
+                                .lineLimit(spanCount > 1 ? 3 : 2)
+                                .minimumScaleFactor(0.7)
+                                .multilineTextAlignment(.center)
+                                .padding(2)
+                        }
+                        .assignmentBadge(show: hasBadge, iconSize: badgeIconSize, padding: 4)
+                        .frame(height: totalHeight)
+                        .scrollSafeTapAction {
+                            viewModel.selectCourse(course, weekday: weekday, periodId: periodId)
+                        }
+                        .accessibilityLabel(
+                            Text(String(
+                                format: String(localized: "a11y_timetable_cell"),
+                                weekdayDisplayName(weekday),
+                                viewModel.activePeriods.first { $0.id == periodId }?.displayLabel ?? periodId,
+                                course.displayName
+                            ))
+                        )
+                        .contextMenu {
+                            Button {
+                                viewModel.startRename(course)
+                            } label: {
+                                Label(String(localized: "class_table_rename_title"), systemImage: "pencil")
                             }
-                            .assignmentBadge(show: hasBadge, iconSize: badgeIconSize, padding: 4)
-                            .frame(height: totalHeight)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(
-                        Text(String(
-                            format: String(localized: "a11y_timetable_cell"),
-                            weekdayDisplayName(weekday),
-                            viewModel.activePeriods.first { $0.id == periodId }?.displayLabel ?? periodId,
-                            course.displayName
-                        ))
-                    )
-                    .contextMenu {
-                        Button {
-                            viewModel.startRename(course)
-                        } label: {
-                            Label(String(localized: "class_table_rename_title"), systemImage: "pencil")
+                            Button {
+                                viewModel.startRecolor(course)
+                            } label: {
+                                Label(String(localized: "course_color_picker_title"), systemImage: "paintpalette")
+                            }
+                            Button(role: .destructive) {
+                                viewModel.deleteCourse(course)
+                            } label: {
+                                Label(String(localized: "class_table_delete"), systemImage: "trash")
+                            }
                         }
-                        Button {
-                            viewModel.startRecolor(course)
-                        } label: {
-                            Label(String(localized: "course_color_picker_title"), systemImage: "paintpalette")
-                        }
-                        Button(role: .destructive) {
-                            viewModel.deleteCourse(course)
-                        } label: {
-                            Label(String(localized: "class_table_delete"), systemImage: "trash")
-                        }
-                    }
                 }
                 .zIndex(1)
 
@@ -288,52 +289,48 @@ private struct ConflictClusterView: View {
                 sharpBottomOuter: sharpBottom
             )
 
-            // A real `Button` (replacing `.onTapGesture`) wins iOS 18 gesture
-            // arbitration against the surrounding scroll view, matching the
-            // single-course cell above so the conflict picker opens on the
-            // first tap. `.contentShape` (moved inside the label) keeps the
-            // whole cluster hittable; `Button` supplies the `.isButton` trait.
-            Button {
+            // `scrollSafeTapAction` wraps the cluster in a real `Button` so the
+            // first tap wins iOS 18 arbitration against the surrounding scroll
+            // view, matching the single-course cell above. One tap anywhere in
+            // the cluster opens the picker, which resolves which course to
+            // inspect — per-shape hit-testing would bypass the picker, but the
+            // Android version also routes through the sheet so the user sees
+            // both options. `Button` supplies the `.isButton` trait and hit
+            // shape. See View+ScrollSafeGesture.
+            ZStack(alignment: .topLeading) {
+                courseRegion(
+                    course: courseA,
+                    shape: shapeA,
+                    labelAlignment: .topTrailing,
+                    barFraction: aBarFraction
+                )
+                .frame(width: proxy.size.width, height: aHeight)
+                .offset(y: aTop)
+
+                courseRegion(
+                    course: courseB,
+                    shape: shapeB,
+                    labelAlignment: .bottomLeading,
+                    barFraction: bBarFraction
+                )
+                .frame(width: proxy.size.width, height: bHeight)
+                .offset(y: bTop)
+            }
+            .overlay(alignment: .topTrailing) {
+                if diffWithoutColor {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .padding(2)
+                        .accessibilityHidden(true)
+                }
+            }
+            .scrollSafeTapAction {
                 viewModel.presentConflictPicker(
                     courseA: courseA, courseB: courseB,
                     weekday: weekday, periodId: periodId
                 )
-            } label: {
-                ZStack(alignment: .topLeading) {
-                    courseRegion(
-                        course: courseA,
-                        shape: shapeA,
-                        labelAlignment: .topTrailing,
-                        barFraction: aBarFraction
-                    )
-                    .frame(width: proxy.size.width, height: aHeight)
-                    .offset(y: aTop)
-
-                    courseRegion(
-                        course: courseB,
-                        shape: shapeB,
-                        labelAlignment: .bottomLeading,
-                        barFraction: bBarFraction
-                    )
-                    .frame(width: proxy.size.width, height: bHeight)
-                    .offset(y: bTop)
-                }
-                .overlay(alignment: .topTrailing) {
-                    if diffWithoutColor {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.caption2)
-                            .foregroundStyle(.orange)
-                            .padding(2)
-                            .accessibilityHidden(true)
-                    }
-                }
-                // One tap anywhere in the cluster opens the picker; the picker
-                // resolves which course to inspect. Per-shape hit-testing would
-                // bypass the picker entirely, but the Android version still goes
-                // through the sheet so the user can see both options.
-                .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
             .accessibilityLabel(
                 Text("\(String(localized: "a11y_class_table_conflict_prefix")): " +
                      String(format: String(localized: "a11y_timetable_cell"),

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
@@ -37,18 +37,14 @@ struct CourseTimeCard: View {
 
     @ViewBuilder
     private func cardContent(slot: CourseTimeSlot, opacity: Double) -> some View {
-        // The card is a real `Button`, not a `.onTapGesture` surface: inside
-        // Home's ScrollView the button gesture wins iOS 18 arbitration, so the
-        // first tap opens the detail sheet instead of being swallowed. `Button`
-        // supplies the `.isButton` trait automatically, so it's no longer added
-        // by hand on the surface below.
-        Button {
-            onSelect?(slot)
-        } label: {
-            cardSurface(slot: slot, opacity: opacity)
-        }
-        .buttonStyle(.plain)
-        .accessibilityHint(Text(String(localized: "a11y_course_card_open_details_hint")))
+        // `scrollSafeTapAction` wraps the surface in a real `Button` so the
+        // first tap inside Home's ScrollView opens the detail sheet instead of
+        // being swallowed (iOS 18 arbitration). `Button` supplies the
+        // `.isButton` trait and the hit shape, so the surface no longer adds
+        // those by hand.
+        cardSurface(slot: slot, opacity: opacity)
+            .scrollSafeTapAction { onSelect?(slot) }
+            .accessibilityHint(Text(String(localized: "a11y_course_card_open_details_hint")))
     }
 
     @ViewBuilder
@@ -102,7 +98,8 @@ struct CourseTimeCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .modifier(CourseCardSurfaceModifier(tint: course.color, policy: policy))
         .opacity(opacity)
-        .contentShape(Rectangle())
+        // Hit shape + tap handling come from `scrollSafeTapAction` in
+        // `cardContent`, which wraps this surface in a `Button`.
     }
 
     private func subtitle(for course: SDCourse, weekday: Int) -> String {

--- a/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
+++ b/swift/TigerDuck/Features/Home/Components/TimeSlider/CourseTimeCard.swift
@@ -37,6 +37,22 @@ struct CourseTimeCard: View {
 
     @ViewBuilder
     private func cardContent(slot: CourseTimeSlot, opacity: Double) -> some View {
+        // The card is a real `Button`, not a `.onTapGesture` surface: inside
+        // Home's ScrollView the button gesture wins iOS 18 arbitration, so the
+        // first tap opens the detail sheet instead of being swallowed. `Button`
+        // supplies the `.isButton` trait automatically, so it's no longer added
+        // by hand on the surface below.
+        Button {
+            onSelect?(slot)
+        } label: {
+            cardSurface(slot: slot, opacity: opacity)
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint(Text(String(localized: "a11y_course_card_open_details_hint")))
+    }
+
+    @ViewBuilder
+    private func cardSurface(slot: CourseTimeSlot, opacity: Double) -> some View {
         let course = slot.course
         let weekday = slot.date.scheduleWeekday
         let isToday = AppConstants.taipeiCalendar.isDateInToday(slot.date)
@@ -87,9 +103,6 @@ struct CourseTimeCard: View {
         .modifier(CourseCardSurfaceModifier(tint: course.color, policy: policy))
         .opacity(opacity)
         .contentShape(Rectangle())
-        .onTapGesture { onSelect?(slot) }
-        .accessibilityAddTraits(.isButton)
-        .accessibilityHint(Text(String(localized: "a11y_course_card_open_details_hint")))
     }
 
     private func subtitle(for course: SDCourse, weekday: Int) -> String {

--- a/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
+++ b/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
@@ -313,23 +313,30 @@ private struct SwipeableRow<Content: View>: View {
 
     @ViewBuilder
     private var tappableContent: some View {
-        let row = content
-            .contentShape(Rectangle())
-            .offset(x: offset)
-            .gesture(dragGesture)
-            .onTapGesture {
-                if offset != 0 {
-                    snapBack()
-                } else {
-                    onTap()
-                }
-            }
         if let tapHint {
-            row
-                .accessibilityAddTraits(.isButton)
+            // A real `Button` (not `.onTapGesture`) so the first tap wins iOS 18
+            // gesture arbitration against Home's ScrollView instead of needing a
+            // second press; the swipe-to-reveal drag rides alongside via
+            // `.simultaneousGesture` so it isn't blocked. `Button` supplies the
+            // `.isButton` trait automatically.
+            content
+                .offset(x: offset)
+                .scrollSafeTapAction {
+                    if offset != 0 {
+                        snapBack()
+                    } else {
+                        onTap()
+                    }
+                }
+                .simultaneousGesture(dragGesture)
                 .accessibilityHint(Text(tapHint))
         } else {
-            row
+            // No tap destination: keep the row non-interactive (no button trait)
+            // while still swipeable.
+            content
+                .contentShape(Rectangle())
+                .offset(x: offset)
+                .gesture(dragGesture)
         }
     }
 

--- a/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
+++ b/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
@@ -286,8 +286,9 @@ private struct SwipeableRow<Content: View>: View {
     let content: Content
 
     @State private var offset: CGFloat = 0
-    /// Set the instant the drag moves the row, cleared one run-loop turn
-    /// after the drag ends. Owned by `dragGesture`; the tap handler only
+    /// Set the instant the drag moves the row; cleared on the next Button
+    /// press-down (touch-down of the following interaction). Owned by
+    /// `dragGesture` + the tap's `onPressChanged` hook; the tap action only
     /// reads it. See `tappableContent` for why this exists.
     @State private var didSwipe = false
 
@@ -325,15 +326,27 @@ private struct SwipeableRow<Content: View>: View {
             // `.isButton` trait automatically.
             content
                 .offset(x: offset)
-                .scrollSafeTapAction {
-                    // The swipe drag rides alongside via `.simultaneousGesture`,
-                    // so a swipe-release also delivers a Button tap. `didSwipe`
-                    // lets this tap defer to `dragGesture.onEnded`, which is the
-                    // sole owner of the swipe action + snap-back. Reading shared
-                    // `offset` here instead raced: `onEnded` always resets it to
-                    // 0, so the tap and the drag-end could each see the other's
-                    // reset and the row would either skip its swipe action or
-                    // navigate right after performing it.
+                .scrollSafeTapAction(
+                    onPressChanged: { isPressed in
+                        // Touch-down of a fresh interaction clears the swipe
+                        // latch. The Button reports `isPressed == true` before
+                        // it ever delivers its tap action on release, and
+                        // `dragGesture` only sets `didSwipe` once the row moves,
+                        // so the latch always reflects the current interaction
+                        // — no ordering or timer assumptions about when the
+                        // simultaneous tap/drag callbacks fire.
+                        if isPressed { didSwipe = false }
+                    }
+                ) {
+                    // A swipe-release also delivers a Button tap because the
+                    // drag rides alongside via `.simultaneousGesture`. `didSwipe`
+                    // is set the moment the drag moves the row and stays set
+                    // until the next press-down, so this tap reliably bows out
+                    // and lets `dragGesture.onEnded` solely own the swipe action
+                    // + snap-back. Reading shared `offset` here instead raced:
+                    // `onEnded` always resets it to 0, so the tap and the
+                    // drag-end could each see the other's reset and the row would
+                    // either skip its swipe action or navigate right after it.
                     guard !didSwipe else { return }
                     onTap()
                 }
@@ -404,13 +417,10 @@ private struct SwipeableRow<Content: View>: View {
                     action.action()
                 }
                 snapBack()
-                // Clear one run-loop turn later: the spurious Button tap a
-                // swipe-release also delivers fires within this same event turn
-                // and must still see `didSwipe == true`, while the next genuine
-                // tap (a later turn) sees it cleared.
-                if didSwipe {
-                    Task { @MainActor in didSwipe = false }
-                }
+                // `didSwipe` is intentionally NOT cleared here: it must outlive
+                // the simultaneous Button tap this release also delivers, whose
+                // ordering relative to `onEnded` is undefined. The next
+                // interaction's press-down clears it (see `tappableContent`).
             }
     }
 

--- a/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
+++ b/swift/TigerDuck/Features/Home/Components/UpcomingAssignmentsView.swift
@@ -286,6 +286,10 @@ private struct SwipeableRow<Content: View>: View {
     let content: Content
 
     @State private var offset: CGFloat = 0
+    /// Set the instant the drag moves the row, cleared one run-loop turn
+    /// after the drag ends. Owned by `dragGesture`; the tap handler only
+    /// reads it. See `tappableContent` for why this exists.
+    @State private var didSwipe = false
 
     private let triggerThreshold: CGFloat = 96
     private let snapAnimation = Animation.spring(response: 0.32, dampingFraction: 0.78)
@@ -322,11 +326,16 @@ private struct SwipeableRow<Content: View>: View {
             content
                 .offset(x: offset)
                 .scrollSafeTapAction {
-                    if offset != 0 {
-                        snapBack()
-                    } else {
-                        onTap()
-                    }
+                    // The swipe drag rides alongside via `.simultaneousGesture`,
+                    // so a swipe-release also delivers a Button tap. `didSwipe`
+                    // lets this tap defer to `dragGesture.onEnded`, which is the
+                    // sole owner of the swipe action + snap-back. Reading shared
+                    // `offset` here instead raced: `onEnded` always resets it to
+                    // 0, so the tap and the drag-end could each see the other's
+                    // reset and the row would either skip its swipe action or
+                    // navigate right after performing it.
+                    guard !didSwipe else { return }
+                    onTap()
                 }
                 .simultaneousGesture(dragGesture)
                 .accessibilityHint(Text(tapHint))
@@ -379,6 +388,9 @@ private struct SwipeableRow<Content: View>: View {
                 if dx > 0 && leadingAction == nil { return }
                 if dx < 0 && trailingAction == nil { return }
                 offset = dx
+                // Mark the gesture a swipe the moment it moves the row, so the
+                // simultaneous Button tap on release bows out of `onTap()`.
+                didSwipe = true
             }
             .onEnded { _ in
                 // `offset` is only ever mutated by horizontal-intent updates
@@ -392,6 +404,13 @@ private struct SwipeableRow<Content: View>: View {
                     action.action()
                 }
                 snapBack()
+                // Clear one run-loop turn later: the spurious Button tap a
+                // swipe-release also delivers fires within this same event turn
+                // and must still see `didSwipe == true`, while the next genuine
+                // tap (a later turn) sees it cleared.
+                if didSwipe {
+                    Task { @MainActor in didSwipe = false }
+                }
             }
     }
 

--- a/swift/TigerDuck/Features/Home/Components/WidgetGridView.swift
+++ b/swift/TigerDuck/Features/Home/Components/WidgetGridView.swift
@@ -74,23 +74,14 @@ struct WidgetGridView: View {
                     )
                 )
         } else {
-            // A real `Button` (not `.onTapGesture`) is what wins iOS 18 gesture
-            // arbitration against the enclosing ScrollView/LazyVGrid, so the tap
-            // registers on the first press instead of needing a second one. The
-            // edit-mode long-press rides alongside via `.simultaneousGesture` so
-            // it never blocks that tap; `.contentShape` makes the whole card
-            // hittable, including the padding between the icon and the edges.
-            Button { onTap?(widget.feature) } label: {
-                card
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .simultaneousGesture(
-                LongPressGesture(minimumDuration: 0.5)
-                    .onEnded { _ in
-                        withAnimation(reduceMotion ? nil : .smoothSpring) { isEditing = true }
-                    }
-            )
+            // `scrollSafeTapAction` wraps the card in a real `Button` so the tap
+            // wins iOS 18 arbitration against the enclosing ScrollView/LazyVGrid
+            // (registers on the first press, not the second). The edit-mode
+            // long-press rides alongside via `.simultaneousGesture` so it never
+            // blocks that tap. See View+ScrollSafeGesture for the rationale.
+            card
+                .scrollSafeTapAction { onTap?(widget.feature) }
+                .longPressToEdit(reduceMotion: reduceMotion) { isEditing = true }
         }
     }
 

--- a/swift/TigerDuck/Features/Home/Components/WidgetGridView.swift
+++ b/swift/TigerDuck/Features/Home/Components/WidgetGridView.swift
@@ -74,11 +74,23 @@ struct WidgetGridView: View {
                     )
                 )
         } else {
-            card
-                .onTapGesture { onTap?(widget.feature) }
-                .onLongPressGesture {
-                    withAnimation(reduceMotion ? nil : .smoothSpring) { isEditing = true }
-                }
+            // A real `Button` (not `.onTapGesture`) is what wins iOS 18 gesture
+            // arbitration against the enclosing ScrollView/LazyVGrid, so the tap
+            // registers on the first press instead of needing a second one. The
+            // edit-mode long-press rides alongside via `.simultaneousGesture` so
+            // it never blocks that tap; `.contentShape` makes the whole card
+            // hittable, including the padding between the icon and the edges.
+            Button { onTap?(widget.feature) } label: {
+                card
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .simultaneousGesture(
+                LongPressGesture(minimumDuration: 0.5)
+                    .onEnded { _ in
+                        withAnimation(reduceMotion ? nil : .smoothSpring) { isEditing = true }
+                    }
+            )
         }
     }
 

--- a/swift/TigerDuck/Features/Home/HomeView.swift
+++ b/swift/TigerDuck/Features/Home/HomeView.swift
@@ -73,13 +73,21 @@ struct HomeView: View {
                 )
             )
             .contentShape(Rectangle())
-            .onLongPressGesture {
-                if !viewModel.isEditingHome {
-                    withAnimation(reduceMotion ? nil : .smoothSpring) {
-                        viewModel.isEditingHome = true
+            // A plain `.onLongPressGesture` here installs a recognizer over the
+            // whole scroll content that, on iOS 18, competes with every child
+            // tap (widgets, course cards, sections) and eats the *first* tap —
+            // making buttons feel like they need a second press. `.simultaneousGesture`
+            // lets the long-press coexist without blocking those child taps.
+            .simultaneousGesture(
+                LongPressGesture(minimumDuration: 0.5)
+                    .onEnded { _ in
+                        if !viewModel.isEditingHome {
+                            withAnimation(reduceMotion ? nil : .smoothSpring) {
+                                viewModel.isEditingHome = true
+                            }
+                        }
                     }
-                }
-            }
+            )
         }
         .refreshable {
             // Fire-and-forget: the pull gesture should dismiss the

--- a/swift/TigerDuck/Features/Home/HomeView.swift
+++ b/swift/TigerDuck/Features/Home/HomeView.swift
@@ -73,21 +73,14 @@ struct HomeView: View {
                 )
             )
             .contentShape(Rectangle())
-            // A plain `.onLongPressGesture` here installs a recognizer over the
-            // whole scroll content that, on iOS 18, competes with every child
-            // tap (widgets, course cards, sections) and eats the *first* tap —
-            // making buttons feel like they need a second press. `.simultaneousGesture`
-            // lets the long-press coexist without blocking those child taps.
-            .simultaneousGesture(
-                LongPressGesture(minimumDuration: 0.5)
-                    .onEnded { _ in
-                        if !viewModel.isEditingHome {
-                            withAnimation(reduceMotion ? nil : .smoothSpring) {
-                                viewModel.isEditingHome = true
-                            }
-                        }
-                    }
-            )
+            // Long-press anywhere in the scroll content (empty space, section
+            // headers, the course slider) enters edit mode. `longPressToEdit`
+            // attaches it via `.simultaneousGesture` so on iOS 18 it coexists
+            // with — rather than swallows — the first tap on every child
+            // (widgets, course cards). See View+ScrollSafeGesture.
+            .longPressToEdit(reduceMotion: reduceMotion) {
+                if !viewModel.isEditingHome { viewModel.isEditingHome = true }
+            }
         }
         .refreshable {
             // Fire-and-forget: the pull gesture should dismiss the

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -65,12 +65,12 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .contentShape(Rectangle())
         #if canImport(UIKit)
-        // `.simultaneousGesture` (not `.onTapGesture`): a plain tap recognizer on
-        // the page root competes with — and on iOS 18 swallows — taps on the
-        // interactive `Link`s / `Button`s inside `content`, which is what left the
-        // lower welcome-page links (e.g. GitHub) dead. A simultaneous tap still
-        // dismisses the keyboard without blocking those child taps.
-        .simultaneousGesture(TapGesture().onEnded { UIApplication.dismissKeyboard() })
+        // `dismissTapGesture` attaches via `.simultaneousGesture` (not
+        // `.onTapGesture`): a plain tap recognizer on the page root competes
+        // with — and on iOS 18 swallows — taps on the interactive `Link`s /
+        // `Button`s inside `content`, which is what left the lower welcome-page
+        // links (e.g. GitHub) dead. See View+ScrollSafeGesture.
+        .dismissTapGesture { UIApplication.dismissKeyboard() }
         #endif
     }
 

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -65,7 +65,12 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .contentShape(Rectangle())
         #if canImport(UIKit)
-        .onTapGesture { UIApplication.dismissKeyboard() }
+        // `.simultaneousGesture` (not `.onTapGesture`): a plain tap recognizer on
+        // the page root competes with — and on iOS 18 swallows — taps on the
+        // interactive `Link`s / `Button`s inside `content`, which is what left the
+        // lower welcome-page links (e.g. GitHub) dead. A simultaneous tap still
+        // dismisses the keyboard without blocking those child taps.
+        .simultaneousGesture(TapGesture().onEnded { UIApplication.dismissKeyboard() })
         #endif
     }
 

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -100,9 +100,11 @@ struct OnboardingView: View {
                     VStack(spacing: TigerDuckTheme.Spacing.lg) {
                         Link(destination: AppURLs.website) {
                             Label(String(localized: "onboarding_welcome_website_label"), systemImage: "globe")
+                                .frame(maxWidth: .infinity)
                         }
                         Link(destination: AppURLs.github) {
                             Label(String(localized: "onboarding_welcome_github_label"), systemImage: "chevron.left.forwardslash.chevron.right")
+                                .frame(maxWidth: .infinity)
                         }
                     }
                     .buttonStyle(.bordered)

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -4,6 +4,7 @@ import UserNotifications
 struct OnboardingView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.openURL) private var openURL
     @State private var currentPage = 0
     @State private var studentId = ""
     @State private var password = ""
@@ -57,7 +58,10 @@ struct OnboardingView: View {
         // give the user a way to clear the keyboard.
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .contentShape(Rectangle())
-        .onTapGesture { focusedField = nil }
+        // Simultaneous (not `.onTapGesture`) so this keyboard-dismiss tap on the
+        // TabView root doesn't swallow taps on interactive children — see
+        // OnboardingPageView for the iOS 18 gesture-arbitration details.
+        .simultaneousGesture(TapGesture().onEnded { focusedField = nil })
         .onChange(of: currentPage) { _, _ in focusedField = nil }
         .task { await refreshNotificationStatus() }
         .onChange(of: scenePhase) { _, newPhase in
@@ -87,10 +91,24 @@ struct OnboardingView: View {
                         .lineLimit(12)
                         .minimumScaleFactor(0.6)
 
-                    VStack(spacing: TigerDuckTheme.Spacing.md) {
-                        Link(String(localized: "onboarding_welcome_website_label"), destination: AppURLs.website)
-                        Link(String(localized: "onboarding_welcome_github_label"), destination: AppURLs.github)
+                    // Real `Button`s (not `Link`s): a bordered button gives a
+                    // large, reliable hit target and wins iOS 18 gesture
+                    // arbitration against the page's scroll/tap recognizers,
+                    // which made the text `Link`s hard to tap.
+                    VStack(spacing: TigerDuckTheme.Spacing.lg) {
+                        Button {
+                            openURL(AppURLs.website)
+                        } label: {
+                            Label(String(localized: "onboarding_welcome_website_label"), systemImage: "globe")
+                        }
+                        Button {
+                            openURL(AppURLs.github)
+                        } label: {
+                            Label(String(localized: "onboarding_welcome_github_label"), systemImage: "chevron.left.forwardslash.chevron.right")
+                        }
                     }
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
                     .font(.callout.weight(.semibold))
                     .padding(.top, TigerDuckTheme.Spacing.sm)
                 }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -4,7 +4,6 @@ import UserNotifications
 struct OnboardingView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Environment(\.openURL) private var openURL
     @State private var currentPage = 0
     @State private var studentId = ""
     @State private var password = ""
@@ -60,8 +59,8 @@ struct OnboardingView: View {
         .contentShape(Rectangle())
         // Simultaneous (not `.onTapGesture`) so this keyboard-dismiss tap on the
         // TabView root doesn't swallow taps on interactive children — see
-        // OnboardingPageView for the iOS 18 gesture-arbitration details.
-        .simultaneousGesture(TapGesture().onEnded { focusedField = nil })
+        // View+ScrollSafeGesture for the iOS 18 gesture-arbitration details.
+        .dismissTapGesture { focusedField = nil }
         .onChange(of: currentPage) { _, _ in focusedField = nil }
         .task { await refreshNotificationStatus() }
         .onChange(of: scenePhase) { _, newPhase in
@@ -91,19 +90,18 @@ struct OnboardingView: View {
                         .lineLimit(12)
                         .minimumScaleFactor(0.6)
 
-                    // Real `Button`s (not `Link`s): a bordered button gives a
-                    // large, reliable hit target and wins iOS 18 gesture
-                    // arbitration against the page's scroll/tap recognizers,
-                    // which made the text `Link`s hard to tap.
+                    // `Link` (not a bare `Button`) keeps the semantic
+                    // `.isLink` VoiceOver trait and the system URL affordances
+                    // (long-press peek / Copy Link / Share). The bordered,
+                    // large control size gives the reliable hit target the
+                    // plain text links lacked, and now that the page's
+                    // keyboard-dismiss tap is a `.simultaneousGesture` it no
+                    // longer swallows these links' first tap on iOS 18.
                     VStack(spacing: TigerDuckTheme.Spacing.lg) {
-                        Button {
-                            openURL(AppURLs.website)
-                        } label: {
+                        Link(destination: AppURLs.website) {
                             Label(String(localized: "onboarding_welcome_website_label"), systemImage: "globe")
                         }
-                        Button {
-                            openURL(AppURLs.github)
-                        } label: {
+                        Link(destination: AppURLs.github) {
                             Label(String(localized: "onboarding_welcome_github_label"), systemImage: "chevron.left.forwardslash.chevron.right")
                         }
                     }

--- a/swift/TigerDuck/Features/Updates/UpdateNotifyCoordinator.swift
+++ b/swift/TigerDuck/Features/Updates/UpdateNotifyCoordinator.swift
@@ -224,7 +224,7 @@ final class UpdateNotifyCoordinator {
         // throttle / iTunes Lookup so it works even when a recent real
         // check has been throttled.
         if Self.consumeDebugSimulateUpdateFlag() {
-            surfaceSyntheticUpdatePrompt()
+            Task { await surfaceSyntheticUpdatePrompt() }
             return
         }
         #endif
@@ -274,11 +274,23 @@ final class UpdateNotifyCoordinator {
     }
 
     /// Plant a synthetic ``PendingUpdate`` so the regular sheet host
-    /// surfaces the prompt. The URL points at the App Store homepage so
-    /// "Update Now" doesn't 404 on a real device — we don't have a real
-    /// `trackId` to deep-link to during pre-launch debug.
-    private func surfaceSyntheticUpdatePrompt() {
-        guard let url = URL(string: "https://apps.apple.com/") else { return }
+    /// surfaces the prompt. Now that the app is published, resolve the
+    /// real App Store deep link through the same iTunes Lookup the
+    /// production path uses, so the debug prompt's "Update Now" opens the
+    /// actual product page instead of the App Store homepage. Falls back
+    /// to the homepage only if the lookup can't be reached (offline, or
+    /// no public record yet).
+    private func surfaceSyntheticUpdatePrompt() async {
+        let appStoreURL: URL
+        if case .found(let lookup)? = try? await AppStoreUpdateService.fetchLatest(
+            bundleId: bundleId,
+            session: session,
+            country: AppConstants.appStoreLookupStorefront
+        ) {
+            appStoreURL = URL.knownGoodAppStoreLink(trackId: lookup.trackId)
+        } else {
+            appStoreURL = URL(string: "https://apps.apple.com/")!
+        }
         // "99.0.0" is the sentinel version surfaced in the debug update
         // prompt. Picked to be unambiguously larger than any shipping
         // TigerDuck version for the foreseeable future, so:
@@ -289,7 +301,7 @@ final class UpdateNotifyCoordinator {
         //   2. The version string reads as "obviously not a real
         //      release" on screen, so the debug-triggered prompt is
         //      visually distinguishable from a real available update.
-        pendingUpdate = PendingUpdate(latestVersion: "99.0.0", appStoreURL: url)
+        pendingUpdate = PendingUpdate(latestVersion: "99.0.0", appStoreURL: appStoreURL)
     }
     #endif
 

--- a/swift/TigerDuck/Services/API/Library/LibraryService.swift
+++ b/swift/TigerDuck/Services/API/Library/LibraryService.swift
@@ -168,7 +168,7 @@ enum LibraryService {
                 throw error
             }
 
-            await saveCredentials(username: username, password: password)
+            saveCredentials(username: username, password: password)
             saveToken(loginData.token, expirationMs: loginData.expirationTimeStamp)
             return loginData.token
         } catch {

--- a/swift/TigerDuck/Services/Push/PushCoordinator.swift
+++ b/swift/TigerDuck/Services/Push/PushCoordinator.swift
@@ -59,7 +59,11 @@ final class PushCoordinator {
         self.apiClient = resolvedClient
         self.registration = PushRegistrationService(
             identity: identity,
-            apiClient: resolvedClient
+            apiClient: resolvedClient,
+            // Evaluated here in `PushCoordinator`'s `@MainActor` init so the
+            // `@MainActor` `resolvedForBuild` (reads `UIDevice.current`) is
+            // reached from the main actor.
+            deviceClass: PushDeviceClass.resolvedForBuild
         )
         self.relay = PushTokenRelay(registration: registration)
         self.scheduleSync = ScheduleSyncService(

--- a/swift/TigerDuck/Services/Push/PushRegistrationService.swift
+++ b/swift/TigerDuck/Services/Push/PushRegistrationService.swift
@@ -36,6 +36,11 @@ nonisolated enum PushAPNsEnv {
 /// targeting (iPhone vs iPad vs Mac) without needing the backend to
 /// re-parse build metadata.
 nonisolated enum PushDeviceClass {
+    // `@MainActor`: reading `UIDevice.current.userInterfaceIdiom` requires the
+    // main actor. The only caller is `PushRegistrationService.init`'s default
+    // argument, which is evaluated at the `@MainActor` `PushCoordinator.init`
+    // call site, so the isolation requirement is always satisfied.
+    @MainActor
     static var resolvedForBuild: String {
         #if os(macOS)
         return "mac"
@@ -100,7 +105,11 @@ actor PushRegistrationService {
         bundleId: String = "org.ntust.app.TigerDuck",
         attrsType: String = "TigerDuckActivityAttributes",
         apnsEnv: String = PushAPNsEnv.resolvedForBuild,
-        deviceClass: String = PushDeviceClass.resolvedForBuild
+        // No default: `PushDeviceClass.resolvedForBuild` is `@MainActor` (it
+        // reads `UIDevice.current`), and an actor init's default-argument
+        // expressions are evaluated in a nonisolated context. Callers pass it
+        // from their own (MainActor) context instead.
+        deviceClass: String
     ) {
         self.identity = identity
         self.apiClient = apiClient

--- a/swift/TigerDuck/Shared/CourseCardFontScale.swift
+++ b/swift/TigerDuck/Shared/CourseCardFontScale.swift
@@ -33,7 +33,12 @@ import SwiftUI
 /// become unreadable inside the timetable cells, above 1.6× they overflow
 /// the cell before `minimumScaleFactor` rescues them — at which point the
 /// user is fighting the layout, not customizing it.
-enum CourseCardFontScale {
+// `nonisolated` because every member is a pure constant or pure function
+// (no actor state). Without it, the project's `SWIFT_DEFAULT_ACTOR_ISOLATION
+// = MainActor` makes the enum MainActor-isolated, which then can't be read
+// from the `nonisolated` `CourseCardFontScaleStore` below (or the widget
+// extension, which compiles without the MainActor default).
+nonisolated enum CourseCardFontScale {
     /// Inclusive bounds the slider operates over. Out-of-range stored
     /// values are clamped on read so a manually-edited UserDefaults value
     /// can never escape this range.


### PR DESCRIPTION
## Summary

Fixes iOS 18 / iPadOS 18 gesture-arbitration regressions where the enclosing scroll view swallowed the **first tap** on interactive content, plus a set of related fixes surfaced while reviewing the branch against `dev`.

## Changes

### iOS 18 gesture arbitration (the core fix)
- New `Extensions/View+ScrollSafeGesture.swift` centralizes the workaround in three reusable helpers — `scrollSafeTapAction` (wrap a tap target in a real `Button` so it wins arbitration), `longPressToEdit` and `dismissTapGesture` (whole-view recognizers via `.simultaneousGesture` so they don't eat child taps).
- Adopted across **Home** (`CourseTimeCard`, `WidgetGridView`, `HomeView`), **ClassTable** (`TimetableGridView` solo + conflict cells), and **Onboarding** (`OnboardingView`, `OnboardingPageView`), replacing per-site `.onTapGesture` / hand-rolled `Button` copies.
- `UpcomingAssignmentsView`: the swipeable assignment row now uses a real `Button` for its tap (swipe drag rides alongside via `.simultaneousGesture`); rows with no destination stay non-interactive — first tap no longer needs a second press.

### Onboarding
- Welcome-page links restored to `Link` (keeps the `.isLink` VoiceOver trait + system link affordances) with bordered/large styling, and the two links are now **equal width** (`.frame(maxWidth: .infinity)`).

### Concurrency warnings (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`)
- `CourseCardFontScale`: marked the pure-constant enum `nonisolated` so the `nonisolated` store (and widget extension) can read it.
- `PushDeviceClass.resolvedForBuild`: marked `@MainActor` (it reads `UIDevice.current`) and `deviceClass` is now passed explicitly from the `@MainActor` `PushCoordinator.init` rather than via an actor-init default arg.
- `LibraryService.login`: dropped the now-redundant `await` on `saveCredentials` (MainActor-default isolation makes `login` `@MainActor`, so there is no hop).

### Updates
- Debug-only simulated update prompt now deep-links "Update Now" to the **real App Store product page** (resolves `trackId` via the live iTunes Lookup), instead of the App Store homepage. Falls back to the homepage only when offline.

## Verification
`xcodebuild` BUILD SUCCEEDED with **0 warnings** for `TigerDuck` (iOS), `TigerDuckWidgetsExtension` (iOS), and `TigerDuckWatch Watch App` (watchOS).