### PR TITLE
fix(library): stop the QR from pinning system brightness on EDR devices

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 <br>
 
 [![License](https://img.shields.io/github/license/tigerduck-app/tigerduck-app?style=for-the-badge)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v1.7.3-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.7.3)
+[![Version](https://img.shields.io/badge/Version-v1.8.1-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.8.1)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/ios)
 
 [![App Store](https://img.shields.io/badge/App%20Store-Download-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://apps.apple.com/app/id6761084888)
@@ -92,6 +92,8 @@ Ever used [TAT](https://github.com/morris13579/tat_ntust)? We're working hard ma
 
 | Version | Date | Highlights |
 |:---:|:---:|---|
+| **`v1.8.1`** | 2026-08-21 | The library QR leans on HDR local highlighting again instead of overriding whole-device brightness — the EDR check read "is HDR content on screen right now", which is always false before the QR has drawn, so EDR devices still ended up pinned at full brightness |
+| **`v1.8.0`** | 2026-08-20 | 🔔 **Bulletin push notifications** — device registration, push preferences and bulletin deep links end to end; update prompts plus a What's New sheet after installing; flip the phone face-down to open the library QR; passwords and the library QR masked in screenshots and recordings; TLS SPKI pinning on NTUST and Library traffic; course-name font-size slider, Settings reordered to match Android, macOS surfaces and colour-blind-friendly conflict marking |
 | **`v1.7.3`** | 2026-08-20 | Manually added courses stay in the semester they were added to — they previously showed up in every semester's timetable, Home and widgets |
 | **`v1.7.2`** | 2026-08-20 | 📋 **Term-window gating** — Home's time slider and the class table's today carousel appear only while classes are in session (2026-09-07 – 2026-12-25), so neither shows a blank or wrong-term day outside it; the current term is pinned to 115-1 |
 | **`v1.7.1`** | 2026-08-20 | 📋 **Class-table semester fixes** — the semester list now comes from the university's course-query API, so a term released early (115-1) is selectable right away; 選課 enrolments are filed under the term that system actually has open, so 114-2 and 115-1 no longer render into one grid; the picker reopens on your last pick, or the newest term if you never picked one; one-shot clear of course caches written under the wrong term |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <br>
 
 [![License](https://img.shields.io/github/license/tigerduck-app/tigerduck-app?style=for-the-badge)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v1.7.3-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.7.3)
+[![Version](https://img.shields.io/badge/Version-v1.8.1-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v1.8.1)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/ios)
 
 [![App Store](https://img.shields.io/badge/App%20Store-Download-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://apps.apple.com/app/id6761084888)
@@ -93,6 +93,8 @@ TigerDuck 是由一群學生共同開發的校園助手
 
 | 版本 | 日期 | 重點 |
 |:---:|:---:|---|
+| **`v1.8.1`** | 2026-08-21 | 圖書證 QR 改回只靠 HDR 局部高亮，不再調整整台裝置的螢幕亮度 — EDR 判斷誤用了「當下是否正在顯示 HDR 內容」的數值，而 QR 還沒畫出來時它必然為否，於是 EDR 機型仍舊被鎖在最大亮度 |
+| **`v1.8.0`** | 2026-08-20 | 🔔 **公告推播上線** — 裝置註冊、推播偏好與公告深層連結全鏈路；有新版本時主動提醒，更新後顯示「這一版有什麼」；手機翻面朝下叫出圖書證 QR；密碼與圖書證 QR 在截圖與螢幕錄影中自動遮蔽；NTUST 與圖書館連線加上 TLS SPKI pinning；課名字級滑桿、設定頁依 Android 順序重整、macOS 各頁面與色盲友善的衝堂標示 |
 | **`v1.7.3`** | 2026-08-20 | 手動加入的課程只留在加入時所選的學期 — 先前會同時出現在每個學期的課表、首頁與小工具中 |
 | **`v1.7.2`** | 2026-08-20 | 📋 **學期期間限定顯示** — 首頁「時光機」與課表「今日課程」只在學期內（2026-09-07 ~ 2026-12-25）出現，開學前後不再顯示空白或錯期的當日課表；當前學期一律標示為 115-1 |
 | **`v1.7.1`** | 2026-08-20 | 📋 **課表學期修正** — 學期清單改由學校課程查詢 API 供應，學校提前釋出的 115-1 立刻可選；選課系統的選課清單改依「實際開放中的學期」歸戶，114-2 與 115-1 不再疊進同一張課表；學期選單預設沿用上次選取，從未選過則落在最新學期；一次性清掉舊版寫錯學期的課程快取 |

--- a/swift/TigerDuck.xcodeproj/project.pbxproj
+++ b/swift/TigerDuck.xcodeproj/project.pbxproj
@@ -1159,7 +1159,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1340,7 +1340,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1484,7 +1484,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.TigerDuckLiveActivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1521,7 +1521,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.TigerDuckLiveActivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1559,7 +1559,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1596,7 +1596,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1739,7 +1739,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1785,7 +1785,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -117,17 +117,30 @@ struct LibraryView: View {
     // MARK: - Brightness boost (scanner readability)
 
     #if os(iOS)
-    /// `true` when EDR is *actually* delivering extra luminance to the QR
-    /// right now, so the Metal renderer's local highlight is enough and we
-    /// can leave global brightness alone.
+    /// `true` when this display can drive EDR at all, so the Metal renderer's
+    /// local highlight carries the QR and global brightness is left alone.
     ///
-    /// Neither `HDRQRCodeImage.isSupported` (only proves a Metal device
-    /// exists) nor `potentialEDRHeadroom` (the display's *theoretical* max,
-    /// still > 1 while EDR is thermally throttled) is a reliable signal.
-    /// `currentEDRHeadroom` reflects the headroom usable at this moment and
-    /// collapses to `1.0` on SDR panels or when EDR is unavailable.
-    private var edrIsActive: Bool {
-        HDRQRCodeImage.isSupported && UIScreen.main.currentEDRHeadroom > 1.0
+    /// The question has to be answerable *before* any EDR content exists,
+    /// which is precisely what rules out `currentEDRHeadroom`. Apple
+    /// documents that one as changing "depending on its configuration and
+    /// whether it's displaying extended dynamic range content" — so at
+    /// `onAppear`, before `EDRMetalQRView`'s `CAMetalLayer` has drawn a
+    /// single frame, it always reads `1.0`. The guard then lets the global
+    /// boost through on every device, and nothing re-evaluates it, which is
+    /// how an EDR iPhone still ended up pinned at full system brightness.
+    ///
+    /// `potentialEDRHeadroom` is the property Apple documents as queryable
+    /// "even when the screen isn't displaying extended dynamic range
+    /// content", and it collapses to `1.0` on SDR panels — exactly the case
+    /// that still needs the Wallet-style fallback.
+    ///
+    /// Tradeoff: a thermally throttled EDR display reports potential > 1
+    /// while delivering less, so the QR renders at ordinary SDR white rather
+    /// than boosted. The SDR `Image` stacked under the Metal layer in
+    /// `LibraryQRCodeView` keeps it scannable, and overriding system
+    /// brightness is the behaviour this view exists to avoid.
+    private var edrIsAvailable: Bool {
+        HDRQRCodeImage.isSupported && UIScreen.main.potentialEDRHeadroom > 1.0
     }
 
     /// Pin the screen at full brightness while the QR is on-screen — the
@@ -136,7 +149,7 @@ struct LibraryView: View {
     /// the QR pop locally, so the global brightness override is skipped to
     /// preserve the local-highlight behaviour this view is built around.
     private func boostBrightnessForQR() {
-        guard !edrIsActive else { return }
+        guard !edrIsAvailable else { return }
         if savedBrightness == nil {
             savedBrightness = UIScreen.main.brightness
         }


### PR DESCRIPTION
## The bug

ffaedb66 set out to keep the library QR on HDR local highlighting instead of
overriding whole-device brightness. On an EDR iPhone it still pins the screen
to 1.0 for the whole session.

The guard reads the wrong one of two similarly named properties:

| Property | Apple's wording |
|---|---|
| `currentEDRHeadroom` | "can change depending on its configuration **and whether it's displaying extended dynamic range content**" |
| `potentialEDRHeadroom` | "**You can query this property even when the screen isn't displaying extended dynamic range content.**" |

`boostBrightnessForQR()` runs from `onAppear`, before `EDRMetalQRView`'s
`CAMetalLayer` has drawn its first frame. At that moment `currentEDRHeadroom`
is necessarily `1.0`, so the guard always falls through and the boost always
fires — on precisely the EDR devices the local-highlight design exists for.
Nothing re-evaluates it afterwards, so the screen stays pinned until the view
goes away.

It is an ordering bug: the gate is keyed on a signal that only becomes true
*after* the thing it is gating.

## The fix

```diff
-    private var edrIsActive: Bool {
-        HDRQRCodeImage.isSupported && UIScreen.main.currentEDRHeadroom > 1.0
+    private var edrIsAvailable: Bool {
+        HDRQRCodeImage.isSupported && UIScreen.main.potentialEDRHeadroom > 1.0
     }
```

Renamed because the property now describes display *capability* rather than
live EDR state. `potentialEDRHeadroom` still collapses to `1.0` on SDR panels,
so older devices keep the Wallet-style global fallback.

ffaedb66 rejected `potentialEDRHeadroom` because a thermally throttled display
keeps reporting > 1. That is true, and the cost is that the QR renders at
ordinary SDR white instead of boosted — `LibraryQRCodeView` already stacks the
SDR `Image` under the Metal layer, so it stays scannable. Overriding system
brightness is the behaviour this view exists to avoid. The tradeoff is written
into the doc comment.

## Release

`MARKETING_VERSION` 1.8.0 → 1.8.1 across the 8 shipping targets (the 8
`= 1.0;` test placeholders are untouched).

Both READMEs were still on the **v1.7.3** badge — 1.8.0 shipped without the
doc update — so the release history gains two rows, not one.

## Verified

Compiles clean against `main` on a separate machine: `** BUILD SUCCEEDED **`.
The behaviour itself needs a device check — on an EDR iPhone the system
brightness slider should not move when the QR opens.