### PR TITLE
release: v2.0.1

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 <br>
 
 [![License](https://img.shields.io/github/license/tigerduck-app/tigerduck-app?style=for-the-badge)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v2.0.0-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v2.0.0)
+[![Version](https://img.shields.io/badge/Version-v2.0.1-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v2.0.1)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/ios)
 [![macOS](https://img.shields.io/badge/macOS-14%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/macos)
 [![watchOS](https://img.shields.io/badge/watchOS-11%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/watchos)
@@ -111,6 +111,7 @@ Ever used [TAT](https://github.com/morris13579/tat_ntust)? We're working hard ma
 
 | Version | Date | Highlights |
 |:---:|:---:|---|
+| **`v2.0.1`** | 2026-09-07 | Semester picker lists only terms from the admission year on, so space-padded legacy codes no longer leak in; theme colour reaches icons, the library QR countdown ring, the GPA trend line and the Mac Settings window; the course-selection term is owned by its enrolment list, so dropped courses stop coming back from Moodle |
 | **`v2.0.0`** | 2026-08-23 | 🚀 **Cloud sync GA** — real-time course & assignment upload, macOS push & account sync, 401 auto-recovery, server push channel settings |
 | **`v1.8.1`** | 2026-08-21 | The library QR leans on HDR local highlighting again instead of overriding whole-device brightness — the EDR check read "is HDR content on screen right now", which is always false before the QR has drawn, so EDR devices still ended up pinned at full brightness |
 | **`v1.8.0`** | 2026-08-20 | 🔔 **Bulletin push notifications** — device registration, push preferences and bulletin deep links end to end; update prompts plus a What's New sheet after installing; flip the phone face-down to open the library QR; passwords and the library QR masked in screenshots and recordings; TLS SPKI pinning on NTUST and Library traffic; course-name font-size slider, Settings reordered to match Android, macOS surfaces and colour-blind-friendly conflict marking |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <br>
 
 [![License](https://img.shields.io/github/license/tigerduck-app/tigerduck-app?style=for-the-badge)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v2.0.0-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v2.0.0)
+[![Version](https://img.shields.io/badge/Version-v2.0.1-00BB00?style=for-the-badge)](https://github.com/tigerduck-app/tigerduck-app/releases/tag/v2.0.1)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/ios)
 [![macOS](https://img.shields.io/badge/macOS-14%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/macos)
 [![watchOS](https://img.shields.io/badge/watchOS-11%2B-black?style=for-the-badge&logo=apple&logoColor=white)](https://apple.com/watchos)
@@ -112,6 +112,7 @@ TigerDuck 是由一群學生共同開發的校園助手
 
 | 版本 | 日期 | 重點 |
 |:---:|:---:|---|
+| **`v2.0.1`** | 2026-09-07 | 課表學期選單只列入學年以後的學期，舊制空格補位的學期代碼不再混入；主題色擴及圖示、圖書證倒數圈、歷年成績趨勢線與 Mac 設定視窗；選課系統所服務的學期以選課清單為準，已退選的課不再從 Moodle 被加回 |
 | **`v2.0.0`** | 2026-08-23 | 🚀 **雲端同步正式上線** — 課程/作業即時上傳、macOS 推播與帳號同步、401 自動恢復、伺服器推播頻道設定 |
 | **`v1.8.1`** | 2026-08-21 | 圖書證 QR 改回只靠 HDR 局部高亮，不再調整整台裝置的螢幕亮度 — EDR 判斷誤用了「當下是否正在顯示 HDR 內容」的數值，而 QR 還沒畫出來時它必然為否，於是 EDR 機型仍舊被鎖在最大亮度 |
 | **`v1.8.0`** | 2026-08-20 | 🔔 **公告推播上線** — 裝置註冊、推播偏好與公告深層連結全鏈路；有新版本時主動提醒，更新後顯示「這一版有什麼」；手機翻面朝下叫出圖書證 QR；密碼與圖書證 QR 在截圖與螢幕錄影中自動遮蔽；NTUST 與圖書館連線加上 TLS SPKI pinning；課名字級滑桿、設定頁依 Android 順序重整、macOS 各頁面與色盲友善的衝堂標示 |

--- a/swift/TigerDuck.xcodeproj/project.pbxproj
+++ b/swift/TigerDuck.xcodeproj/project.pbxproj
@@ -1203,7 +1203,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1426,7 +1426,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1572,7 +1572,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.TigerDuckLiveActivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1609,7 +1609,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.TigerDuckLiveActivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1647,7 +1647,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1684,7 +1684,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1831,7 +1831,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1877,7 +1877,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ntust.app.TigerDuck.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/swift/TigerDuck/Bridge/AppServiceBridge.swift
+++ b/swift/TigerDuck/Bridge/AppServiceBridge.swift
@@ -318,29 +318,29 @@ enum AppServiceBridge {
 
     /// The course numbers a term renders, in source priority order, deduped.
     ///
-    /// The 選課 system is the authority for the one term it serves: Moodle
-    /// keeps an enrolment after the student drops the class, so unioning
-    /// the two re-added dropped courses. Pass `selection` as nil for every
-    /// other term, and when 選課 was unreachable, to make Moodle the source.
-    /// An *empty* list is treated the same way: the D01 scrape is a regex
-    /// over HTML that yields zero matches, not an error, when the page
-    /// layout drifts, and that result is cached for a day — so it cannot be
-    /// told apart from "no enrolments" and must not blank the term.
-    /// The transcript always tops up — it is the only source that covers
-    /// non-Moodle classes in past terms.
+    /// A non-empty 選課 answer owns its term outright. Moodle keeps an
+    /// enrolment after the student drops the class, and the cached
+    /// transcript can predate the drop, so either top-up would put the
+    /// course back. Pass `selection` as nil for every other term and when
+    /// 選課 was unreachable: Moodle is the source then, and the transcript
+    /// tops up the non-Moodle classes it alone covers. An *empty* list is
+    /// treated the same way — the D01 scrape is a regex over HTML that
+    /// yields zero matches, not an error, when the layout drifts, and that
+    /// result is cached for a day, so it cannot be told apart from "no
+    /// enrolments" and must not blank the term.
     static func enrolledCourseNos(
         selection: [String]?,
         moodle: [String],
         transcript: [String]
     ) -> [String] {
-        let selectionOwnsTerm = !(selection ?? []).isEmpty
-        var ordered: [String] = []
-        var seen = Set<String>()
-        for courseNo in (selection ?? []) + (selectionOwnsTerm ? [] : moodle) + transcript
-        where !courseNo.isEmpty && seen.insert(courseNo).inserted {
-            ordered.append(courseNo)
+        let candidates: [String]
+        if let selection, !selection.isEmpty {
+            candidates = selection
+        } else {
+            candidates = moodle + transcript
         }
-        return ordered
+        var seen = Set<String>()
+        return candidates.filter { !$0.isEmpty && seen.insert($0).inserted }
     }
 
     /// The per-user display toggles a course lookup has to honour, read once

--- a/swift/TigerDuck/Bridge/AppServiceBridge.swift
+++ b/swift/TigerDuck/Bridge/AppServiceBridge.swift
@@ -107,7 +107,11 @@ enum AppServiceBridge {
             // still fall through to the Moodle path; otherwise the whole
             // fetch would throw, the catch below would return an empty cache,
             // and Home / Class Table / Time Machine would stay blank.
-            var courseSelectionNos: [String] = []
+            // nil = the 選課 system was not consulted (another term) or was
+            // unreachable; Moodle is the enrolment source then. When it
+            // answers, it is the authority for its term and Moodle only
+            // enriches — see `enrolledCourseNos`.
+            var courseSelectionNos: [String]?
             if servesSelectionSemester {
                 do {
                     courseSelectionNos = try await CourseSelectionService.fetchEnrolledCourseNos(
@@ -185,23 +189,11 @@ enum AppServiceBridge {
                 uniquingKeysWith: { first, _ in first }
             )
 
-            var orderedCourseNos: [String] = []
-            var seenCourseNos = Set<String>()
-
-            for courseNo in courseSelectionNos where seenCourseNos.insert(courseNo).inserted {
-                orderedCourseNos.append(courseNo)
-            }
-
-            for moodleCourse in moodleForSemester {
-                let courseNo = moodleCourse.courseNo
-                guard !courseNo.isEmpty, seenCourseNos.insert(courseNo).inserted else { continue }
-                orderedCourseNos.append(courseNo)
-            }
-
-            for grade in scoreCoursesForSemester
-                where seenCourseNos.insert(grade.code).inserted {
-                orderedCourseNos.append(grade.code)
-            }
+            let orderedCourseNos = enrolledCourseNos(
+                selection: courseSelectionNos,
+                moodle: moodleForSemester.map(\.courseNo),
+                transcript: scoreCoursesForSemester.map(\.code)
+            )
 
             let courseDataList = await withTaskGroup(of: CourseData?.self) { group in
                 for courseNo in orderedCourseNos {
@@ -322,6 +314,28 @@ enum AppServiceBridge {
             }
             return DataCache.shared.loadCourses(semester: semester)
         }
+    }
+
+    /// The course numbers a term renders, in source priority order, deduped.
+    ///
+    /// The 選課 system is the authority for the one term it serves: Moodle
+    /// keeps an enrolment after the student drops the class, so unioning
+    /// the two re-added dropped courses. Pass `selection` as nil for every
+    /// other term, and when 選課 was unreachable, to make Moodle the source.
+    /// The transcript always tops up — it is the only source that covers
+    /// non-Moodle classes in past terms.
+    static func enrolledCourseNos(
+        selection: [String]?,
+        moodle: [String],
+        transcript: [String]
+    ) -> [String] {
+        var ordered: [String] = []
+        var seen = Set<String>()
+        for courseNo in (selection ?? []) + (selection == nil ? moodle : []) + transcript
+        where !courseNo.isEmpty && seen.insert(courseNo).inserted {
+            ordered.append(courseNo)
+        }
+        return ordered
     }
 
     /// The per-user display toggles a course lookup has to honour, read once

--- a/swift/TigerDuck/Bridge/AppServiceBridge.swift
+++ b/swift/TigerDuck/Bridge/AppServiceBridge.swift
@@ -322,6 +322,10 @@ enum AppServiceBridge {
     /// keeps an enrolment after the student drops the class, so unioning
     /// the two re-added dropped courses. Pass `selection` as nil for every
     /// other term, and when 選課 was unreachable, to make Moodle the source.
+    /// An *empty* list is treated the same way: the D01 scrape is a regex
+    /// over HTML that yields zero matches, not an error, when the page
+    /// layout drifts, and that result is cached for a day — so it cannot be
+    /// told apart from "no enrolments" and must not blank the term.
     /// The transcript always tops up — it is the only source that covers
     /// non-Moodle classes in past terms.
     static func enrolledCourseNos(
@@ -329,9 +333,10 @@ enum AppServiceBridge {
         moodle: [String],
         transcript: [String]
     ) -> [String] {
+        let selectionOwnsTerm = !(selection ?? []).isEmpty
         var ordered: [String] = []
         var seen = Set<String>()
-        for courseNo in (selection ?? []) + (selection == nil ? moodle : []) + transcript
+        for courseNo in (selection ?? []) + (selectionOwnsTerm ? [] : moodle) + transcript
         where !courseNo.isEmpty && seen.insert(courseNo).inserted {
             ordered.append(courseNo)
         }

--- a/swift/TigerDuck/ContentView.swift
+++ b/swift/TigerDuck/ContentView.swift
@@ -251,7 +251,7 @@ struct PlaceholderFeatureView: View {
             VStack(spacing: TigerDuckTheme.Spacing.lg) {
                 Image(systemName: feature.iconName)
                     .font(.system(size: heroIconSize))
-                    .foregroundStyle(Color.accentPrimary)
+                    .foregroundStyle(.tint)
                 Text(feature.displayName)
                     .font(TigerDuckTheme.Typography.title)
                     .foregroundStyle(Color.textPrimary)

--- a/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
+++ b/swift/TigerDuck/Features/Bulletins/BulletinsView.swift
@@ -334,7 +334,7 @@ struct BulletinsView: View {
                         )
                         .labelStyle(.iconOnly)
                     }
-                    .tint(.accentColor)
+                    .tint(appState.accentColor)
                 }
                 .task {
                     await viewModel.loadMoreIfNeeded(triggeredBy: bulletin)

--- a/swift/TigerDuck/Features/Bulletins/Components/BulletinCardView.swift
+++ b/swift/TigerDuck/Features/Bulletins/Components/BulletinCardView.swift
@@ -36,7 +36,7 @@ struct BulletinCardView: View {
         HStack(alignment: .center, spacing: TigerDuckTheme.Spacing.sm) {
             if !isRead {
                 Circle()
-                    .fill(Color.accentColor)
+                    .fill(.tint)
                     .frame(width: 7, height: 7)
                     .accessibilityLabel(String(localized: "bulletin_unread_dot_label"))
             }
@@ -92,7 +92,7 @@ struct BulletinCardView: View {
             .foregroundStyle(.white)
             .padding(.horizontal, 10)
             .padding(.vertical, 4)
-            .background(Color.accentColor, in: Capsule())
+            .background(.tint, in: Capsule())
     }
 
     /// Hashtag-style inline strip. Pairs intentionally with the filled org

--- a/swift/TigerDuck/Features/Bulletins/Components/BulletinDetailView.swift
+++ b/swift/TigerDuck/Features/Bulletins/Components/BulletinDetailView.swift
@@ -80,7 +80,7 @@ struct BulletinDetailView: View {
             if let org = bulletin.canonicalOrg {
                 Text(taxonomy.orgLabel(for: org))
                     .font(.footnote.weight(.semibold))
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(.tint)
             }
             if let importance = bulletin.importance, importance == .high {
                 importanceBadge
@@ -117,10 +117,10 @@ struct BulletinDetailView: View {
             WrappingHStack(items: bulletin.contentTags, spacing: 6, lineSpacing: 6) { tag in
                 Text("#\(taxonomy.tagLabel(for: tag))")
                     .font(TigerDuckTheme.Typography.caption)
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(.tint)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)
-                    .background(Color.accentColor.opacity(0.12), in: Capsule())
+                    .background(.tint.opacity(0.12), in: Capsule())
             }
         }
         .padding(.top, TigerDuckTheme.Spacing.md)
@@ -177,7 +177,7 @@ struct BulletinDetailView: View {
                     .foregroundStyle(.white)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)
-                    .background(Color.accentColor, in: Capsule())
+                    .background(.tint, in: Capsule())
                     .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
             }
             .buttonStyle(.plain)
@@ -202,7 +202,7 @@ struct BulletinDetailView: View {
                 ForegroundColor(Color.textPrimary)
             }
             .link {
-                ForegroundColor(Color.accentColor)
+                ForegroundColor(appState.accentColor)
                 UnderlineStyle(.single)
             }
             .strong {

--- a/swift/TigerDuck/Features/Bulletins/Components/BulletinTaxonomyPickerView.swift
+++ b/swift/TigerDuck/Features/Bulletins/Components/BulletinTaxonomyPickerView.swift
@@ -30,7 +30,7 @@ struct BulletinTaxonomyPickerView: View {
                             Spacer()
                             if selected.contains(option.id) {
                                 Image(systemName: "checkmark")
-                                    .foregroundStyle(Color.accentColor)
+                                    .foregroundStyle(.tint)
                             }
                         }
                         // Without contentShape, taps in the Spacer / trailing

--- a/swift/TigerDuck/Features/Calendar/Components/MonthCalendarView.swift
+++ b/swift/TigerDuck/Features/Calendar/Components/MonthCalendarView.swift
@@ -28,7 +28,7 @@ struct MonthCalendarView: View {
             HStack {
                 Button(action: viewModel.previousMonth) {
                     Image(systemName: "chevron.left")
-                        .foregroundStyle(Color.accentPrimary)
+                        .foregroundStyle(.tint)
                 }
                 .accessibilityLabel(String(localized: "a11y_calendar_nav_prev"))
                 Spacer()
@@ -38,7 +38,7 @@ struct MonthCalendarView: View {
                 Spacer()
                 Button(action: viewModel.nextMonth) {
                     Image(systemName: "chevron.right")
-                        .foregroundStyle(Color.accentPrimary)
+                        .foregroundStyle(.tint)
                 }
                 .accessibilityLabel(String(localized: "a11y_calendar_nav_next"))
             }
@@ -103,13 +103,13 @@ private struct DayCellView: View {
             VStack(spacing: 2) {
                 Text("\(AppConstants.taipeiCalendar.component(.day, from: date))")
                     .font(TigerDuckTheme.Typography.body)
-                    .foregroundStyle(isSelected ? .white : (isToday ? .accentPrimary : .textPrimary))
+                    .foregroundStyle(isSelected ? AnyShapeStyle(.white) : isToday ? AnyShapeStyle(.tint) : AnyShapeStyle(Color.textPrimary))
                     .frame(width: 32, height: 32)
                     .background {
                         if isSelected {
-                            Circle().fill(Color.accentPrimary)
+                            Circle().fill(.tint)
                         } else if isToday {
-                            Circle().stroke(Color.accentPrimary, lineWidth: 1.5)
+                            Circle().stroke(.tint, lineWidth: 1.5)
                         }
                     }
 

--- a/swift/TigerDuck/Features/ClassTable/Components/AddCourseSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/AddCourseSheet.swift
@@ -316,7 +316,7 @@ struct AddCourseSheet: View {
                             .foregroundStyle(.green)
                     } else {
                         Image(systemName: "plus.circle")
-                            .foregroundStyle(Color.accentPrimary)
+                            .foregroundStyle(.tint)
                     }
                 }
                 .contentShape(Rectangle())

--- a/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
+++ b/swift/TigerDuck/Features/ClassTable/Components/CourseDetailSheet.swift
@@ -54,7 +54,7 @@ struct CourseDetailSheet: View {
                     Button(action: openMoodleCourse) {
                         Image(systemName: "arrow.up.right.square.fill")
                             .font(.title2)
-                            .foregroundStyle(Color.accentPrimary)
+                            .foregroundStyle(.tint)
                     }
                     .accessibilityLabel(String(localized: "a11y_course_detail_open_moodle"))
                 }
@@ -149,7 +149,7 @@ struct CourseDetailSheet: View {
                 } label: {
                     HStack {
                         Image(systemName: "doc.text")
-                            .foregroundStyle(Color.accentPrimary)
+                            .foregroundStyle(.tint)
                         VStack(alignment: .leading) {
                             Text(assignment.displayTitle)
                                 .font(TigerDuckTheme.Typography.body)

--- a/swift/TigerDuck/Features/Home/Components/AddSectionSheet.swift
+++ b/swift/TigerDuck/Features/Home/Components/AddSectionSheet.swift
@@ -36,7 +36,7 @@ struct AddSectionSheet: View {
                             dismiss()
                         } label: {
                             Image(systemName: "plus.circle.fill")
-                                .foregroundStyle(Color.accentPrimary)
+                                .foregroundStyle(.tint)
                         }
                         .disabled(customTitle.isEmpty)
                     }

--- a/swift/TigerDuck/Features/Home/Components/WidgetGridEditMode.swift
+++ b/swift/TigerDuck/Features/Home/Components/WidgetGridEditMode.swift
@@ -53,13 +53,13 @@ struct WidgetGridEditMode: View {
                             } label: {
                                 HStack {
                                     Image(systemName: feature.iconName)
-                                        .foregroundStyle(Color.accentPrimary)
+                                        .foregroundStyle(.tint)
                                     Text(feature.displayName)
                                         .font(TigerDuckTheme.Typography.body)
                                         .foregroundStyle(Color.textPrimary)
                                     Spacer()
                                     Image(systemName: "plus.circle.fill")
-                                        .foregroundStyle(Color.accentPrimary)
+                                        .foregroundStyle(.tint)
                                 }
                                 .cardPadding()
                                 .glassCard()

--- a/swift/TigerDuck/Features/Home/Components/WidgetGridView.swift
+++ b/swift/TigerDuck/Features/Home/Components/WidgetGridView.swift
@@ -128,7 +128,7 @@ private struct WidgetDragPreview: View {
         HStack(spacing: TigerDuckTheme.Spacing.sm) {
             Image(systemName: widget.feature.iconName)
                 .font(.title3)
-                .foregroundStyle(Color.accentPrimary)
+                .foregroundStyle(.tint)
                 .frame(width: 28, height: 28)
 
             VStack(alignment: .leading, spacing: 2) {

--- a/swift/TigerDuck/Features/Home/HomeView.swift
+++ b/swift/TigerDuck/Features/Home/HomeView.swift
@@ -306,7 +306,7 @@ private struct SectionDragPreview: View {
         HStack(spacing: TigerDuckTheme.Spacing.sm) {
             Image(systemName: section.type.iconName)
                 .font(.title3)
-                .foregroundStyle(Color.accentPrimary)
+                .foregroundStyle(.tint)
             Text(section.title)
                 .font(TigerDuckTheme.Typography.headline)
                 .foregroundStyle(Color.textPrimary)

--- a/swift/TigerDuck/Features/Library/Components/LibraryQRCodeView.swift
+++ b/swift/TigerDuck/Features/Library/Components/LibraryQRCodeView.swift
@@ -78,7 +78,7 @@ struct LibraryQRCodeView: View {
                     Circle()
                         .trim(from: 0, to: ringFraction)
                         .stroke(
-                            Color.accentPrimary,
+                            .tint,
                             style: StrokeStyle(lineWidth: 2.5, lineCap: .round)
                         )
                         .rotationEffect(.degrees(-90))

--- a/swift/TigerDuck/Features/Library/LibraryView.swift
+++ b/swift/TigerDuck/Features/Library/LibraryView.swift
@@ -265,7 +265,7 @@ struct LibraryView: View {
         VStack(spacing: TigerDuckTheme.Spacing.lg) {
             Image(systemName: "qrcode")
                 .font(.system(size: heroIconSize))
-                .foregroundStyle(Color.accentPrimary)
+                .foregroundStyle(.tint)
 
             Text(String(localized: "library_sign_in_qr_prompt"))
                 .font(TigerDuckTheme.Typography.title)
@@ -331,7 +331,7 @@ struct LibraryView: View {
                     .frame(maxWidth: .infinity)
                     .padding(TigerDuckTheme.Spacing.md)
                     .background(
-                        Color.accentPrimary.opacity(disabled ? 0.5 : 1),
+                        .tint.opacity(disabled ? 0.5 : 1),
                         in: RoundedRectangle(cornerRadius: TigerDuckTheme.CornerRadius.md)
                     )
             }
@@ -378,7 +378,7 @@ struct LibraryView: View {
             VStack(spacing: TigerDuckTheme.Spacing.sm) {
                 Image(systemName: icon)
                     .font(.title2)
-                    .foregroundStyle(Color.accentPrimary)
+                    .foregroundStyle(.tint)
 
                 Text(title)
                     .font(TigerDuckTheme.Typography.headline)

--- a/swift/TigerDuck/Features/More/Components/FeatureCardView.swift
+++ b/swift/TigerDuck/Features/More/Components/FeatureCardView.swift
@@ -8,7 +8,7 @@ struct FeatureCardView: View {
             HStack {
                 Image(systemName: feature.iconName)
                     .font(.title2)
-                    .foregroundStyle(Color.accentPrimary)
+                    .foregroundStyle(.tint)
                     .frame(width: 28, height: 28)
                 Spacer()
             }

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -12,7 +12,7 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
     let icon: String
     let title: String
     let subtitle: String
-    var accentColor: Color = .accentPrimary
+    var accentColor: Color = .blue
     var iconAnimation: IconAnimation = .pulse
     /// Fill both margins instead of centring — for the pages whose
     /// subtitle is a paragraph of terms rather than a one-line tagline.
@@ -113,7 +113,7 @@ extension OnboardingPageView where Content == EmptyView {
         icon: String,
         title: String,
         subtitle: String,
-        accentColor: Color = .accentPrimary,
+        accentColor: Color = .blue,
         iconAnimation: IconAnimation = .pulse,
         @ViewBuilder actions: @escaping () -> Actions
     ) {

--- a/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingPageView.swift
@@ -12,7 +12,7 @@ struct OnboardingPageView<Content: View, Actions: View>: View {
     let icon: String
     let title: String
     let subtitle: String
-    var accentColor: Color = .blue
+    var accentColor: Color = .onboardingAccent
     var iconAnimation: IconAnimation = .pulse
     /// Fill both margins instead of centring — for the pages whose
     /// subtitle is a paragraph of terms rather than a one-line tagline.
@@ -113,7 +113,7 @@ extension OnboardingPageView where Content == EmptyView {
         icon: String,
         title: String,
         subtitle: String,
-        accentColor: Color = .blue,
+        accentColor: Color = .onboardingAccent,
         iconAnimation: IconAnimation = .pulse,
         @ViewBuilder actions: @escaping () -> Actions
     ) {

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -85,7 +85,7 @@ struct OnboardingView: View {
             icon: "graduationcap.fill",
             title: String(localized: "onboarding_welcome_title"),
             subtitle: String(localized: "onboarding_welcome_subtitle"),
-            accentColor: .blue,
+            accentColor: .onboardingAccent,
             content: {
                 VStack(spacing: TigerDuckTheme.Spacing.md) {
                     Text(String(localized: "onboarding_welcome_description"))
@@ -553,7 +553,7 @@ struct OnboardingView: View {
             icon: "checkmark.circle.fill",
             title: String(localized: "onboarding_ready_title"),
             subtitle: String(localized: "onboarding_ready_subtitle"),
-            accentColor: .blue
+            accentColor: .onboardingAccent
         ) {
             Button(String(localized: "onboarding_start_button")) {
                 appState.completeOnboarding()

--- a/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
+++ b/swift/TigerDuck/Features/Onboarding/OnboardingView.swift
@@ -85,7 +85,7 @@ struct OnboardingView: View {
             icon: "graduationcap.fill",
             title: String(localized: "onboarding_welcome_title"),
             subtitle: String(localized: "onboarding_welcome_subtitle"),
-            accentColor: .accentPrimary,
+            accentColor: .blue,
             content: {
                 VStack(spacing: TigerDuckTheme.Spacing.md) {
                     Text(String(localized: "onboarding_welcome_description"))
@@ -195,7 +195,7 @@ struct OnboardingView: View {
                 Image(systemName: isOn.wrappedValue ? "checkmark.circle.fill" : "circle")
                     .font(.title2)
                     .symbolRenderingMode(.hierarchical)
-                    .foregroundStyle(isOn.wrappedValue ? Color.accentPrimary : Color.textSecondary)
+                    .foregroundStyle(isOn.wrappedValue ? AnyShapeStyle(.tint) : AnyShapeStyle(Color.textSecondary))
                     .contentTransition(reduceMotion ? .identity : .symbolEffect(.replace))
             }
             .buttonStyle(.plain)
@@ -553,7 +553,7 @@ struct OnboardingView: View {
             icon: "checkmark.circle.fill",
             title: String(localized: "onboarding_ready_title"),
             subtitle: String(localized: "onboarding_ready_subtitle"),
-            accentColor: .accentPrimary
+            accentColor: .blue
         ) {
             Button(String(localized: "onboarding_start_button")) {
                 appState.completeOnboarding()

--- a/swift/TigerDuck/Features/Score/Components/RankingsTrendCard.swift
+++ b/swift/TigerDuck/Features/Score/Components/RankingsTrendCard.swift
@@ -22,7 +22,8 @@ struct RankingsTrendCard: View {
 
     @State private var selectedTerm: String?
 
-    private let lineColor = Color(hex: 0x4ECDC4)
+    /// The theme tint; `Color.accentColor` ignores `.tint(...)`, this doesn't.
+    private let lineColor = TintShapeStyle()
 
     var body: some View {
         VStack(alignment: .leading, spacing: TigerDuckTheme.Spacing.sm) {

--- a/swift/TigerDuck/Features/Score/Components/StudentHeaderCard.swift
+++ b/swift/TigerDuck/Features/Score/Components/StudentHeaderCard.swift
@@ -14,9 +14,9 @@ struct StudentHeaderCard: View {
         HStack(alignment: .center, spacing: TigerDuckTheme.Spacing.md) {
             Image(systemName: "graduationcap.fill")
                 .font(.title2)
-                .foregroundStyle(Color(hex: 0x4ECDC4))
+                .foregroundStyle(.tint)
                 .frame(width: 44, height: 44)
-                .background(Color(hex: 0x4ECDC4).opacity(0.15), in: Circle())
+                .background(.tint.opacity(0.15), in: Circle())
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(student.isEmpty ? String(localized: "feature_score") : student)

--- a/swift/TigerDuck/Features/Settings/Components/FontSizeSettingsView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/FontSizeSettingsView.swift
@@ -165,7 +165,7 @@ private struct ClassCardPreview: View {
 
     private var soloCell: some View {
         RoundedRectangle(cornerRadius: cornerRadius)
-            .fill(Color.accentColor.opacity(0.35))
+            .fill(.tint.opacity(0.35))
             .overlay {
                 Text(String(localized: "settings_font_size_preview_course_name"))
                     .font(.system(size: courseFontSize, weight: .medium))

--- a/swift/TigerDuck/Features/Settings/Components/TabEditorView.swift
+++ b/swift/TigerDuck/Features/Settings/Components/TabEditorView.swift
@@ -96,7 +96,7 @@ struct TabEditorView: View {
                                             .font(.caption2)
                                             .lineLimit(1)
                                     }
-                                    .foregroundStyle(Color.accentPrimary)
+                                    .foregroundStyle(.tint)
                                     .frame(width: 56)
                                     .scaleEffect(1.1)
                                     .shadow(color: .black.opacity(0.3), radius: 8, x: 0, y: 4)
@@ -132,7 +132,7 @@ struct TabEditorView: View {
                                     } label: {
                                         HStack {
                                             Image(systemName: feature.iconName)
-                                                .foregroundStyle(Color.accentPrimary)
+                                                .foregroundStyle(.tint)
                                                 .frame(width: 24)
                                             Text(feature.displayName)
                                                 .font(TigerDuckTheme.Typography.body)
@@ -140,7 +140,7 @@ struct TabEditorView: View {
                                                 .lineLimit(1)
                                             Spacer()
                                             Image(systemName: "plus.circle.fill")
-                                                .foregroundStyle(Color.accentPrimary)
+                                                .foregroundStyle(.tint)
                                         }
                                         .cardPadding()
                                         .glassCard()
@@ -157,7 +157,7 @@ struct TabEditorView: View {
                             tabs = AppFeature.defaultTabs
                         }
                     }
-                    .foregroundStyle(Color.accentPrimary)
+                    .foregroundStyle(.tint)
                     .padding(.bottom)
                 }
                 .padding(.top, TigerDuckTheme.Spacing.lg)
@@ -230,7 +230,7 @@ private struct TabPreviewItem: View {
                 .font(.caption2)
                 .lineLimit(1)
         }
-        .foregroundStyle(Color.accentPrimary)
+        .foregroundStyle(.tint)
         .frame(width: 56)
         .overlay(alignment: .topTrailing) {
             Button(action: onRemove) {

--- a/swift/TigerDuck/Platform/Mac/MacBulletinsView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacBulletinsView.swift
@@ -110,7 +110,7 @@ struct MacBulletinsView: View {
     private func bulletinRow(_ b: BulletinAPI.BulletinSummary) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Circle()
-                .fill(readStore.isRead(b.id) ? Color.clear : Color.accentColor)
+                .fill(.tint.opacity(readStore.isRead(b.id) ? 0 : 1))
                 .frame(width: 8, height: 8)
                 .padding(.top, 6)
             VStack(alignment: .leading, spacing: 4) {

--- a/swift/TigerDuck/Platform/Mac/MacCalendarView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacCalendarView.swift
@@ -308,9 +308,9 @@ private struct DayCell: View {
                     .frame(width: 28, height: 28)
                     .background {
                         if isSelected {
-                            Circle().fill(Color.accentColor)
+                            Circle().fill(.tint)
                         } else if isToday {
-                            Circle().stroke(Color.accentColor, lineWidth: 1.5)
+                            Circle().stroke(.tint, lineWidth: 1.5)
                         }
                     }
                     .padding(.top, 4)
@@ -336,17 +336,17 @@ private struct DayCell: View {
                 // in #135 was that the today/selected ring touched the
                 // outer rounded fill with zero breathing room.
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(isSelected ? Color.accentColor.opacity(0.08) : Color.clear)
+                    .fill(.tint.opacity(isSelected ? 0.08 : 0))
                     .padding(3)
             )
         }
         .buttonStyle(.plain)
     }
 
-    private var textColor: Color {
-        if isSelected { return .white }
-        if isToday { return .accentColor }
-        return .primary
+    private var textColor: AnyShapeStyle {
+        if isSelected { return AnyShapeStyle(.white) }
+        if isToday { return AnyShapeStyle(.tint) }
+        return AnyShapeStyle(.primary)
     }
 
     private func dedupedSources() -> [EventSource] {

--- a/swift/TigerDuck/Platform/Mac/MacSettingsScene.swift
+++ b/swift/TigerDuck/Platform/Mac/MacSettingsScene.swift
@@ -14,6 +14,8 @@ import SwiftUI
 /// override controls so QA can scrub fake time on the Mac the same way
 /// they can on iPhone.
 struct MacSettingsScene: View {
+    @Environment(AppState.self) private var appState
+
     var body: some View {
         TabView {
             MacGeneralSettingsView()
@@ -32,6 +34,9 @@ struct MacSettingsScene: View {
                 .tabItem { Label(String(localized: "settings_section_about"), systemImage: "info.circle") }
         }
         .frame(width: 580, height: 480)
+        // Separate scene from MacRootView, so the theme tint has to be
+        // applied here too or `.tint`-styled icons fall back to the system accent.
+        .tint(appState.accentColor)
     }
 }
 #endif

--- a/swift/TigerDuck/Platform/Mac/MacSidebarSettingsView.swift
+++ b/swift/TigerDuck/Platform/Mac/MacSidebarSettingsView.swift
@@ -127,7 +127,7 @@ struct MacSidebarSettingsView: View {
                 pin(feature)
             } label: {
                 Image(systemName: "plus.circle.fill")
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(.tint)
             }
             .buttonStyle(.borderless)
             .help(String(localized: "desktop_settings_sidebar_pin"))

--- a/swift/TigerDuck/Services/API/NTUST/SemesterCatalog.swift
+++ b/swift/TigerDuck/Services/API/NTUST/SemesterCatalog.swift
@@ -69,14 +69,23 @@ enum SemesterCatalog {
         return terms(from: cached, admissionYear: admissionYear(studentId: studentId))
     }
 
-    /// Catalogue terms from the fall of the admission year onwards; the
-    /// fixed depth when the id is unknown. Codes are `YYYS` with S in
-    /// 1 / 2 / H, so plain string order is chronological within a year
-    /// (`113H` sorts after `1131`).
+    /// Catalogue terms from the admission year onwards; the fixed depth
+    /// when the id is unknown. Compared numerically: the catalogue pads
+    /// pre-100 years as `99 1`, and those sort *after* `1131` as strings,
+    /// which is how every term back to 95-1 leaked into the picker.
     nonisolated static func terms(from catalogue: [String], admissionYear: Int?) -> [String] {
-        guard let admissionYear else { return Array(catalogue.prefix(pickerDepth)) }
-        let firstTerm = "\(admissionYear)1"
-        return catalogue.filter { $0 >= firstTerm }
+        let fallback = Array(catalogue.prefix(pickerDepth))
+        guard let admissionYear else { return fallback }
+        let fromAdmission = catalogue.filter { (academicYear(of: $0) ?? -1) >= admissionYear }
+        // An id whose parsed "year" is nonsense (a non-letter prefix yields
+        // e.g. 131) would otherwise empty the picker.
+        return fromAdmission.isEmpty ? fallback : fromAdmission
+    }
+
+    /// `1151` → 115, `114H` → 114, `99 1` → 99. The last character is the
+    /// term (1 / 2 / H); everything before it is the ROC academic year.
+    nonisolated static func academicYear(of code: String) -> Int? {
+        Int(code.dropLast().trimmingCharacters(in: .whitespaces))
     }
 
     /// NTUST ids are one degree letter plus the three-digit admission year

--- a/swift/TigerDuck/Services/API/NTUST/SemesterCatalog.swift
+++ b/swift/TigerDuck/Services/API/NTUST/SemesterCatalog.swift
@@ -73,13 +73,14 @@ enum SemesterCatalog {
     /// when the id is unknown. Compared numerically: the catalogue pads
     /// pre-100 years as `99 1`, and those sort *after* `1131` as strings,
     /// which is how every term back to 95-1 leaked into the picker.
+    ///
+    /// Deliberately empty for a student admitted after the newest published
+    /// term: every catalogue term predates them, so offering (and warming)
+    /// any of it is wrong. `ClassTableViewModel.semesterOptions` keeps the
+    /// heuristic term selectable until NTUST publishes theirs.
     nonisolated static func terms(from catalogue: [String], admissionYear: Int?) -> [String] {
-        let fallback = Array(catalogue.prefix(pickerDepth))
-        guard let admissionYear else { return fallback }
-        let fromAdmission = catalogue.filter { (academicYear(of: $0) ?? -1) >= admissionYear }
-        // An id whose parsed "year" is nonsense (a non-letter prefix yields
-        // e.g. 131) would otherwise empty the picker.
-        return fromAdmission.isEmpty ? fallback : fromAdmission
+        guard let admissionYear else { return Array(catalogue.prefix(pickerDepth)) }
+        return catalogue.filter { (academicYear(of: $0) ?? -1) >= admissionYear }
     }
 
     /// `1151` → 115, `114H` → 114, `99 1` → 99. The last character is the

--- a/swift/TigerDuck/SharedUI/LoginRequiredView.swift
+++ b/swift/TigerDuck/SharedUI/LoginRequiredView.swift
@@ -36,7 +36,7 @@ struct LoginRequiredView: View {
         VStack(spacing: TigerDuckTheme.Spacing.lg) {
             Image(systemName: "lock.shield")
                 .font(.system(size: heroIconSize))
-                .foregroundStyle(Color.accentPrimary)
+                .foregroundStyle(.tint)
             Text(title)
                 .font(TigerDuckTheme.Typography.title)
                 .foregroundStyle(Color.textPrimary)
@@ -78,7 +78,7 @@ struct LoginRequiredView: View {
             HStack(alignment: .top, spacing: TigerDuckTheme.Spacing.md) {
                 Image(systemName: "lock.shield")
                     .font(.title3)
-                    .foregroundStyle(Color.accentPrimary)
+                    .foregroundStyle(.tint)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
                         .font(TigerDuckTheme.Typography.headline)

--- a/swift/TigerDuck/SharedUI/SectionHeader.swift
+++ b/swift/TigerDuck/SharedUI/SectionHeader.swift
@@ -14,7 +14,7 @@ struct SectionHeader: View {
             if let trailing, let action {
                 Button(trailing, action: action)
                     .font(TigerDuckTheme.Typography.caption)
-                    .foregroundStyle(Color.accentPrimary)
+                    .foregroundStyle(.tint)
             }
         }
         .padding(.horizontal, TigerDuckTheme.Spacing.lg)

--- a/swift/TigerDuck/SharedUI/WidgetContainer.swift
+++ b/swift/TigerDuck/SharedUI/WidgetContainer.swift
@@ -25,7 +25,7 @@ struct SimpleWidgetContent: View {
             HStack {
                 Image(systemName: feature.iconName)
                     .font(.title2)
-                    .foregroundStyle(Color.accentPrimary)
+                    .foregroundStyle(.tint)
                     .frame(width: 28, height: 28)
                 Spacer()
                 if badgeCount > 0 {

--- a/swift/TigerDuck/Theme/Color+Extensions.swift
+++ b/swift/TigerDuck/Theme/Color+Extensions.swift
@@ -45,6 +45,9 @@ extension Color {
     static let cardSurface = Color(hex: 0x1E1E1E, alpha: 0.8)
     static let textPrimary = Color.white
     static let textSecondary = Color(hex: 0xFFFFFF, alpha: 0.6)
+    /// Fixed on purpose: onboarding runs before a theme is chosen, and its
+    /// pages carry their own per-page colours rather than the app tint.
+    static let onboardingAccent = Color(hex: 0x007AFF)
     static let badgeRed = Color(hex: 0xFF3B30)
 
     // MARK: - Calendar Event Colors

--- a/swift/TigerDuck/Theme/Color+Extensions.swift
+++ b/swift/TigerDuck/Theme/Color+Extensions.swift
@@ -45,7 +45,6 @@ extension Color {
     static let cardSurface = Color(hex: 0x1E1E1E, alpha: 0.8)
     static let textPrimary = Color.white
     static let textSecondary = Color(hex: 0xFFFFFF, alpha: 0.6)
-    static let accentPrimary = Color(hex: 0x007AFF)
     static let badgeRed = Color(hex: 0xFF3B30)
 
     // MARK: - Calendar Event Colors

--- a/swift/TigerDuck/Theme/View+GlassEffect.swift
+++ b/swift/TigerDuck/Theme/View+GlassEffect.swift
@@ -18,7 +18,7 @@ extension View {
             .padding(.vertical, TigerDuckTheme.Spacing.sm)
             .background {
                 if isSelected {
-                    Capsule().fill(Color.accentColor)
+                    Capsule().fill(.tint)
                 } else {
                     Capsule().fill(.ultraThinMaterial)
                 }

--- a/swift/TigerDuck/Theme/View+SurfaceStyle.swift
+++ b/swift/TigerDuck/Theme/View+SurfaceStyle.swift
@@ -97,7 +97,7 @@ private struct PresetChipModifier: ViewModifier {
             padded
                 .background {
                     if isSelected {
-                        Capsule().fill(Color.accentColor)
+                        Capsule().fill(.tint)
                     } else {
                         Capsule().fill(.ultraThinMaterial)
                     }
@@ -106,7 +106,7 @@ private struct PresetChipModifier: ViewModifier {
             padded
                 .background {
                     if isSelected {
-                        Capsule().fill(Color.accentColor)
+                        Capsule().fill(.tint)
                     } else {
                         Capsule().fill(Color.white.opacity(0.08))
                     }

--- a/swift/TigerDuck/whatsnew.json
+++ b/swift/TigerDuck/whatsnew.json
@@ -58,5 +58,23 @@
         "The Apple Watch library QR code now comes through your iPhone, so it stays fresh."
       ]
     }
+  },
+  "2.0.1": {
+    "zh-TW": {
+      "title": "2.0.1 更新內容",
+      "highlights": [
+        "課表的學期選單只會列出入學年以後的學期。",
+        "設定中的主題色現在也套用到圖示、圖書證倒數圈與歷年成績趨勢線。",
+        "選課系統目前開放的學期以選課清單為準，已退選的課不會再從 Moodle 被加回課表。"
+      ]
+    },
+    "en": {
+      "title": "What's new in 2.0.1",
+      "highlights": [
+        "The class table's semester menu only lists terms from your admission year onward.",
+        "Your theme colour now reaches icons, the library QR countdown ring and the GPA trend line.",
+        "The term the course-selection system is serving follows its enrolment list, so dropped courses no longer come back from Moodle."
+      ]
+    }
   }
 }

--- a/swift/TigerDuckTests/EnrolledCourseNosTests.swift
+++ b/swift/TigerDuckTests/EnrolledCourseNosTests.swift
@@ -3,14 +3,14 @@ import Testing
 @testable import TigerDuck
 
 struct EnrolledCourseNosTests {
-    @Test("選課 answered: Moodle extras are dropped, transcript still tops up")
+    @Test("選課 answered: it owns the term, so neither Moodle nor a stale transcript adds courses")
     func selectionIsAuthoritative() {
         let nos = AppServiceBridge.enrolledCourseNos(
-            selection: ["CS1", "CS2"],
+            selection: ["CS1", "CS2", "CS1"],
             moodle: ["CS2", "DROPPED"],
-            transcript: ["CS1", "PE9"]
+            transcript: ["CS1", "DROPPED"]
         )
-        #expect(nos == ["CS1", "CS2", "PE9"])
+        #expect(nos == ["CS1", "CS2"])
     }
 
     @Test("選課 not consulted or unreachable: Moodle is the source")

--- a/swift/TigerDuckTests/EnrolledCourseNosTests.swift
+++ b/swift/TigerDuckTests/EnrolledCourseNosTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import TigerDuck
+
+struct EnrolledCourseNosTests {
+    @Test("選課 answered: Moodle extras are dropped, transcript still tops up")
+    func selectionIsAuthoritative() {
+        let nos = AppServiceBridge.enrolledCourseNos(
+            selection: ["CS1", "CS2"],
+            moodle: ["CS2", "DROPPED"],
+            transcript: ["CS1", "PE9"]
+        )
+        #expect(nos == ["CS1", "CS2", "PE9"])
+    }
+
+    @Test("選課 not consulted or unreachable: Moodle is the source")
+    func moodleWhenNoSelection() {
+        let nos = AppServiceBridge.enrolledCourseNos(
+            selection: nil,
+            moodle: ["CS2", "", "CS2", "CS3"],
+            transcript: ["CS3", "PE9"]
+        )
+        #expect(nos == ["CS2", "CS3", "PE9"])
+    }
+
+    @Test("An empty 選課 answer is still authoritative")
+    func emptySelectionHidesMoodle() {
+        #expect(AppServiceBridge.enrolledCourseNos(selection: [], moodle: ["CS2"], transcript: []).isEmpty)
+    }
+}

--- a/swift/TigerDuckTests/EnrolledCourseNosTests.swift
+++ b/swift/TigerDuckTests/EnrolledCourseNosTests.swift
@@ -23,8 +23,8 @@ struct EnrolledCourseNosTests {
         #expect(nos == ["CS2", "CS3", "PE9"])
     }
 
-    @Test("An empty 選課 answer is still authoritative")
-    func emptySelectionHidesMoodle() {
-        #expect(AppServiceBridge.enrolledCourseNos(selection: [], moodle: ["CS2"], transcript: []).isEmpty)
+    @Test("An empty 選課 answer falls back to Moodle: parser drift is indistinguishable from no enrolments")
+    func emptySelectionFallsBackToMoodle() {
+        #expect(AppServiceBridge.enrolledCourseNos(selection: [], moodle: ["CS2"], transcript: ["PE9"]) == ["CS2", "PE9"])
     }
 }

--- a/swift/TigerDuckTests/SemesterCatalogTests.swift
+++ b/swift/TigerDuckTests/SemesterCatalogTests.swift
@@ -45,10 +45,29 @@ struct SemesterCatalogTests {
             == ["1151", "114H", "1142", "1141", "113H", "1132", "1131"])
     }
 
-    @Test("Unknown student id keeps the fixed depth")
+    @Test("Space-padded pre-100 terms never leak past the admission year")
+    func dropsPaddedLegacyTerms() {
+        let catalogue = ["1151", "114H", "1142", "1141", "113H", "1132", "1131", "112H", "1001", "99 H", "99 2", "99 1", "95 1"]
+        #expect(SemesterCatalog.terms(from: catalogue, admissionYear: 113)
+            == ["1151", "114H", "1142", "1141", "113H", "1132", "1131"])
+        #expect(SemesterCatalog.terms(from: catalogue, admissionYear: 99)
+            == ["1151", "114H", "1142", "1141", "113H", "1132", "1131", "112H", "1001", "99 H", "99 2", "99 1"])
+    }
+
+    @Test("Academic year is everything before the term character, whitespace tolerant")
+    func parsesAcademicYear() {
+        #expect(SemesterCatalog.academicYear(of: "1151") == 115)
+        #expect(SemesterCatalog.academicYear(of: "114H") == 114)
+        #expect(SemesterCatalog.academicYear(of: "99 1") == 99)
+        #expect(SemesterCatalog.academicYear(of: "") == nil)
+        #expect(SemesterCatalog.academicYear(of: "H") == nil)
+    }
+
+    @Test("Unknown or implausible admission year keeps the fixed depth")
     func fixedDepthWithoutId() {
         let catalogue = ["1151", "114H", "1142", "1141", "113H", "1132", "1131", "112H"]
         #expect(SemesterCatalog.terms(from: catalogue, admissionYear: nil).count == 6)
+        #expect(SemesterCatalog.terms(from: catalogue, admissionYear: 131).count == 6)
     }
 
     @Test("Admission year is the three digits after the degree letter")

--- a/swift/TigerDuckTests/SemesterCatalogTests.swift
+++ b/swift/TigerDuckTests/SemesterCatalogTests.swift
@@ -63,11 +63,16 @@ struct SemesterCatalogTests {
         #expect(SemesterCatalog.academicYear(of: "H") == nil)
     }
 
-    @Test("Unknown or implausible admission year keeps the fixed depth")
+    @Test("Unknown student id keeps the fixed depth")
     func fixedDepthWithoutId() {
         let catalogue = ["1151", "114H", "1142", "1141", "113H", "1132", "1131", "112H"]
         #expect(SemesterCatalog.terms(from: catalogue, admissionYear: nil).count == 6)
-        #expect(SemesterCatalog.terms(from: catalogue, admissionYear: 131).count == 6)
+    }
+
+    @Test("Admission after the newest published term offers nothing, not older terms")
+    func futureAdmissionIsEmpty() {
+        let catalogue = ["1151", "114H", "1142", "1141", "113H", "1132", "1131", "112H"]
+        #expect(SemesterCatalog.terms(from: catalogue, admissionYear: 116).isEmpty)
     }
 
     @Test("Admission year is the three digits after the degree letter")


### PR DESCRIPTION
## Summary
Patch release with the two fixes merged to dev since v2.0.0.

- **ClassTable** (#191): the semester picker lists only terms from the admission year onward. NTUST pads pre-100 codes as `99 1`, which sorted after `1131` as a string and leaked every legacy term into the menu; terms are now compared by numeric academic year, and a student admitted after the newest published term gets no pre-admission terms.
- **Theme** (#191): `Color.accentColor` and the hard-coded accent token ignored the root `.tint`, so icons, capsules, the calendar today ring, the library QR countdown ring, the GPA trend line and the Mac Settings window stayed blue. Every site now uses the `.tint` shape style; onboarding keeps a fixed `Color.onboardingAccent`.
- **Bridge** (#192): the term the course-selection system serves is owned by its enrolment list, so courses the student dropped no longer come back from Moodle. Moodle stays the source for every other term, and for the served term when the course-selection fetch fails or scrapes empty.
- **Release**: MARKETING_VERSION 2.0.0 → 2.0.1 (build stays 4), What's New entry for 2.0.1, README badges and release-history rows.

## Test plan
- [x] Both PRs: full `TigerDuckTests` target on iPhone 17 Pro, macOS build, Greptile 5/5 after review fixes
- [x] `tools/check_macos_sources.py` OK
- [ ] Release gates on this PR (version bumped, What's New has version, macOS sources, localization keys, submodules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
