### PR TITLE
feat(Home,ClassTable): gate today-scoped surfaces on a hard-coded term window

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 <br>
 
 [![License](https://img.shields.io/github/license/tigerduck-app/tigerduck-app?style=for-the-badge)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v1.7.1-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.7.1)
+[![Version](https://img.shields.io/badge/Version-v1.7.2-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.7.2)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/ios)
 
 [![TestFlight](https://img.shields.io/badge/TestFlight-Join-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/eVt9Gjkw)
@@ -85,6 +85,7 @@ Ever used [TAT](https://github.com/morris13579/tat_ntust)? We're working hard ma
 
 | Version | Date | Highlights |
 |:---:|:---:|---|
+| **`v1.7.2`** | 2026-08-20 | 📋 **Term-window gating** — Home's time slider and the class table's today carousel appear only while classes are in session (2026-09-07 – 2026-12-25), so neither shows a blank or wrong-term day outside it; the current term is pinned to 115-1 |
 | **`v1.7.1`** | 2026-08-20 | 📋 **Class-table semester fixes** — the semester list now comes from the university's course-query API, so a term released early (115-1) is selectable right away; 選課 enrolments are filed under the term that system actually has open, so 114-2 and 115-1 no longer render into one grid; the picker reopens on your last pick, or the newest term if you never picked one; one-shot clear of course caches written under the wrong term |
 | **`v1.7.0`** | 2026-05-18 | 🔔 **Apple Watch app launch** — Library QR as the leftmost tab, WatchConnectivity credential push, fullscreen QR + idle-fade page dots, localized QR-page strings; macOS dashboard and class-table unified through `CanonicalCourseProvider`, longer next-class time range; Home / class-table card rows lock to the tallest seen, conflicting (衝堂) classes laid out side-by-side at their own offsets; max screen brightness while Library QR is shown; onboarding keyboard anchoring + post-grant push enablement fixes; backend split into a dedicated `tigerduck-backend` repo; bumped to Xcode 26.4 with Swift 6 strict concurrency clean |
 | **`v1.6.1`** | 2026-05-01 | 🤖 **Android FCM push delivery** (groundwork for the Android client; batched fan-out, bad-token classification), API base path bumped from `/v1` to `/v2` (`/v1` kept as deprecated alias), iOS device registration now reports `platform=apple` |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <br>
 
 [![License](https://img.shields.io/github/license/tigerduck-app/tigerduck-app?style=for-the-badge)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v1.7.1-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.7.1)
+[![Version](https://img.shields.io/badge/Version-v1.7.2-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.7.2)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/ios)
 
 [![TestFlight](https://img.shields.io/badge/TestFlight-Join-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/eVt9Gjkw)
@@ -86,6 +86,7 @@ TigerDuck 是由一群學生共同開發的校園助手
 
 | 版本 | 日期 | 重點 |
 |:---:|:---:|---|
+| **`v1.7.2`** | 2026-08-20 | 📋 **學期期間限定顯示** — 首頁「時光機」與課表「今日課程」只在學期內（2026-09-07 ~ 2026-12-25）出現，開學前後不再顯示空白或錯期的當日課表；當前學期一律標示為 115-1 |
 | **`v1.7.1`** | 2026-08-20 | 📋 **課表學期修正** — 學期清單改由學校課程查詢 API 供應，學校提前釋出的 115-1 立刻可選；選課系統的選課清單改依「實際開放中的學期」歸戶，114-2 與 115-1 不再疊進同一張課表；學期選單預設沿用上次選取，從未選過則落在最新學期；一次性清掉舊版寫錯學期的課程快取 |
 | **`v1.7.0`** | 2026-05-18 | 🔔 **Apple Watch App 上線** — Library QR 作為左側分頁、WatchConnectivity 即時推送憑證、全螢幕 QR 與閒置淡出頁碼、QR 頁面字串在地化；macOS 儀表板與課表統一走 `CanonicalCourseProvider`、下一堂課時間區間加長；Home / 課表卡片等高鎖定、衝堂並排顯示各自時段；圖書館 QR 顯示時自動最大亮度；Onboarding 登入鍵盤錨點與授權後推播啟用修正；後端拆出獨立 `tigerduck-backend` repo；升級至 Xcode 26.4、Swift 6 strict concurrency 全綠 |
 | **`v1.6.1`** | 2026-05-01 | 🤖 **Android FCM 推播通道**（為 Android 版鋪路、批次 fan-out、bad-token 分類）、API base path 從 `/v1` 升 `/v2`（`/v1` 保留為 deprecated alias）、iOS 註冊裝置帶 `platform=apple` |

--- a/swift/TigerDuck.xcodeproj/project.pbxproj
+++ b/swift/TigerDuck.xcodeproj/project.pbxproj
@@ -1151,7 +1151,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1325,7 +1325,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1469,7 +1469,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.TigerDuckLiveActivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1506,7 +1506,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.TigerDuckLiveActivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1544,7 +1544,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1581,7 +1581,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1724,7 +1724,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1770,7 +1770,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.7.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/swift/TigerDuck/App/AppConstants.swift
+++ b/swift/TigerDuck/App/AppConstants.swift
@@ -36,6 +36,47 @@ nonisolated enum AppConstants {
         return cal
     }()
 
+    /// The academic term the app currently considers "now".
+    ///
+    /// ponytail: hard-coded. Nothing in the app knows when classes actually
+    /// start or end — `CourseSelectionService.currentSemesterCode()` is a
+    /// month heuristic that only guesses the *term code*, and the semester
+    /// catalogue reports which term 選課 has open, which runs weeks ahead of
+    /// the term in session. Swap `code`/`start`/`end` for the academic
+    /// calendar feed (`CalendarService` already fetches the ICS that carries
+    /// 開學/結業) when that lands; every consumer reads `code` or
+    /// `isInSession` and needs no change.
+    enum CurrentTerm {
+        /// 115 學年度第 1 學期.
+        static let code = "1151"
+
+        /// First day of classes, Taipei wall time.
+        static let start = taipeiDate(year: 2026, month: 9, day: 7)
+        /// Exclusive upper bound — the day *after* the last day of classes,
+        /// so 2026-12-25 counts as in session right up to midnight.
+        static let end = taipeiDate(year: 2026, month: 12, day: 26)
+
+        /// True while classes are in session.
+        ///
+        /// Gates the "today"-scoped surfaces — Home's time slider and the
+        /// class table's today carousel — which outside the term would
+        /// either sit empty or scrub a day that has no classes.
+        static var isInSession: Bool {
+            let now = AppClock.now()
+            return now >= start && now < end
+        }
+
+        /// Fails closed: an unbuildable date lands in the distant future, so
+        /// `isInSession` reads false rather than true-forever.
+        private static func taipeiDate(year: Int, month: Int, day: Int) -> Date {
+            var components = DateComponents()
+            components.year = year
+            components.month = month
+            components.day = day
+            return AppConstants.taipeiCalendar.date(from: components) ?? .distantFuture
+        }
+    }
+
     static let dataDidUpdate = Notification.Name("TigerDuck.dataDidUpdate")
     static let liveActivityPreferencesDidChange = Notification.Name("TigerDuck.liveActivityPreferencesDidChange")
     static let languageDidChange = Notification.Name("TigerDuck.languageDidChange")

--- a/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
@@ -302,6 +302,10 @@ final class ClassTableViewModel {
         // dependency tracking aware of debug-time-override flips.
         _ = AppClockState.shared.version
         _ = minuteTicker.tick
+        // ponytail: outside the term there is no "today" worth showing —
+        // the carousel would either be empty or surface a stale day. Empty
+        // here also hides the section, which keys off `todayCourses.isEmpty`.
+        guard AppConstants.CurrentTerm.isInSession else { return [] }
         return currentSemesterCourses.coursesForToday()
     }
 

--- a/swift/TigerDuck/Features/Home/HomeView.swift
+++ b/swift/TigerDuck/Features/Home/HomeView.swift
@@ -13,11 +13,22 @@ struct HomeView: View {
     @State private var activeSectionDrag: ReorderDragPayload?
     @State private var didReorderSection = false
 
+    /// Slow pulse so the term gate below flips on its own when wall-clock
+    /// time crosses `CurrentTerm.start` / `.end` while Home stays mounted.
+    /// `content` already reads `AppClockState.version`, which covers debug
+    /// clock overrides, but ordinary time passing invalidates nothing —
+    /// `AppClock.now()` is an untracked side-effect as far as Observation is
+    /// concerned. Both boundaries land at midnight, so a minute of latency is
+    /// ample and 60s keeps this far cheaper than the 5s default the today
+    /// carousel needs.
+    @State private var termTicker = MinuteTicker(interval: 60)
+
     /// ponytail: Home's time slider is a "today" surface, so it is dropped
     /// outside the term rather than left to scrub a day with no classes.
     /// Reorder and drag are unaffected — everything downstream keys off
     /// `section.id`, never this array's indices.
     private var visibleSections: [HomeSection] {
+        _ = termTicker.tick
         guard !AppConstants.CurrentTerm.isInSession else { return viewModel.sections }
         return viewModel.sections.filter { $0.type != .todayCourses }
     }

--- a/swift/TigerDuck/Features/Home/HomeView.swift
+++ b/swift/TigerDuck/Features/Home/HomeView.swift
@@ -13,6 +13,15 @@ struct HomeView: View {
     @State private var activeSectionDrag: ReorderDragPayload?
     @State private var didReorderSection = false
 
+    /// ponytail: Home's time slider is a "today" surface, so it is dropped
+    /// outside the term rather than left to scrub a day with no classes.
+    /// Reorder and drag are unaffected — everything downstream keys off
+    /// `section.id`, never this array's indices.
+    private var visibleSections: [HomeSection] {
+        guard !AppConstants.CurrentTerm.isInSession else { return viewModel.sections }
+        return viewModel.sections.filter { $0.type != .todayCourses }
+    }
+
     var body: some View {
         if embedded {
             content
@@ -56,7 +65,7 @@ struct HomeView: View {
                 }
 
                 // Sections
-                ForEach(viewModel.sections) { section in
+                ForEach(visibleSections) { section in
                     sectionCell(section)
                 }
             }

--- a/swift/TigerDuck/Services/API/NTUST/CourseSelectionService.swift
+++ b/swift/TigerDuck/Services/API/NTUST/CourseSelectionService.swift
@@ -162,6 +162,16 @@ enum CourseSelectionService {
     /// During those windows callers may briefly see the previous term's
     /// data; if precision is required, prefer a server-driven term code.
     nonisolated static func currentSemesterCode() -> String {
+        // ponytail: pinned to the hard-coded term. The heuristic below still
+        // says 114-2 through August, which mislabels the 115-1 term the
+        // school opened early. Delete this line to hand control back to
+        // `heuristicSemesterCode()`, which is left intact below.
+        AppConstants.CurrentTerm.code
+    }
+
+    /// The month-based guess `currentSemesterCode()` used before it was
+    /// pinned. Kept so lifting the pin is a one-line change.
+    nonisolated static func heuristicSemesterCode() -> String {
         // Pin to gregorian — Calendar.current returns ROC/Buddhist-era
         // years on a TW device and would shift the rocYear math.
         let cal = Calendar(identifier: .gregorian)


### PR DESCRIPTION
## What

Adds `AppConstants.CurrentTerm` — one place holding the 115-1 term:

```swift
static let code  = "1151"
static let start = taipeiDate(year: 2026, month: 9,  day: 7)
static let end   = taipeiDate(year: 2026, month: 12, day: 26)   // exclusive
static var isInSession: Bool { let now = AppClock.now(); return now >= start && now < end }
```

`end` is 12/26 exclusive so 12/25 counts as in session right up to midnight. Dates are built through `AppConstants.taipeiCalendar` and the check reads `AppClock.now()` rather than `Date()`, so it honours Taipei wall time and the debug clock override.

## Why hard-coded

Deliberate, and marked as such. Nothing in the app knows when classes actually start or end:

- `CourseSelectionService.currentSemesterCode()` only guesses a term **code** from the gregorian month — it has no notion of the first or last day of classes, and through August it still says 114-2.
- `SemesterCatalog.selectionSemesterCode()` reports which term 選課 has **open**, which runs weeks ahead of the term in session.

`CalendarService` already fetches the ICS carrying 開學/結業, so that is the natural source when this goes dynamic. Every consumer reads `code` or `isInSession`, so none of them change when it does.

## Wiring

- **`currentSemesterCode()` returns the pinned code.** Single lever — today's courses, Live Activity, widget snapshots, cache keys and the picker fallback all agree on 115-1 instead of the heuristic's stale 114-2. The old body survives verbatim as `heuristicSemesterCode()`, so lifting the pin is deleting one line.
- **`ClassTableViewModel.todayCourses` returns `[]` out of term.** The section already keys off `todayCourses.isEmpty`, so it hides itself.
- **`HomeView.visibleSections` filters out `.todayCourses` out of term.** Filtering the display rather than blanking the cell avoids an empty gap; reorder and drag are unaffected because everything downstream keys off `section.id`, not this array's indices.

The window fails closed: an unbuildable date lands in `.distantFuture`, so `isInSession` reads false rather than true forever.

## Scope

macOS is untouched. Its Home「今日課程」section wraps `MacHomeWidgetsRow` — a quick-widgets row, not a time slider — and the Mac class table has no today section.

## Version

`MARKETING_VERSION` 1.7.1 → 1.7.2. `CURRENT_PROJECT_VERSION` stays at 2: with the marketing version moving, `version-bumped` no longer requires a build tick, and 1.7.2 (2) is still unique in App Store Connect.

## Test plan

- [x] macOS builds clean — covers `AppConstants` and `CourseSelectionService`.
- [x] `ClassTableViewModel` type-checks (temporarily added to the macOS `INCLUDED_SOURCE_FILE_NAMES` allowlist, then reverted; pbxproj is back to its committed state).
- [ ] `HomeView` is **not** compiled locally — pulling it into the macOS target cascades on ~19 iOS-only symbols it depends on. The change there is four lines using `$0.type != .todayCourses`, the same construct already at its line 355. Xcode Cloud is the first real check.
- [ ] Before 2026-09-07: Home shows no time slider, class table shows no today carousel, picker reads 115-1.
- [ ] On/after 2026-09-07: both reappear.
- [ ] Debug clock override past 2026-12-25 hides both again.