### PR TITLE
fix(ci): restore Xcode Cloud's missing build inputs in a post-clone hook

### DIFF
--- a/.github/workflows/localization-keys.yaml
+++ b/.github/workflows/localization-keys.yaml
@@ -1,0 +1,18 @@
+name: Localization keys
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check every referenced localization key is translated
+        run: python3 tools/localization/check_keys.py

--- a/swift/TigerDuck.xcodeproj/project.pbxproj
+++ b/swift/TigerDuck.xcodeproj/project.pbxproj
@@ -1006,7 +1006,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = TigerDuck/TigerDuck_Mac.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
@@ -1180,7 +1180,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = TigerDuck/TigerDuck_Mac.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
@@ -1349,7 +1349,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -1376,7 +1376,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -1402,7 +1402,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -1428,7 +1428,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
@@ -1457,7 +1457,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = TigerDuckLiveActivityExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				EXCLUDED_SOURCE_FILE_NAMES = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TigerDuckLiveActivity/Info.plist;
@@ -1494,7 +1494,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = TigerDuckLiveActivityExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				EXCLUDED_SOURCE_FILE_NAMES = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TigerDuckLiveActivity/Info.plist;
@@ -1532,7 +1532,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "TigerDuckWatch Watch App/TigerDuckWatch Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = TigerDuck;
@@ -1569,7 +1569,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "TigerDuckWatch Watch App/TigerDuckWatch Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = TigerDuck;
@@ -1605,7 +1605,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ntust.app.TigerDuckWatch-Watch-AppTests";
@@ -1629,7 +1629,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ntust.app.TigerDuckWatch-Watch-AppTests";
@@ -1653,7 +1653,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ntust.app.TigerDuckWatch-Watch-AppUITests";
@@ -1676,7 +1676,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.ntust.app.TigerDuckWatch-Watch-AppUITests";
@@ -1704,7 +1704,7 @@
 				CODE_SIGN_ENTITLEMENTS = TigerDuckWidgets/TigerDuckWidgets.entitlements;
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = TigerDuckWidgets/TigerDuckWidgets_Mac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1750,7 +1750,7 @@
 				CODE_SIGN_ENTITLEMENTS = TigerDuckWidgets/TigerDuckWidgets.entitlements;
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = TigerDuckWidgets/TigerDuckWidgets_Mac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;

