### PR TITLE
fix(ClassTable): scope manually-added courses to the semester they were added in

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 <br>
 
 [![License](https://img.shields.io/github/license/tigerduck-app/tigerduck-app?style=for-the-badge)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v1.7.2-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.7.2)
+[![Version](https://img.shields.io/badge/Version-v1.7.3-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.7.3)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/ios)
 
 [![TestFlight](https://img.shields.io/badge/TestFlight-Join-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/eVt9Gjkw)
@@ -85,6 +85,7 @@ Ever used [TAT](https://github.com/morris13579/tat_ntust)? We're working hard ma
 
 | Version | Date | Highlights |
 |:---:|:---:|---|
+| **`v1.7.3`** | 2026-08-20 | Manually added courses stay in the semester they were added to — they previously showed up in every semester's timetable, Home and widgets |
 | **`v1.7.2`** | 2026-08-20 | 📋 **Term-window gating** — Home's time slider and the class table's today carousel appear only while classes are in session (2026-09-07 – 2026-12-25), so neither shows a blank or wrong-term day outside it; the current term is pinned to 115-1 |
 | **`v1.7.1`** | 2026-08-20 | 📋 **Class-table semester fixes** — the semester list now comes from the university's course-query API, so a term released early (115-1) is selectable right away; 選課 enrolments are filed under the term that system actually has open, so 114-2 and 115-1 no longer render into one grid; the picker reopens on your last pick, or the newest term if you never picked one; one-shot clear of course caches written under the wrong term |
 | **`v1.7.0`** | 2026-05-18 | 🔔 **Apple Watch app launch** — Library QR as the leftmost tab, WatchConnectivity credential push, fullscreen QR + idle-fade page dots, localized QR-page strings; macOS dashboard and class-table unified through `CanonicalCourseProvider`, longer next-class time range; Home / class-table card rows lock to the tallest seen, conflicting (衝堂) classes laid out side-by-side at their own offsets; max screen brightness while Library QR is shown; onboarding keyboard anchoring + post-grant push enablement fixes; backend split into a dedicated `tigerduck-backend` repo; bumped to Xcode 26.4 with Swift 6 strict concurrency clean |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <br>
 
 [![License](https://img.shields.io/github/license/tigerduck-app/tigerduck-app?style=for-the-badge)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v1.7.2-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.7.2)
+[![Version](https://img.shields.io/badge/Version-v1.7.3-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.7.3)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/ios)
 
 [![TestFlight](https://img.shields.io/badge/TestFlight-Join-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/eVt9Gjkw)
@@ -86,6 +86,7 @@ TigerDuck 是由一群學生共同開發的校園助手
 
 | 版本 | 日期 | 重點 |
 |:---:|:---:|---|
+| **`v1.7.3`** | 2026-08-20 | 手動加入的課程只留在加入時所選的學期 — 先前會同時出現在每個學期的課表、首頁與小工具中 |
 | **`v1.7.2`** | 2026-08-20 | 📋 **學期期間限定顯示** — 首頁「時光機」與課表「今日課程」只在學期內（2026-09-07 ~ 2026-12-25）出現，開學前後不再顯示空白或錯期的當日課表；當前學期一律標示為 115-1 |
 | **`v1.7.1`** | 2026-08-20 | 📋 **課表學期修正** — 學期清單改由學校課程查詢 API 供應，學校提前釋出的 115-1 立刻可選；選課系統的選課清單改依「實際開放中的學期」歸戶，114-2 與 115-1 不再疊進同一張課表；學期選單預設沿用上次選取，從未選過則落在最新學期；一次性清掉舊版寫錯學期的課程快取 |
 | **`v1.7.0`** | 2026-05-18 | 🔔 **Apple Watch App 上線** — Library QR 作為左側分頁、WatchConnectivity 即時推送憑證、全螢幕 QR 與閒置淡出頁碼、QR 頁面字串在地化；macOS 儀表板與課表統一走 `CanonicalCourseProvider`、下一堂課時間區間加長；Home / 課表卡片等高鎖定、衝堂並排顯示各自時段；圖書館 QR 顯示時自動最大亮度；Onboarding 登入鍵盤錨點與授權後推播啟用修正；後端拆出獨立 `tigerduck-backend` repo；升級至 Xcode 26.4、Swift 6 strict concurrency 全綠 |

--- a/swift/TigerDuck.xcodeproj/project.pbxproj
+++ b/swift/TigerDuck.xcodeproj/project.pbxproj
@@ -1151,7 +1151,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1325,7 +1325,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1469,7 +1469,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.TigerDuckLiveActivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1506,7 +1506,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.TigerDuckLiveActivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1544,7 +1544,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1581,7 +1581,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1724,7 +1724,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1770,7 +1770,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.7.2;
+				MARKETING_VERSION = 1.7.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
@@ -100,7 +100,7 @@ final class ClassTableViewModel {
         )
         await MainActor.run { [weak self] in
             guard let self, self.currentSemester == target else { return }
-            let userAdded = DataCache.shared.loadUserAddedCourses()
+            let userAdded = DataCache.shared.loadUserAddedCourses(semester: target)
             let merged = self.buildCourseList(fresh, userAdded)
             // Silent overwrite: only swap in-memory list when content actually
             // changed, so SwiftUI doesn't churn on identical data.
@@ -233,7 +233,7 @@ final class ClassTableViewModel {
         reloadCurrentSemesterCourses()
         courses = buildCourseList(
             DataCache.shared.loadCourses(semester: currentSemester),
-            DataCache.shared.loadUserAddedCourses()
+            DataCache.shared.loadUserAddedCourses(semester: currentSemester)
         )
         assignments = DataCache.shared.loadAssignments()
     }
@@ -683,9 +683,24 @@ final class ClassTableViewModel {
         return true
     }
 
+    /// Replaces only `currentSemester`'s slice of the user-added store.
+    ///
+    /// `courses` holds one semester, so writing it wholesale — which this
+    /// used to do — drops every other semester's manual additions the moment
+    /// the user adds or removes one here. That stayed invisible while the
+    /// merge surfaced all semesters' rows in every timetable; scoping the
+    /// merge is what makes the wholesale write destructive.
     private func persistUserAddedCourses() {
-        let userAdded = courses.filter { $0.moodleIdNumber == nil }
-        DataCache.shared.saveUserAddedCourses(userAdded)
+        let mine = courses.filter { $0.moodleIdNumber == nil }
+        // Stamp rows that predate per-semester tracking with the semester
+        // they are being shown in, so they stop leaking into all of them.
+        for course in mine where course.semester.isEmpty {
+            course.semester = currentSemester
+        }
+        let others = DataCache.shared.loadUserAddedCourses().filter {
+            !DataCache.userAddedCourse($0, belongsTo: currentSemester)
+        }
+        DataCache.shared.saveUserAddedCourses(others + mine)
     }
 
     private func applyCustomizations(_ courses: inout [SDCourse]) {
@@ -801,7 +816,7 @@ final class ClassTableViewModel {
         let cachedAssignments = DataCache.shared.loadAssignments()
         let merged = buildCourseList(
             DataCache.shared.loadCourses(semester: currentSemester),
-            DataCache.shared.loadUserAddedCourses()
+            DataCache.shared.loadUserAddedCourses(semester: currentSemester)
         )
         reloadCurrentSemesterCourses()
         assignments = cachedAssignments
@@ -835,7 +850,7 @@ final class ClassTableViewModel {
                 )
                 await MainActor.run { [weak self] in
                     guard let self else { return }
-                    let userAdded = DataCache.shared.loadUserAddedCourses()
+                    let userAdded = DataCache.shared.loadUserAddedCourses(semester: latestSemester)
                     self.currentSemesterCourses = self.buildCourseList(latestCourses, userAdded)
                     self.refreshCourseColors()
                 }
@@ -865,7 +880,7 @@ final class ClassTableViewModel {
         let fetchedCourses = await coursesTask
         let fetchedAssignments = await assignmentsTask
 
-        let userAdded = DataCache.shared.loadUserAddedCourses()
+        let userAdded = DataCache.shared.loadUserAddedCourses(semester: targetSemester)
 
         await MainActor.run {
             isUpdatingFromNetwork = true

--- a/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
+++ b/swift/TigerDuck/Features/ClassTable/ClassTableViewModel.swift
@@ -697,8 +697,18 @@ final class ClassTableViewModel {
         for course in mine where course.semester.isEmpty {
             course.semester = currentSemester
         }
-        let others = DataCache.shared.loadUserAddedCourses().filter {
-            !DataCache.userAddedCourse($0, belongsTo: currentSemester)
+        // Keep everything `mine` does not stand in for. An unstamped row is
+        // only replaced when it actually surfaced here — `mergeWithUserAdded`
+        // drops a manual row whose courseNo a fetched course already owns, so
+        // matching it on semester alone would erase it from the store, and
+        // with no semester recorded there is no other slice it could return
+        // in. A row stamped for this semester is replaced unconditionally:
+        // that is how a delete removes it.
+        let survivingNos = Set(mine.map(\.courseNo))
+        let others = DataCache.shared.loadUserAddedCourses().filter { stored in
+            if stored.semester == currentSemester { return false }
+            if stored.semester.isEmpty { return !survivingNos.contains(stored.courseNo) }
+            return true
         }
         DataCache.shared.saveUserAddedCourses(others + mine)
     }

--- a/swift/TigerDuck/LiveActivity/Providers/CanonicalCourseProvider.swift
+++ b/swift/TigerDuck/LiveActivity/Providers/CanonicalCourseProvider.swift
@@ -20,7 +20,7 @@ struct CanonicalCourseProvider {
     func currentCourses() -> [SDCourse] {
         Self.merge(
             primary: cache.loadCourses(semester: CourseSelectionService.currentSemesterCode()),
-            userAdded: cache.loadUserAddedCourses(),
+            userAdded: cache.loadUserAddedCourses(semester: CourseSelectionService.currentSemesterCode()),
             deletedCourseNos: Set(cache.loadDeletedCourseNos()),
             customNames: cache.loadCourseCustomNames()
         )

--- a/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacClassTableView.swift
@@ -90,8 +90,7 @@ struct MacClassTableView: View {
         // the live `CourseSelectionService` semester) — feed the static
         // `merge` directly with per-semester inputs instead.
         let cached = DataCache.shared.loadCourses(semester: selectedSemester)
-        let userAdded = DataCache.shared.loadUserAddedCourses()
-            .filter { $0.semester == selectedSemester || $0.semester.isEmpty }
+        let userAdded = DataCache.shared.loadUserAddedCourses(semester: selectedSemester)
         return CanonicalCourseProvider.merge(
             primary: cached,
             userAdded: userAdded,

--- a/swift/TigerDuck/Services/Core/DataCache.swift
+++ b/swift/TigerDuck/Services/Core/DataCache.swift
@@ -82,6 +82,26 @@ final class DataCache {
         save(dtos, to: "user_added_courses.json", in: persistentDir)
     }
 
+    /// Whether a manually-added course belongs to `semester`.
+    ///
+    /// An empty semester predates per-semester stamping. Those are surfaced
+    /// in every semester rather than dropped — losing a course the user
+    /// typed in by hand is worse than showing it twice — and
+    /// `ClassTableViewModel.persistUserAddedCourses` stamps them on the next
+    /// write so they settle into one term.
+    static func userAddedCourse(_ course: SDCourse, belongsTo semester: String) -> Bool {
+        course.semester == semester || course.semester.isEmpty
+    }
+
+    /// User-added courses scoped to one semester.
+    ///
+    /// A manually-added course lives in the semester it was added to. The
+    /// unscoped overload returns every semester's rows and is only correct
+    /// for maintenance sweeps that walk them all (relabel, rename).
+    func loadUserAddedCourses(semester: String) -> [SDCourse] {
+        loadUserAddedCourses().filter { Self.userAddedCourse($0, belongsTo: semester) }
+    }
+
     func loadUserAddedCourses() -> [SDCourse] {
         let dtos: [CachedCourse] = load(from: "user_added_courses.json", in: persistentDir) ?? []
         let customNames = loadCourseCustomNames()


### PR DESCRIPTION
## Problem

A course added by hand appeared in **every** semester's timetable, not just the one it was added to.

The iOS merge appended the whole user-added store with no semester check:

```swift
for course in userAdded where !merged.contains(where: { $0.courseNo == course.courseNo }) {
    merged.append(course)
}
```

macOS already filtered by `selectedSemester`, so this was iOS-only — plus `CanonicalCourseProvider`, which feeds Home, the widgets and Live Activity.

## Why filtering alone would have made it worse

`persistUserAddedCourses()` rewrote the **entire** store from `courses`, which only ever holds one semester:

```swift
let userAdded = courses.filter { $0.moodleIdNumber == nil }
DataCache.shared.saveUserAddedCourses(userAdded)      // whole-store overwrite
```

That was harmless *only because* the broken merge put every semester's rows on screen, so the overwrite happened to write them all back. Scope the merge and the same line turns destructive: adding one course in 115-1 would silently delete everything manually added to 114-2.

So both halves move together — reads are scoped, and the write replaces only the current semester's slice.

## Changes

- `DataCache.loadUserAddedCourses(semester:)`, plus a shared `userAddedCourse(_:belongsTo:)` predicate. That rule had four inline copies (iOS merge, Mac read, Mac remove, score sheet) and they had already drifted — the iOS one had no filter at all. The Mac read now routes through it; the Mac remove and score-sheet copies are already correct and left alone.
- Every iOS read path scoped to the semester it is building: cache reload, initial load, pull-to-refresh, silent refresh, live-semester catch-up.
- `CanonicalCourseProvider` scoped to `currentSemesterCode()`, so Home / widgets / Live Activity stop inheriting other semesters' manual rows.
- `persistUserAddedCourses` replaces one slice instead of the whole store.

Rows with an empty semester predate per-semester stamping. They still surface in every semester rather than vanishing — losing a hand-typed course is worse than showing it twice — and the next write stamps them with the semester they are displayed in so they settle into one term.

## Version

`MARKETING_VERSION` 1.7.2 → 1.7.3. `CURRENT_PROJECT_VERSION` stays at 2: the marketing move satisfies `version-bumped` on its own, and 1.7.3 (2) is unique in App Store Connect.

## Test plan

- [x] macOS builds clean.
- [x] `ClassTableViewModel` type-checks (temporarily added to the macOS `INCLUDED_SOURCE_FILE_NAMES` allowlist, then reverted; pbxproj is back to its committed state).
- [ ] **No runnable test** — `swift/TigerDuckTests` still does not compile on `main` (`WatchSyncCoordinatorTests.StubSession` missing three protocol members; `WidgetTimelineDerivationTests` cannot find `WidgetTimelineDerivation`). The slice-replace is reasoned and reviewed but not executed, and it is a data-loss path, so it wants a real check on device.
- [ ] Add a course in 115-1, switch to 114-2, add a different one, switch back — the 115-1 course must still be there.
- [ ] A course added in 115-1 must not appear in 114-2's grid, on Home, or in the widgets.
- [ ] Delete a manually-added course in one semester and confirm the other semester's are untouched.