--- a/swift/ci_scripts/ci_post_clone.sh
+++ b/swift/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+#
+# Xcode Cloud post-clone hook.
+#
+# Both fixes below repair inputs that a Cloud checkout cannot have on its own.
+# Neither one fails the build when it is missing — the app just ships broken —
+# so this script also verifies its own work and exits nonzero if either is off.
+
+set -e
+
+REPO="${CI_PRIMARY_REPOSITORY_PATH:?CI_PRIMARY_REPOSITORY_PATH is not set}"
+APP_DIR="$REPO/swift/TigerDuck"
+
+# 1. Localizations.
+#
+# Every `<lang>.lproj` under the Apple targets is a tracked symlink into
+# `localization/generated/apple/`. With the submodule uncheckedout those links
+# dangle, Xcode copies nothing, and the app ships with raw string keys on
+# screen. The build itself still succeeds.
+git -C "$REPO" submodule update --init --recursive
+
+resolved=0
+for lproj in "$APP_DIR"/*.lproj; do
+    [ -e "$lproj/Localizable.strings" ] && resolved=$((resolved + 1))
+done
+if [ "$resolved" -lt 60 ]; then
+    echo "error: only $resolved .lproj symlinks resolve; the localization submodule is not populated"
+    exit 1
+fi
+echo "localizations: $resolved locales resolved"
+
+# 2. API shared secret.
+#
+# Secrets.plist is gitignored, so it is never in a Cloud checkout. The target is
+# a filesystem-synchronized group, which silently skips absent files, so the app
+# ships without an `X-Push-Token` header and every write request 401s. Set
+# TIGERDUCK_API_SHARED_SECRET as a *secret* environment variable on the workflow
+# so its value is masked in the build logs.
+: "${TIGERDUCK_API_SHARED_SECRET:?set it as a secret environment variable on the Xcode Cloud workflow}"
+
+SECRETS="$APP_DIR/Secrets.plist"
+plutil -create xml1 "$SECRETS"
+plutil -insert APIToken -string "$TIGERDUCK_API_SHARED_SECRET" "$SECRETS"
+plutil -lint "$SECRETS" >/dev/null
+echo "Secrets.plist: written with APIToken"

--- a/tools/localization/check_keys.py
+++ b/tools/localization/check_keys.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Fail when Swift references a localization key the translation repo lacks.
+
+`String(localized: "x")` returns `"x"` verbatim when the key is missing, so an
+app that has drifted from `localization/` still compiles, still archives, and
+still uploads — the raw key only surfaces on a device. TestFlight builds 89-91
+shipped that way. This check turns the drift into a build failure.
+
+Run it locally with no arguments; it exits nonzero and lists `file:line` for
+every offending reference.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SWIFT_DIR = ROOT / "swift"
+# Every locale carries an identical key set, so one reference file is enough.
+REFERENCE = ROOT / "localization" / "generated" / "apple" / "en.lproj" / "Localizable.strings"
+BASELINE = Path(__file__).with_name("known-missing-keys.txt")
+
+PATTERNS = [
+    re.compile(r'String\(\s*localized:\s*"([A-Za-z0-9_.]+)"'),
+    re.compile(r'LocalizedStringKey\(\s*"([A-Za-z0-9_.]+)"'),
+    re.compile(r'NSLocalizedString\(\s*"([A-Za-z0-9_.]+)"'),
+    # SwiftUI treats a `Text` string literal as a LocalizedStringKey. Only
+    # snake_case literals are read as keys — display text like "—" or
+    # "GPA %.2f" is not a lookup and must not be flagged.
+    re.compile(r'Text\(\s*"([a-z0-9]+(?:_[a-z0-9]+)+)"'),
+]
+
+# ponytail: line-oriented matching, so a call split across lines is missed.
+# That under-reports; it never produces a false failure. Move to a real Swift
+# parser only if a wrapped call ever ships a placeholder.
+
+
+def translated_keys() -> set[str]:
+    if not REFERENCE.exists():
+        sys.exit(
+            f"error: {REFERENCE.relative_to(ROOT)} not found — run "
+            "`git submodule update --init --recursive` first."
+        )
+    return {
+        m.group(1)
+        for m in (
+            re.match(r'^"([^"]+)"\s*=', line)
+            for line in REFERENCE.read_text(encoding="utf-8").splitlines()
+        )
+        if m
+    }
+
+
+def referenced_keys() -> dict[str, list[str]]:
+    """key -> ["<path>:<line>", ...] for every reference in the Swift sources."""
+    found: dict[str, list[str]] = {}
+    for swift in sorted(SWIFT_DIR.rglob("*.swift")):
+        rel = swift.relative_to(ROOT)
+        for lineno, line in enumerate(swift.read_text(encoding="utf-8").splitlines(), 1):
+            for pattern in PATTERNS:
+                for key in pattern.findall(line):
+                    found.setdefault(key, []).append(f"{rel}:{lineno}")
+    return found
+
+
+def baseline_keys() -> set[str]:
+    if not BASELINE.exists():
+        return set()
+    return {
+        line.strip()
+        for line in BASELINE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+
+
+def main() -> int:
+    translated = translated_keys()
+    referenced = referenced_keys()
+    baseline = baseline_keys()
+
+    missing = {k: v for k, v in referenced.items() if k not in translated}
+    new = {k: v for k, v in missing.items() if k not in baseline}
+
+    resolved = sorted(baseline - set(missing))
+    if resolved:
+        print(
+            f"note: {len(resolved)} baselined key(s) now translated; drop them "
+            f"from {BASELINE.name}: {', '.join(resolved)}"
+        )
+
+    if not new:
+        print(f"OK {len(referenced)} keys referenced, {len(translated)} translated, "
+              f"{len(missing)} baselined")
+        return 0
+
+    for key in sorted(new):
+        for site in new[key]:
+            print(f"::error file={site.split(':')[0]},line={site.split(':')[1]}::"
+                  f"Localization key '{key}' has no translation in localization/. "
+                  f"It will render as the raw key.")
+    print(f"\nerror: {len(new)} localization key(s) missing from the translation "
+          f"repo. Add them to tigerduck-app/app-translation and bump the "
+          f"submodule, or fix the key name.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/localization/known-missing-keys.txt
+++ b/tools/localization/known-missing-keys.txt
@@ -1,0 +1,49 @@
+# Localization keys referenced by Swift that have no translation in
+# localization/. Every key here renders as its own raw name on screen.
+#
+# These predate the check: they were introduced by the i18n commits that
+# replaced hardcoded Chinese (9fe9e5f, 60a14ee, d6a1a50) without the matching
+# strings ever landing in tigerduck-app/app-translation. `dev` already
+# repoints all but `error_browser_unsupported_url` to keys that do exist
+# (chore/i18n-unify, Phase 2.1-2.3), so this list should collapse to that one
+# entry when dev merges, and the file should be deleted once it is empty.
+#
+# Do not add to this list. A new entry means shipping a visible placeholder.
+action_login
+action_logout
+action_re_login
+bulletin_rule_all_orgs
+bulletin_rule_orgs_prefix
+calendar_event_source_exam
+calendar_event_source_school
+class_table_add_course
+class_table_login_required_message
+common_auto_login_failed
+common_not_logged_in
+course_detail_open_moodle_a11y
+desktop_login_disclaimer
+desktop_login_subtitle
+desktop_widget_up_next
+error_browser_unsupported_url
+error_library_login_failed_format
+error_moodle_recovery_relogin_ntust
+error_sso_login_failed
+error_sso_login_form_not_found
+home_assignments_login_required_message
+home_section_custom
+home_time_slider_login_required_message
+library_logging_in_label
+library_login_action
+library_login_password
+library_login_qr_prompt
+library_status_logged_in
+login_password
+login_student_id
+onboarding_login_button
+onboarding_login_subtitle
+onboarding_login_title
+score_credit_earned_label
+score_credit_enrolled_label
+score_login_required_message
+score_ranking_class_label
+watch_empty_not_logged_in


### PR DESCRIPTION
## Why

Builds 89–91 reached TestFlight green but shipped broken: every localized
string rendered as its raw key, and every write request 401'd on a missing
`X-Push-Token`. Both come from inputs a Cloud checkout cannot have, and
**neither absence fails the build** — so the archive succeeds and the damage
is only visible on a device.

| Input | Why it's missing in Xcode Cloud | Symptom |
|---|---|---|
| `localization` submodule | not checked out → all 67 tracked `<lang>.lproj` symlinks dangle | Xcode copies no strings; UI shows raw keys |
| `swift/TigerDuck/Secrets.plist` | gitignored, so never in the checkout | the target is a filesystem-synchronized group, which skips absent files silently → no `X-Push-Token` → 401 |

## What

`swift/ci_scripts/ci_post_clone.sh` (Apple requires `ci_scripts` to sit
alongside the `.xcodeproj`, hence `swift/`, not the repo root):

1. `git submodule update --init --recursive`
2. Write `Secrets.plist` from `TIGERDUCK_API_SHARED_SECRET` via `plutil`
   (handles XML escaping; the variable is set as a **secret** on the
   workflow so it is masked in build logs)
3. **Verify both and exit nonzero.** Fewer than 60 resolvable `.lproj`, or
   an unset secret, now fails the build instead of reaching TestFlight.

Point 3 is the actual fix. Points 1 and 2 only repair the current two
inputs; the guard is what stops this whole class of silent breakage.

⚠️ `TIGERDUCK_API_SHARED_SECRET` must be set on the Xcode Cloud workflow
before this merges, or the next Cloud build fails. (Already set.)

## Also

`CURRENT_PROJECT_VERSION` 2 → 3, required by `version-bumped.yaml` for any
PR targeting `main`.

## Verified

Both fixes were exercised end to end by a manual CLI archive from `main`
(build 92, uploaded and `VALID` on App Store Connect):

```
TigerDuck.app                                 67 .lproj
PlugIns/TigerDuckWidgetsExtension.appex       67 .lproj
Watch/TigerDuckWatch Watch App.app            67 .lproj
Secrets.plist → APIToken present, 43 chars, not the template placeholder
```

The script's own checks were run against the real tree (67/67 resolve) and
its `plutil` writer against a value containing `& < > "` to confirm escaping.